### PR TITLE
fix(ci): unblock v1.1.x release image builds

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -6,6 +6,7 @@ ENV PATH=$PNPM_HOME:$PATH
 RUN corepack enable && corepack prepare pnpm@10.0.0 --activate
 
 WORKDIR /workspace
+ENV DATABASE_URL=postgresql://sentinel:sentinel@localhost:5432/sentinel?schema=public
 
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
 COPY apps/backend/package.json ./apps/backend/package.json

--- a/apps/frontend-admin/Dockerfile
+++ b/apps/frontend-admin/Dockerfile
@@ -6,6 +6,7 @@ ENV PATH=$PNPM_HOME:$PATH
 RUN corepack enable && corepack prepare pnpm@10.0.0 --activate
 
 WORKDIR /workspace
+ENV DATABASE_URL=postgresql://sentinel:sentinel@localhost:5432/sentinel?schema=public
 
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
 COPY apps/frontend-admin/package.json ./apps/frontend-admin/package.json
@@ -19,7 +20,7 @@ RUN pnpm install --frozen-lockfile --ignore-scripts
 COPY . .
 
 RUN pnpm --filter @sentinel/database prisma:generate
-RUN pnpm --filter frontend-admin build
+RUN pnpm -r build
 
 FROM node:24.11.0-alpine3.21 AS runtime
 


### PR DESCRIPTION
## Summary
- set a build-stage `DATABASE_URL` in backend and frontend Dockerfiles so `prisma generate` succeeds in CI image builds
- build workspace packages in frontend Docker image (`pnpm -r build`) so internal package artifacts exist during Next build

## Validation
- `docker build -f apps/backend/Dockerfile -t sentinel-backend:test .`
- `docker build -f apps/frontend-admin/Dockerfile -t sentinel-frontend:test .`
