### PR TITLE
Release v1.1.9 deploy fixes

### DIFF
--- a/deploy/README_DEPLOY.md
+++ b/deploy/README_DEPLOY.md
@@ -48,7 +48,8 @@ cd deploy
 Installer behavior:
 
 - If `.env` is missing, installer creates it from `.env.example`.
-- If secret fields still have placeholders (for example `change-this-...` / `changeme`), installer auto-generates secure random values.
+- If secret fields still have placeholders (for example `change-this-...`, `replace-this-...`, or `changeme`), installer auto-generates secure random values.
+- Installer writes a root-only snapshot of service credentials to `/opt/sentinel/credentials/service-secrets.env`.
 - You can still edit `.env` later for custom settings.
 
 If operators will browse by IP (`http://<server-ip>`), ensure `CORS_ORIGIN` in `.env` includes both hostname and IP origins, for example:

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -141,6 +141,7 @@ fi
 
 ensure_env_file
 bootstrap_env_defaults
+write_admin_credentials_snapshot
 
 if [[ -z "${TARGET_VERSION}" ]]; then
   TARGET_VERSION="$(grep -E '^SENTINEL_VERSION=' "${ENV_FILE}" | cut -d= -f2- || true)"

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -94,6 +94,8 @@ if ! check_ghcr_reachability; then
 fi
 
 ensure_env_file
+bootstrap_env_defaults
+write_admin_credentials_snapshot
 load_state
 
 if [[ -n "${CLI_WITH_OBS}" ]]; then


### PR DESCRIPTION
## Summary\n- include pending deploy fixes after v1.1.8\n- auto-generate placeholder service secrets in deploy .env on install/update\n- persist generated service secrets to /opt/sentinel/credentials/service-secrets.env (root-only)\n- keep prisma parity checks compatible with prisma 7 datasource flags\n\n## Validation\n- bash -n deploy/_common.sh deploy/install.sh deploy/update.sh\n