### PR TITLE
fix: sync deploy seed baselines and improve backend health/status reporting

### DIFF
--- a/apps/backend/scripts/seed-default-enums.ts
+++ b/apps/backend/scripts/seed-default-enums.ts
@@ -11,14 +11,15 @@ const __dirname = dirname(__filename)
 interface EnumSeedInput {
   code: string
   name: string
-  description: string
+  description: string | null
   chipVariant: string
   chipColor: string
+  isHidden?: boolean
 }
 
 interface TagSeedInput {
   name: string
-  description: string
+  description: string | null
   displayOrder: number
   chipVariant: string
   chipColor: string
@@ -66,85 +67,99 @@ const DEFAULT_MEMBER_STATUSES: ReadonlyArray<EnumSeedInput> = [
   {
     code: 'active',
     name: 'Active',
-    description: 'Member is active and can check in',
-    chipVariant: 'solid',
+    description: 'Member is actively with the Unit',
+    chipVariant: 'dot',
     chipColor: 'success',
+    isHidden: false,
+  },
+  {
+    code: 'deployed',
+    name: 'Deployed',
+    description: 'Member deployed to another coast',
+    chipVariant: 'dot',
+    chipColor: 'warning',
+    isHidden: true,
   },
   {
     code: 'inactive',
     name: 'Inactive',
     description: 'Member is inactive and cannot check in',
-    chipVariant: 'soft',
+    chipVariant: 'dot',
     chipColor: 'neutral',
+    isHidden: false,
+  },
+  {
+    code: 'suspended',
+    name: 'Suspended',
+    description: null,
+    chipVariant: 'dot',
+    chipColor: 'error',
+    isHidden: false,
   },
 ]
 
 const DEFAULT_MEMBER_TYPES: ReadonlyArray<EnumSeedInput> = [
   {
     code: 'class_a',
-    name: 'Class A Reserve',
-    description: 'Part-time reserve member',
-    chipVariant: 'soft',
-    chipColor: 'info',
+    name: 'Class A',
+    description:
+      'The part-time employment most often associated with the Reserve Force. Members serve short periods of service (to a maximum of 12 consecutive calendar days and a maximum of 16 cumulative calendar days per month).',
+    chipVariant: 'light',
+    chipColor: 'primary',
   },
   {
     code: 'class_b',
-    name: 'Class B Reserve',
-    description: 'Full-time reserve member',
-    chipVariant: 'soft',
-    chipColor: 'accent',
+    name: 'Class B',
+    description:
+      'This full-time Reserve Service is for 13 or more consecutive days. Service can include employment as staff at training establishments, attendance at training courses, or duties of a temporary nature when it is not practical to employ Regular Force members. This class of Reserve Service has two groups: those employed for short-term (180 days or less) and those employed for longer term (more than 180 days).',
+    chipVariant: 'light',
+    chipColor: 'primary',
   },
   {
     code: 'class_c',
-    name: 'Class C Reserve',
-    description: 'Class C reserve member',
-    chipVariant: 'soft',
-    chipColor: 'warning',
+    name: 'Class C',
+    description:
+      'This is full-time Reserve Service. There is no minimum period applicable to this class of Reserve Service. Class “C” Reserve Service may be operational (related to a specific military tasking in or outside of Canada) or non-operational.',
+    chipVariant: 'light',
+    chipColor: 'primary',
   },
   {
     code: 'reg_force',
-    name: 'Regular Force',
-    description: 'Regular force member',
-    chipVariant: 'soft',
-    chipColor: 'secondary',
-  },
-  {
-    code: 'regular',
-    name: 'Regular',
-    description: 'Default generic member classification',
-    chipVariant: 'soft',
-    chipColor: 'primary',
+    name: 'Reg Force',
+    description: null,
+    chipVariant: 'light',
+    chipColor: 'error',
   },
 ]
 
 const DEFAULT_VISIT_TYPES: ReadonlyArray<EnumSeedInput> = [
   {
-    code: 'guest',
-    name: 'Guest',
-    description: 'General guest visit',
-    chipVariant: 'soft',
-    chipColor: 'info',
-  },
-  {
     code: 'contractor',
     name: 'Contractor',
-    description: 'Contracted worker on site',
-    chipVariant: 'soft',
-    chipColor: 'warning',
+    description: 'Contractor at the Unit to conduct work',
+    chipVariant: 'shadow',
+    chipColor: 'blue',
+  },
+  {
+    code: 'guest',
+    name: 'Guest',
+    description: 'Guest visitor to the Unit',
+    chipVariant: 'shadow',
+    chipColor: 'success',
   },
   {
     code: 'official',
     name: 'Official',
     description: 'Official visit or inspection',
-    chipVariant: 'soft',
-    chipColor: 'success',
+    chipVariant: 'shadow',
+    chipColor: 'default',
   },
   {
     code: 'other',
     name: 'Other',
     description: 'Other visitor purpose',
-    chipVariant: 'soft',
-    chipColor: 'neutral',
+    chipVariant: 'shadow',
+    chipColor: 'info',
   },
 ]
 
@@ -152,29 +167,36 @@ const DEFAULT_BADGE_STATUSES: ReadonlyArray<EnumSeedInput> = [
   {
     code: 'active',
     name: 'Active',
-    description: 'Badge is active and can be used',
-    chipVariant: 'solid',
+    description: 'Badge is able to be used',
+    chipVariant: 'bordered',
     chipColor: 'success',
-  },
-  {
-    code: 'inactive',
-    name: 'Inactive',
-    description: 'Badge is inactive and should not be used',
-    chipVariant: 'soft',
-    chipColor: 'neutral',
-  },
-  {
-    code: 'lost',
-    name: 'Lost',
-    description: 'Badge has been reported lost',
-    chipVariant: 'soft',
-    chipColor: 'error',
   },
   {
     code: 'damaged',
     name: 'Damaged',
     description: 'Badge is damaged and unusable',
-    chipVariant: 'soft',
+    chipVariant: 'bordered',
+    chipColor: 'warning',
+  },
+  {
+    code: 'disabled',
+    name: 'Disabled',
+    description: 'Badge has been disabled by an Admin',
+    chipVariant: 'bordered',
+    chipColor: 'danger',
+  },
+  {
+    code: 'inactive',
+    name: 'Inactive',
+    description: 'Badge is inactive and should not be used',
+    chipVariant: 'bordered',
+    chipColor: 'neutral',
+  },
+  {
+    code: 'lost',
+    name: 'Lost',
+    description: 'Badge has been lost or misplaced',
+    chipVariant: 'bordered',
     chipColor: 'warning',
   },
 ]
@@ -185,87 +207,127 @@ const DEFAULT_TAGS: ReadonlyArray<TagSeedInput> = [
     description: 'Duty Day Staff responsibility',
     displayOrder: 1,
     chipVariant: 'solid',
-    chipColor: 'warning',
-    isPositional: true,
+    chipColor: 'success',
+    isPositional: false,
   },
   {
     name: 'SWK',
     description: 'Senior Watchkeeper qualification tag',
-    displayOrder: 2,
-    chipVariant: 'solid',
-    chipColor: 'error',
-    isPositional: true,
-  },
-  {
-    name: 'BUILDING_AUTH',
-    description: 'Authorized for building access and lockup responsibility',
     displayOrder: 3,
     chipVariant: 'solid',
-    chipColor: 'primary',
+    chipColor: 'error',
     isPositional: false,
   },
   {
-    name: 'VAULT_KEY',
-    description: 'Holds vault key access',
-    displayOrder: 4,
-    chipVariant: 'soft',
-    chipColor: 'secondary',
-    isPositional: false,
-  },
-  {
-    name: 'VAULT_CODE',
-    description: 'Holds vault code access',
-    displayOrder: 5,
-    chipVariant: 'soft',
-    chipColor: 'secondary',
-    isPositional: false,
-  },
-  {
-    name: 'FM',
-    description: 'Facility Manager responsibility',
-    displayOrder: 6,
-    chipVariant: 'soft',
-    chipColor: 'accent',
-    isPositional: false,
-  },
-  {
-    name: 'ISA',
-    description: 'Information Systems Authority responsibility',
+    name: 'CMD',
+    description: 'Command Team',
     displayOrder: 7,
-    chipVariant: 'soft',
-    chipColor: 'info',
+    chipVariant: 'shadow',
+    chipColor: 'warning',
+    isPositional: false,
+  },
+  {
+    name: 'VIP',
+    description: 'Member is a Very Important Person',
+    displayOrder: 8,
+    chipVariant: 'shadow',
+    chipColor: 'blue',
+    isPositional: false,
+  },
+  {
+    name: 'FTS',
+    description: 'Full Time Staff',
+    displayOrder: 9,
+    chipVariant: 'shadow',
+    chipColor: 'green',
     isPositional: false,
   },
   {
     name: 'APS',
     description: 'Access Point Sentry duty watch qualification',
     displayOrder: 10,
-    chipVariant: 'soft',
-    chipColor: 'warning',
-    isPositional: true,
+    chipVariant: 'solid',
+    chipColor: 'purple',
+    isPositional: false,
   },
   {
     name: 'BM',
     description: "Bos'n Mate duty watch qualification",
     displayOrder: 11,
-    chipVariant: 'soft',
-    chipColor: 'warning',
-    isPositional: true,
+    chipVariant: 'solid',
+    chipColor: 'purple',
+    isPositional: false,
   },
   {
     name: 'QM',
     description: 'Quartermaster duty watch qualification',
     displayOrder: 12,
-    chipVariant: 'soft',
-    chipColor: 'warning',
-    isPositional: true,
+    chipVariant: 'solid',
+    chipColor: 'purple',
+    isPositional: false,
   },
   {
     name: 'DSWK',
     description: 'Deputy Senior Watchkeeper qualification',
     displayOrder: 13,
-    chipVariant: 'soft',
-    chipColor: 'error',
+    chipVariant: 'solid',
+    chipColor: 'purple',
+    isPositional: false,
+  },
+  {
+    name: 'Commanding Officer',
+    description: 'Commanding Officer',
+    displayOrder: 14,
+    chipVariant: 'faded',
+    chipColor: 'primary',
+    isPositional: true,
+  },
+  {
+    name: 'Executive Officer',
+    description: 'Executive Officer',
+    displayOrder: 15,
+    chipVariant: 'faded',
+    chipColor: 'primary',
+    isPositional: true,
+  },
+  {
+    name: 'COXN',
+    description: 'Coxswain',
+    displayOrder: 16,
+    chipVariant: 'faded',
+    chipColor: 'primary',
+    isPositional: true,
+  },
+  {
+    name: 'Training Officer',
+    description: null,
+    displayOrder: 17,
+    chipVariant: 'faded',
+    chipColor: 'primary',
+    isPositional: true,
+  },
+  {
+    name: 'Facility Manager',
+    description: null,
+    displayOrder: 18,
+    chipVariant: 'faded',
+    chipColor: 'primary',
+    isPositional: true,
+  },
+  {
+    name: 'RPO',
+    description: 'Regulating Petty Officer',
+    displayOrder: 19,
+    chipVariant: 'faded',
+    chipColor: 'primary',
+    isPositional: true,
+  },
+  {
+    name: 'Stores Mgr',
+    description: 'Stores Manager',
+    displayOrder: 20,
+    chipVariant: 'faded',
+    chipColor: 'primary',
     isPositional: true,
   },
 ]
