### PR TITLE
fix(schedules): seed duty role config and complete database explorer mapping

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/routes/database-explorer.ts
+++ b/apps/backend/src/routes/database-explorer.ts
@@ -19,12 +19,20 @@ const MODEL_TO_TABLE: Record<string, string> = {
   Event: 'events',
   EventAttendee: 'event_attendees',
   EventCheckin: 'event_checkins',
+  MissedCheckout: 'missed_checkouts',
+  UnitEventType: 'unit_event_types',
+  UnitEvent: 'unit_events',
+  UnitEventDutyPosition: 'unit_event_duty_positions',
+  UnitEventDutyAssignment: 'unit_event_duty_assignments',
   BmqCourse: 'bmq_courses',
   BmqEnrollment: 'bmq_enrollments',
   TrainingYear: 'training_years',
+  QualificationType: 'qualification_types',
+  MemberQualification: 'member_qualifications',
   AuditLog: 'audit_log',
   SecurityAlert: 'security_alerts',
   ResponsibilityAuditLog: 'responsibility_audit_log',
+  report_audit_log: 'report_audit_log',
   MemberStatus: 'member_statuses',
   MemberType: 'member_types',
   VisitType: 'visit_types',
@@ -35,7 +43,15 @@ const MODEL_TO_TABLE: Record<string, string> = {
   Setting: 'settings',
   AlertConfig: 'alert_configs',
   ReportSetting: 'report_settings',
+  StatHoliday: 'stat_holidays',
   DdsAssignment: 'dds_assignments',
+  DutyRole: 'duty_roles',
+  DutyPosition: 'duty_positions',
+  WeeklySchedule: 'weekly_schedules',
+  ScheduleAssignment: 'schedule_assignments',
+  LockupStatus: 'lockup_status',
+  LockupTransfer: 'lockup_transfers',
+  LockupExecution: 'lockup_executions',
 }
 
 // Get category for a table
@@ -115,13 +131,7 @@ export const databaseExplorerRouter = s.router(databaseExplorerContract, {
   /**
    * Get paginated data from a specific table
    */
-  getTableData: async ({
-    params,
-    query,
-  }: {
-    params: TablePathParams
-    query: TableDataQuery
-  }) => {
+  getTableData: async ({ params, query }: { params: TablePathParams; query: TableDataQuery }) => {
     try {
       const prisma = getPrismaClient()
       const { table: modelName } = params
@@ -131,7 +141,7 @@ export const databaseExplorerRouter = s.router(databaseExplorerContract, {
       const sortOrder = query.sortOrder ?? 'desc'
 
       // Verify table is in whitelist
-      if (!ALLOWED_TABLES.includes(modelName as typeof ALLOWED_TABLES[number])) {
+      if (!ALLOWED_TABLES.includes(modelName as (typeof ALLOWED_TABLES)[number])) {
         return {
           status: 400 as const,
           body: {

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/components/schedules/dds-schedule-card.tsx
+++ b/apps/frontend-admin/src/components/schedules/dds-schedule-card.tsx
@@ -94,7 +94,10 @@ export function DdsScheduleCard({
   }) => {
     if (!ddsSchedule) {
       // Create schedule first, then assign
-      if (!ddsRole) return
+      if (!ddsRole) {
+        toast.error('DDS role is not configured. Run backend seed scripts.')
+        return
+      }
       try {
         const newSchedule = await createSchedule.mutateAsync({
           dutyRoleId: ddsRole.id,
@@ -198,6 +201,28 @@ export function DdsScheduleCard({
         </AppCardHeader>
         <AppCardContent className="flex items-center justify-center h-24">
           <LoadingSpinner size="md" />
+        </AppCardContent>
+      </AppCard>
+    )
+  }
+
+  if (!ddsRole) {
+    return (
+      <AppCard status="error">
+        <AppCardHeader>
+          <AppCardTitle className="flex items-center gap-2">
+            <User className="h-5 w-5" />
+            DDS (Duty Day Staff)
+          </AppCardTitle>
+        </AppCardHeader>
+        <AppCardContent>
+          <div className="flex items-center gap-2 text-error">
+            <AlertCircle className="h-5 w-5" />
+            <span>DDS role is not configured</span>
+          </div>
+          <p className="text-sm text-base-content/60 mt-1">
+            Missing required duty role configuration. Run enum/duty-role seed on the backend.
+          </p>
         </AppCardContent>
       </AppCard>
     )

--- a/apps/frontend-admin/src/components/schedules/duty-watch-card.tsx
+++ b/apps/frontend-admin/src/components/schedules/duty-watch-card.tsx
@@ -103,14 +103,17 @@ function PositionSlot({
           {position.code}
         </Chip>
         <div className="min-w-0">
-          <p className={cn('font-medium text-sm truncate', isUnfilled && 'line-through text-base-content/50')}>
+          <p
+            className={cn(
+              'font-medium text-sm truncate',
+              isUnfilled && 'line-through text-base-content/50'
+            )}
+          >
             {assignment
               ? `${assignment.member.rank} ${assignment.member.lastName}, ${assignment.member.firstName}`
               : position.name}
           </p>
-          {isUnfilled && (
-            <p className="text-xs text-error font-medium">Unfilled</p>
-          )}
+          {isUnfilled && <p className="text-xs text-error font-medium">Unfilled</p>}
           {!assignment && (
             <p className="text-xs text-base-content/60">
               {position.required ? 'Required' : 'Optional'}
@@ -274,7 +277,10 @@ export function DutyWatchCard({
     rank: string
     serviceNumber: string
   }) => {
-    if (!dutyWatchRole) return
+    if (!dutyWatchRole) {
+      toast.error('Duty Watch role is not configured. Run backend seed scripts.')
+      return
+    }
 
     const position = positions?.data?.find((p) => p.code === selectedPosition)
 
@@ -428,6 +434,51 @@ export function DutyWatchCard({
     )
   }
 
+  if (!dutyWatchRole) {
+    return (
+      <AppCard status="error">
+        <AppCardHeader>
+          <AppCardTitle className="flex items-center gap-2">
+            <Users className="h-5 w-5" />
+            Duty Watch Team
+          </AppCardTitle>
+        </AppCardHeader>
+        <AppCardContent>
+          <div className="flex items-center gap-2 text-error">
+            <AlertCircle className="h-5 w-5" />
+            <span>Duty Watch role is not configured</span>
+          </div>
+          <p className="text-sm text-base-content/60 mt-1">
+            Missing required duty role configuration. Run enum/duty-role seed on the backend.
+          </p>
+        </AppCardContent>
+      </AppCard>
+    )
+  }
+
+  if (positionsList.length === 0) {
+    return (
+      <AppCard status="error">
+        <AppCardHeader>
+          <AppCardTitle className="flex items-center gap-2">
+            <Users className="h-5 w-5" />
+            Duty Watch Team
+          </AppCardTitle>
+        </AppCardHeader>
+        <AppCardContent>
+          <div className="flex items-center gap-2 text-error">
+            <AlertCircle className="h-5 w-5" />
+            <span>No Duty Watch positions configured</span>
+          </div>
+          <p className="text-sm text-base-content/60 mt-1">
+            Missing required duty positions for role <span className="font-mono">DUTY_WATCH</span>.
+            Run enum/duty-role seed on the backend.
+          </p>
+        </AppCardContent>
+      </AppCard>
+    )
+  }
+
   const cardStatus = dutyWatchSchedule?.status === 'draft' ? ('warning' as const) : undefined
 
   return (
@@ -523,11 +574,7 @@ export function DutyWatchCard({
               onClick={handlePublish}
               disabled={publishSchedule.isPending || missingRequired > 0}
             >
-              {publishSchedule.isPending ? (
-                <ButtonSpinner />
-              ) : (
-                <Check className="h-4 w-4 mr-2" />
-              )}
+              {publishSchedule.isPending ? <ButtonSpinner /> : <Check className="h-4 w-4 mr-2" />}
               Publish Schedule
             </button>
           </div>
@@ -540,11 +587,7 @@ export function DutyWatchCard({
               onClick={handleEdit}
               disabled={revertToDraft.isPending}
             >
-              {revertToDraft.isPending ? (
-                <ButtonSpinner />
-              ) : (
-                <Pencil className="h-4 w-4 mr-2" />
-              )}
+              {revertToDraft.isPending ? <ButtonSpinner /> : <Pencil className="h-4 w-4 mr-2" />}
               Edit Schedule
             </button>
           </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary\n- seed duty_roles and duty_positions in startup enum seed flow\n- surface missing DDS/Duty Watch configuration errors in Schedules UI\n- align Database Explorer backend table mapping with contract allowlist\n- bump workspace versions to 1.2.1\n\n## Validation\n- pnpm typecheck\n\n## Production issue addressed\n- /api/duty-roles empty caused missing DDS assignment + Duty Watch positions in Schedules\n- Admin Database Explorer omitted multiple existing tables