### PR TITLE
fix(deploy): backend runtime command for v1.1.2

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -58,4 +58,4 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=5 \
   CMD node -e "require('http').get('http://127.0.0.1:3000/health', (r) => { process.exit(r.statusCode === 200 ? 0 : 1); }).on('error', () => process.exit(1))"
 
-CMD ["node", "dist/index.js"]
+CMD ["node", "/app/apps/backend/dist/apps/backend/src/index.js"]


### PR DESCRIPTION
## Summary
- update backend container `CMD` to the compiled runtime path used in this build layout
- fix startup path mismatch that can break backend boot in appliance release images

## Change
- `apps/backend/Dockerfile`

## Release intent
- patch release target: `v1.1.2`
