### PR TITLE
fix(deploy): bootstrap and baseline when members/badges tables are missing

### DIFF
--- a/deploy/README_DEPLOY.md
+++ b/deploy/README_DEPLOY.md
@@ -143,7 +143,8 @@ curl -f http://127.0.0.1/healthz
 - Backend migration command is run as a one-shot deploy step:
   `docker compose exec -T backend sh -lc "cd /app && pnpm --filter @sentinel/database prisma:migrate:deploy:safe"`
 - On empty databases, installer auto-runs `prisma db push` once before migration deploy to bootstrap base schema.
-- If `_prisma_migrations` contains failed rows, installer auto-resolves them as rolled back before retrying deploy.
+- If core tables like `members`/`badges` are missing, installer uses bootstrap mode (`prisma db push` + migration baseline) instead of replaying member-related migration SQL.
+- If `_prisma_migrations` contains failed rows, installer auto-resolves them as rolled back before retrying deploy/baseline.
 - Installer/update then verifies migration status:
   `docker compose exec -T backend sh -lc "cd /app && pnpm --filter @sentinel/database exec prisma migrate status"`
 - Installer/update then verifies schema parity with migration files:


### PR DESCRIPTION
## Problem
Install/update can still fail if database state is partial and core tables (`members`, `badges`) are missing, because early member-tag migration SQL assumes those tables exist.

## Changes
- add DB table existence helper in deploy runtime
- in migration step, trigger bootstrap mode when:
  - schema is empty, or
  - `members`/`badges` tables are missing
- bootstrap mode now runs:
  - `prisma db push`
  - `prisma:baseline`
- keep failed migration auto-resolve and post-checks (`migrate status` + `migrate diff --exit-code`)
- update deploy README behavior notes

## Validation
- `bash -n deploy/_common.sh deploy/install.sh deploy/update.sh deploy/restore.sh`