@@ -288,51 +350,6 @@ const DEFAULT_QUALIFICATION_TYPES: ReadonlyArray<QualificationTypeSeedInput> = [
     isAutomatic: false,
     displayOrder: 2,
     tagName: 'SWK',
-  },
-  {
-    code: 'BUILDING_AUTH',
-    name: 'Building Authorized',
-    description: 'Has alarm codes and building access',
-    canReceiveLockup: true,
-    isAutomatic: false,
-    displayOrder: 3,
-    tagName: 'BUILDING_AUTH',
-  },
-  {
-    code: 'VAULT_KEY',
-    name: 'Vault Key Holder',
-    description: 'Has physical key to the vault',
-    canReceiveLockup: false,
-    isAutomatic: false,
-    displayOrder: 4,
-    tagName: 'VAULT_KEY',
-  },
-  {
-    code: 'VAULT_CODE',
-    name: 'Vault Code Holder',
-    description: 'Knows the vault combination',
-    canReceiveLockup: false,
-    isAutomatic: false,
-    displayOrder: 5,
-    tagName: 'VAULT_CODE',
-  },
-  {
-    code: 'FM',
-    name: 'Facility Manager',
-    description: 'Facility Manager responsibilities',
-    canReceiveLockup: false,
-    isAutomatic: false,
-    displayOrder: 6,
-    tagName: 'FM',
-  },
-  {
-    code: 'ISA',
-    name: 'ISA',
-    description: 'Unit Security Authority responsibilities',
-    canReceiveLockup: false,
-    isAutomatic: false,
-    displayOrder: 7,
-    tagName: 'ISA',
   },
   {
     code: 'APS',
@@ -451,8 +468,12 @@ async function ensureMemberStatuses(): Promise<number> {
 
     await prisma.memberStatus.create({
       data: {
-        ...status,
-        isHidden: false,
+        code: status.code,
+        name: status.name,
+        description: status.description,
+        chipVariant: status.chipVariant,
+        chipColor: status.chipColor,
+        isHidden: status.isHidden ?? false,
       },
     })
     inserted += 1
@@ -521,17 +542,52 @@ async function ensureBadgeStatuses(): Promise<number> {
   return inserted
 }
 
-async function ensureTags(): Promise<{ inserted: number; tagIdsByName: Map<string, string> }> {
+async function ensureTags(): Promise<{
+  inserted: number
+  updated: number
+  tagIdsByName: Map<string, string>
+}> {
   let inserted = 0
+  let updated = 0
   const tagIdsByName = new Map<string, string>()
 
-  for (const tag of DEFAULT_TAGS) {
+  const tagsInOrder = [...DEFAULT_TAGS].sort((a, b) => a.displayOrder - b.displayOrder)
+
+  for (const tag of tagsInOrder) {
     const existing = await prisma.tag.findUnique({
       where: { name: tag.name },
-      select: { id: true },
+      select: {
+        id: true,
+        description: true,
+        displayOrder: true,
+        chipVariant: true,
+        chipColor: true,
+        isPositional: true,
+      },
     })
 
     if (existing) {
+      const needsUpdate =
+        existing.description !== tag.description ||
+        existing.displayOrder !== tag.displayOrder ||
+        existing.chipVariant !== tag.chipVariant ||
+        existing.chipColor !== tag.chipColor ||
+        existing.isPositional !== tag.isPositional
+
+      if (needsUpdate) {
+        await prisma.tag.update({
+          where: { id: existing.id },
+          data: {
+            description: tag.description,
+            displayOrder: tag.displayOrder,
+            chipVariant: tag.chipVariant,
+            chipColor: tag.chipColor,
+            isPositional: tag.isPositional,
+          },
+        })
+        updated += 1
+      }
+
       tagIdsByName.set(tag.name, existing.id)
       continue
     }
@@ -552,21 +608,36 @@ async function ensureTags(): Promise<{ inserted: number; tagIdsByName: Map<strin
     inserted += 1
   }
 
-  return { inserted, tagIdsByName }
+  return { inserted, updated, tagIdsByName }
 }
 
 async function ensureQualificationTypes(tagIdsByName: Map<string, string>): Promise<{
   inserted: number
+  updated: number
   linkedTagIds: number
 }> {
   let inserted = 0
+  let updated = 0
   let linkedTagIds = 0
 
   for (const qualificationType of DEFAULT_QUALIFICATION_TYPES) {
-    const tagId = tagIdsByName.get(qualificationType.tagName) ?? null
+    const tagId = tagIdsByName.get(qualificationType.tagName)
+    if (!tagId) {
+      throw new Error(
+        `Missing linked tag '${qualificationType.tagName}' for qualification type '${qualificationType.code}'`
+      )
+    }
     const existing = await prisma.qualificationType.findUnique({
       where: { code: qualificationType.code },
-      select: { id: true, tagId: true },
+      select: {
+        id: true,
+        name: true,
+        description: true,
+        canReceiveLockup: true,
+        isAutomatic: true,
+        displayOrder: true,
+        tagId: true,
+      },
     })
 
     if (!existing) {
@@ -585,16 +656,34 @@ async function ensureQualificationTypes(tagIdsByName: Map<string, string>): Prom
       continue
     }
 
-    if (!existing.tagId && tagId) {
+    const needsUpdate =
+      existing.name !== qualificationType.name ||
+      existing.description !== qualificationType.description ||
+      existing.canReceiveLockup !== qualificationType.canReceiveLockup ||
+      existing.isAutomatic !== qualificationType.isAutomatic ||
+      existing.displayOrder !== qualificationType.displayOrder ||
+      existing.tagId !== tagId
+
+    if (needsUpdate) {
       await prisma.qualificationType.update({
         where: { id: existing.id },
-        data: { tagId },
+        data: {
+          name: qualificationType.name,
+          description: qualificationType.description,
+          canReceiveLockup: qualificationType.canReceiveLockup,
+          isAutomatic: qualificationType.isAutomatic,
+          displayOrder: qualificationType.displayOrder,
+          tagId,
+        },
       })
-      linkedTagIds += 1
+      updated += 1
+      if (existing.tagId !== tagId) {
+        linkedTagIds += 1
+      }
     }
   }
 
-  return { inserted, linkedTagIds }
+  return { inserted, updated, linkedTagIds }
 }
 
 async function ensureDutyRoles(): Promise<{
@@ -726,14 +815,17 @@ async function main(): Promise<void> {
     const insertedMemberTypes = await ensureMemberTypes()
     const insertedVisitTypes = await ensureVisitTypes()
     const insertedBadgeStatuses = await ensureBadgeStatuses()
-    const { inserted: insertedTags, tagIdsByName } = await ensureTags()
-    const { inserted: insertedQualificationTypes, linkedTagIds } =
-      await ensureQualificationTypes(tagIdsByName)
+    const { inserted: insertedTags, updated: updatedTags, tagIdsByName } = await ensureTags()
+    const {
+      inserted: insertedQualificationTypes,
+      updated: updatedQualificationTypes,
+      linkedTagIds,
+    } = await ensureQualificationTypes(tagIdsByName)
     const { inserted: insertedDutyRoles, roleIdsByCode } = await ensureDutyRoles()
     const insertedDutyPositions = await ensureDutyPositions(roleIdsByCode)
 
     console.log(
-      `enum seed complete: ranks_seeded=${insertedRanks} ranks_existing=${existingRanks} member_statuses=${insertedMemberStatuses} member_types=${insertedMemberTypes} visit_types=${insertedVisitTypes} badge_statuses=${insertedBadgeStatuses} tags=${insertedTags} qualification_types=${insertedQualificationTypes} qualification_tag_links=${linkedTagIds} duty_roles=${insertedDutyRoles} duty_positions=${insertedDutyPositions}`
+      `enum seed complete: ranks_seeded=${insertedRanks} ranks_existing=${existingRanks} member_statuses=${insertedMemberStatuses} member_types=${insertedMemberTypes} visit_types=${insertedVisitTypes} badge_statuses=${insertedBadgeStatuses} tags_inserted=${insertedTags} tags_updated=${updatedTags} qualification_types_inserted=${insertedQualificationTypes} qualification_types_updated=${updatedQualificationTypes} qualification_tag_links=${linkedTagIds} duty_roles=${insertedDutyRoles} duty_positions=${insertedDutyPositions}`
     )
   } finally {
     await prisma.$disconnect()

--- a/apps/backend/src/routes/tags.ts
+++ b/apps/backend/src/routes/tags.ts
@@ -30,6 +30,7 @@ export const tagsRouter = s.router(tagContract, {
             description: tag.description ?? null,
             chipVariant: tag.chipVariant ?? 'solid',
             chipColor: tag.chipColor ?? 'default',
+            isPositional: tag.isPositional,
             createdAt: tag.createdAt.toISOString(),
             updatedAt: tag.updatedAt.toISOString(),
           })),
@@ -78,6 +79,7 @@ export const tagsRouter = s.router(tagContract, {
               description: mt.tag.description ?? null,
               chipVariant: mt.tag.chipVariant ?? 'solid',
               chipColor: mt.tag.chipColor ?? 'default',
+              isPositional: mt.tag.isPositional,
             },
             createdAt: mt.createdAt.toISOString(),
           })),
@@ -97,13 +99,7 @@ export const tagsRouter = s.router(tagContract, {
   /**
    * Assign a tag to a member
    */
-  assignTag: async ({
-    params,
-    body,
-  }: {
-    params: { memberId: string }
-    body: AssignTagInput
-  }) => {
+  assignTag: async ({ params, body }: { params: { memberId: string }; body: AssignTagInput }) => {
     try {
       // Verify member exists
       const member = await memberRepo.findById(params.memberId)
@@ -131,6 +127,7 @@ export const tagsRouter = s.router(tagContract, {
             description: memberTag.tag.description ?? null,
             chipVariant: memberTag.tag.chipVariant ?? 'solid',
             chipColor: memberTag.tag.chipColor ?? 'default',
+            isPositional: memberTag.tag.isPositional,
           },
           createdAt: memberTag.createdAt.toISOString(),
         },

--- a/apps/frontend-admin/next.config.ts
+++ b/apps/frontend-admin/next.config.ts
@@ -9,6 +9,10 @@ const nextConfig: NextConfig = {
   async rewrites() {
     return [
       {
+        source: '/healthz',
+        destination: `${backendInternalUrl}/health`,
+      },
+      {
         source: '/api/:path*',
         destination: `${backendInternalUrl}/api/:path*`,
       },

--- a/apps/frontend-admin/src/app/globals.css
+++ b/apps/frontend-admin/src/app/globals.css
@@ -299,6 +299,16 @@
   box-shadow: 0 2px 4px 0 rgb(0 0 0 / 0.1);
 }
 
+/* Backend status badge in navbar:
+   force solid background by active UI theme */
+.backend-status-badge {
+  background-color: #fff;
+}
+
+html[data-theme='business'] .backend-status-badge {
+  background-color: #000;
+}
+
 /* ========================================
    BUTTON ENHANCEMENTS
    Action button refinements

--- a/apps/frontend-admin/src/components/layout/app-navbar.tsx
+++ b/apps/frontend-admin/src/components/layout/app-navbar.tsx
@@ -57,7 +57,7 @@ export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
         {/* Logo with backend status indicator */}
         <Link
           href="/dashboard"
-          className="btn btn-ghost max-w-[12rem] truncate px-2 text-lg font-bold sm:max-w-none sm:px-4 sm:text-2xl"
+          className="btn btn-ghost max-w-48 truncate px-2 text-lg font-bold sm:max-w-none sm:px-4 sm:text-2xl"
           data-testid={TID.nav.logo}
         >
           HMCS Chippawa
@@ -107,17 +107,17 @@ export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
       <div className="navbar-end gap-1.5 sm:gap-2">
         <div className="dropdown dropdown-end dropdown-hover">
           <div tabIndex={0} role="button" data-testid={TID.nav.backendStatus}>
-            <AppBadge status={badgeStatus} size="md" className="badge-outline">
+            <AppBadge status={badgeStatus} size="md" className="badge-outline backend-status-badge">
               <span className={cn('status', dot)} />
               <span className="hidden sm:inline">{label}</span>
             </AppBadge>
           </div>
           <div
             tabIndex={0}
-            className="dropdown-content card card-sm mt-2 w-72 border border-base-300 bg-base-100 text-base-content shadow-xl z-[var(--z-popover)]"
+            className="dropdown-content card card-sm mt-2 w-72 border border-base-300 bg-base-100 text-base-content shadow-xl z-(--z-popover)"
             data-testid={TID.nav.backendStatusDetails}
           >
-            <div className="card-body gap-2 p-[var(--space-3)]">
+            <div className="card-body gap-2 p-(--space-3)">
               <p className="text-xs font-semibold uppercase tracking-wide">System Status</p>
               <StatusRow label="Frontend" status="success" value="Online" />
               <StatusRow
@@ -152,7 +152,9 @@ export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
                 <p>
                   Last Check:{' '}
                   <span className="font-mono text-base-content">
-                    {formatTimestamp(backendHealth.lastCheckedAt)}
+                    {formatTimestamp(
+                      backendHealth.details?.serviceTimestamp ?? backendHealth.lastCheckedAt
+                    )}
                   </span>
                 </p>
               </div>

--- a/apps/frontend-admin/src/components/members/bulk-assign-tag-modal.tsx
+++ b/apps/frontend-admin/src/components/members/bulk-assign-tag-modal.tsx
@@ -36,13 +36,20 @@ export function BulkAssignTagModal({
   const [progress, setProgress] = useState(0)
   const [error, setError] = useState<string | null>(null)
 
-  // Filter out tags linked to qualifications (auto-assigned via qualification grants)
+  // Filter out qualification-linked tags only when they are non-positional.
+  // Positional tags still require manual assignment.
   const availableTags = useMemo(() => {
     if (!allTags) return []
-    const qualificationTagIds = new Set(
-      qualificationTypes?.filter((qt) => qt.tagId).map((qt) => qt.tagId) ?? []
+    const tagsById = new Map(allTags.map((tag) => [tag.id, tag]))
+    const qualificationNonPositionalTagIds = new Set(
+      qualificationTypes
+        ?.map((qt) => qt.tagId)
+        .filter((tagId): tagId is string => Boolean(tagId))
+        .filter((tagId) => !tagsById.get(tagId)?.isPositional) ?? []
     )
-    return allTags.filter((tag) => !qualificationTagIds.has(tag.id))
+    return allTags.filter(
+      (tag) => tag.isPositional || !qualificationNonPositionalTagIds.has(tag.id)
+    )
   }, [allTags, qualificationTypes])
 
   const selectedTag = availableTags.find((t) => t.id === tagId)

--- a/apps/frontend-admin/src/components/members/member-tags-modal.tsx
+++ b/apps/frontend-admin/src/components/members/member-tags-modal.tsx
@@ -71,13 +71,21 @@ export function MemberTagsModal({ open, onOpenChange, member }: MemberTagsModalP
     }
   }
 
-  // Get tags not already assigned to member and not linked to qualifications
+  // Get tags not already assigned to member.
+  // Qualification-linked tags are excluded only when they are non-positional
+  // because positional tags must remain manually assignable.
   const assignedTagIds = new Set(memberTags?.map((mt) => mt.tagId) ?? [])
-  const qualificationTagIds = new Set(
-    qualificationTypes?.filter((qt) => qt.tagId).map((qt) => qt.tagId) ?? []
+  const tagsById = new Map(allTags?.map((tag) => [tag.id, tag]) ?? [])
+  const qualificationNonPositionalTagIds = new Set(
+    qualificationTypes
+      ?.map((qt) => qt.tagId)
+      .filter((tagId): tagId is string => Boolean(tagId))
+      .filter((tagId) => !tagsById.get(tagId)?.isPositional) ?? []
   )
   const availableTags = allTags?.filter(
-    (tag) => !assignedTagIds.has(tag.id) && !qualificationTagIds.has(tag.id)
+    (tag) =>
+      !assignedTagIds.has(tag.id) &&
+      (tag.isPositional || !qualificationNonPositionalTagIds.has(tag.id))
   )
 
   if (!member) return null

--- a/apps/frontend-admin/src/hooks/use-backend-health.ts
+++ b/apps/frontend-admin/src/hooks/use-backend-health.ts
@@ -1,4 +1,5 @@
 'use client'
+/* global process */
 /* global Response */
 
 import { useEffect, useState } from 'react'
@@ -22,6 +23,8 @@ interface BackendHealthState {
 }
 
 const POLL_INTERVAL = 30_000 // 30 seconds
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || ''
+const HEALTH_URL = API_BASE ? `${API_BASE}/health` : '/healthz'
 
 export function useBackendHealth() {
   const [health, setHealth] = useState<BackendHealthState>({
@@ -36,9 +39,10 @@ export function useBackendHealth() {
 
     async function checkHealth() {
       try {
-        const res = await fetch('/healthz', {
+        const res = await fetch(HEALTH_URL, {
           signal: controller.signal,
           cache: 'no-store',
+          credentials: 'include',
         })
         const details = await parseHealthResponse(res)
         const checkedAt = new Date().toISOString()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "1.2.1",
+  "version": "1.2.4",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    ":separateMajorReleases",
+    ":maintainLockFilesWeekly"
+  ],
+  "timezone": "America/Winnipeg",
+  "labels": ["dependencies", "renovate"],
+  "rangeStrategy": "bump",
+  "minimumReleaseAge": "3 days",
+  "prHourlyLimit": 2,
+  "prConcurrentLimit": 8,
+  "schedule": ["before 6am on monday"],
+  "ignorePaths": ["**/node_modules/**", "packages/database/generated/**"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track Docker service image versions in GitHub workflow YAML",
+      "managerFilePatterns": ["/^\\.github\\/workflows\\/test\\.yml$/"],
+      "matchStrings": ["image:\\s*(?<depName>postgres):(?<currentValue>[\\w.+-]+)"],
+      "datasourceTemplate": "docker"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Keep Prisma updates visible and isolated",
+      "groupName": "prisma",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["prisma", "@prisma/client", "@prisma/adapter-pg"],
+      "automerge": false
+    },
+    {
+      "description": "Group core TypeScript and lint toolchain updates",
+      "groupName": "typescript-eslint-toolchain",
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "typescript",
+        "@types/node",
+        "eslint",
+        "@eslint/js",
+        "@typescript-eslint/eslint-plugin",
+        "@typescript-eslint/parser",
+        "eslint-config-prettier",
+        "prettier"
+      ]
+    },
+    {
+      "description": "Group CI workflow action updates",
+      "groupName": "github-actions",
+      "matchManagers": ["github-actions"]
+    },
+    {
+      "description": "Group Docker image tag updates in deploy manifests",
+      "groupName": "deploy-docker-images",
+      "matchManagers": ["docker-compose", "dockerfile"],
+      "matchFileNames": ["deploy/**", "apps/**/Dockerfile"]
+    },
+    {
+      "description": "Keep major upgrades manual",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- sync enum seed defaults to current Dev baseline for member types/statuses, badge statuses, visit types, tags, and qualification types
- preserve status `isHidden` flags and reconcile existing rows on re-seed
- enforce tag -> qualification linkage ordering and fail fast on missing linked tags
- fix member tag assignment filtering to allow positional tags while still blocking non-positional qualification-driven tags
- expose `isPositional` in tag API responses used by assignment UIs
- improve backend health/version reporting and frontend health source resolution for dev/deploy consistency
- update navbar backend status badge background behavior and status timestamp display

## Why
Deploy bootstrap defaults were drifting from real operational Dev data, and health/status display behavior had inconsistencies across environments.

## Validation
- `pnpm --filter @sentinel/backend typecheck`
- `pnpm --filter frontend-admin type-check`
