### PR TITLE
fix(deploy): harden installer migration execution and validation

### DIFF
--- a/deploy/README_DEPLOY.md
+++ b/deploy/README_DEPLOY.md
@@ -75,7 +75,7 @@ cd /opt/sentinel/deploy
 ./update.sh --version vX.Y.Z
 ```
 
-This performs automatic pre-update backup, image pull, one-shot migration deploy, and health gate verification.
+This performs automatic pre-update backup, image pull, one-shot migration deploy, migration status verification, and health gate verification.
 
 ## Rollback
 
@@ -141,4 +141,8 @@ curl -f http://127.0.0.1/healthz
 - Compose v2 is required (`docker compose`).
 - `SENTINEL_VERSION` must be explicit (never `latest`).
 - Backend migration command is run as a one-shot deploy step:
-  `docker compose exec backend pnpm --filter @sentinel/database prisma:migrate:deploy:safe`
+  `docker compose exec -T backend sh -lc "cd /app && pnpm --filter @sentinel/database prisma:migrate:deploy:safe"`
+- Installer/update then verifies migration status:
+  `docker compose exec -T backend sh -lc "cd /app && pnpm --filter @sentinel/database exec prisma migrate status"`
+- Installer/update then verifies schema parity with migration files:
+  `docker compose exec -T backend sh -lc 'cd /app && pnpm --filter @sentinel/database exec prisma migrate diff --from-migrations prisma/migrations --to-url "$DATABASE_URL" --exit-code'`

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -154,8 +154,7 @@ set_compose_file_args
 ensure_compose_pull_with_login_fallback
 compose up -d
 
-log "Running one-shot safe migration deploy"
-compose exec backend pnpm --filter @sentinel/database prisma:migrate:deploy:safe
+run_safe_migrations
 
 if ! wait_for_healthz 240; then
   print_health_diagnostics

--- a/deploy/restore.sh
+++ b/deploy/restore.sh
@@ -57,8 +57,7 @@ log "Restoring database from ${BACKUP_FILE}"
 compose exec -T postgres psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -c 'DROP SCHEMA public CASCADE; CREATE SCHEMA public;'
 cat "${BACKUP_FILE}" | compose exec -T postgres pg_restore -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" --clean --if-exists --no-owner --no-privileges
 
-log "Running one-shot safe migration deploy"
-compose exec backend pnpm --filter @sentinel/database prisma:migrate:deploy:safe
+run_safe_migrations
 
 if ! wait_for_healthz 240; then
   print_health_diagnostics

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -128,8 +128,7 @@ save_state
 ensure_compose_pull_with_login_fallback
 compose up -d
 
-log "Running one-shot safe migration deploy"
-compose exec backend pnpm --filter @sentinel/database prisma:migrate:deploy:safe
+run_safe_migrations
 
 if ! wait_for_healthz 240; then
   print_health_diagnostics


### PR DESCRIPTION
## Why
Some installs can end up with incomplete schema state while still appearing successful if migration execution context is inconsistent or baseline behavior masks drift.

## What changed
- centralized one-shot migration flow in `deploy/_common.sh` via `run_safe_migrations`
- enforce service readiness before migration (`postgres` and `backend` health)
- run migration from explicit workspace root with non-interactive compose exec:
  - `docker compose exec -T backend sh -lc "cd /app && pnpm --filter @sentinel/database prisma:migrate:deploy:safe"`
- add post-migration checks:
  - `prisma migrate status`
  - `prisma migrate diff --from-migrations ... --to-url "$DATABASE_URL" --exit-code`
- apply shared flow in `install.sh`, `update.sh`, and `restore.sh`
- update deploy README commands to match runtime behavior

## Validation
- `bash -n deploy/_common.sh deploy/install.sh deploy/update.sh deploy/restore.sh`
