### PR TITLE
fix(deploy): recover failed first migration on fresh installs

### DIFF
--- a/deploy/README_DEPLOY.md
+++ b/deploy/README_DEPLOY.md
@@ -142,6 +142,8 @@ curl -f http://127.0.0.1/healthz
 - `SENTINEL_VERSION` must be explicit (never `latest`).
 - Backend migration command is run as a one-shot deploy step:
   `docker compose exec -T backend sh -lc "cd /app && pnpm --filter @sentinel/database prisma:migrate:deploy:safe"`
+- On empty databases, installer auto-runs `prisma db push` once before migration deploy to bootstrap base schema.
+- If `_prisma_migrations` contains failed rows, installer auto-resolves them as rolled back before retrying deploy.
 - Installer/update then verifies migration status:
   `docker compose exec -T backend sh -lc "cd /app && pnpm --filter @sentinel/database exec prisma migrate status"`
 - Installer/update then verifies schema parity with migration files:


### PR DESCRIPTION
## Problem
Fresh appliance installs can fail on `prisma:migrate:deploy:safe` when the earliest migration references pre-existing tables (for example `members`) that are not yet present in an empty DB.

## Changes
- detect empty DB schema (`public` tables excluding `_prisma_migrations`)
- on empty DB, run one-time `prisma db push` bootstrap before migration deploy
- detect failed rows in `_prisma_migrations` and auto-resolve them as rolled back before retrying
- keep existing migration verification checks (`migrate status` + `migrate diff --exit-code`)
- document the bootstrap/recovery behavior in deploy README

## Why this is safe
- bootstrap path only runs when schema is empty (fresh install failure mode)
- existing/non-empty DBs continue normal migration deploy path

## Validation
- `bash -n deploy/_common.sh deploy/install.sh deploy/update.sh deploy/restore.sh`
