### PR TITLE
feat: add lightweight solo-dev GitHub bug triage workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,109 @@
+name: Bug report
+description: Track a defect so it never gets lost while features are in flight.
+title: "[Bug]: "
+labels:
+  - bug
+  - status:triage
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Where is the bug happening?
+      options:
+        - backend
+        - frontend
+        - hardware
+        - infra
+        - database
+        - auth
+        - logging
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: Impact and urgency
+      options:
+        - P0
+        - P1
+        - P2
+    validations:
+      required: true
+
+  - type: textarea
+    id: happened
+    attributes:
+      label: What happened?
+      description: Actual behavior observed.
+      placeholder: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      placeholder: Describe the expected behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: Keep this deterministic if possible.
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / stack trace / screenshots
+      description: Paste logs and any relevant output.
+      render: shell
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: App version/commit, OS, browser, runtime, and anything relevant.
+      placeholder: |
+        - Sentinel version:
+        - Commit SHA:
+        - OS:
+        - Browser:
+        - Node:
+
+  - type: input
+    id: hardware-model
+    attributes:
+      label: Hardware model (if applicable)
+      description: Device, scanner, MCU, board, etc.
+      placeholder: e.g., Zebra DS2208 / Raspberry Pi 5
+
+  - type: input
+    id: firmware
+    attributes:
+      label: Firmware/driver version (if applicable)
+      placeholder: e.g., FW 2.3.1 / driver 1.9.0
+
+  - type: input
+    id: connection
+    attributes:
+      label: Hardware connection details (if applicable)
+      description: USB/serial/Bluetooth/network, baud rate, cable notes, etc.
+      placeholder: e.g., USB CDC @ 115200 baud
+
+  - type: checkboxes
+    id: investigation
+    attributes:
+      label: Investigation hint
+      options:
+        - label: This issue is flaky, intermittent, or root cause is unclear; add the `needs-investigation` label.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Sentinel workflow guide
+    url: https://github.com/DeadshotOMEGA/sentinel/blob/main/docs/WORKFLOW.md
+    about: Read triage and planning rules before opening non-standard issues.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,60 @@
+name: Feature request
+description: Capture feature work in the same system as bugs.
+title: "[Feature]: "
+labels:
+  - feature
+  - status:triage
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - backend
+        - frontend
+        - hardware
+        - infra
+        - database
+        - auth
+        - logging
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What user or developer problem does this solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Smallest useful implementation first.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Check all that apply.
+      options:
+        - label: Scope is clear and testable.
+        - label: Success criteria are measurable.
+        - label: Backward-compatibility impact is identified.
+        - label: Docs/update notes are identified if needed.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional; list rejected options and why.
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks / dependencies
+      description: Technical risks, sequencing concerns, blockers.

--- a/.github/labels.solo-workflow.json
+++ b/.github/labels.solo-workflow.json
@@ -1,0 +1,25 @@
+[
+  {"name":"bug","color":"d73a4a","description":"Type: defect or incorrect behavior"},
+  {"name":"feature","color":"0e8a16","description":"Type: user-facing capability or enhancement"},
+  {"name":"task","color":"5319e7","description":"Type: implementation task/chore"},
+  {"name":"refactor","color":"1d76db","description":"Type: internal code improvement without behavior change"},
+
+  {"name":"backend","color":"0052cc","description":"Area: backend service/API"},
+  {"name":"frontend","color":"fbca04","description":"Area: web/admin UI"},
+  {"name":"hardware","color":"c2e0c6","description":"Area: hardware/device/scanner issues"},
+  {"name":"infra","color":"6f42c1","description":"Area: CI/CD, deploy, ops"},
+  {"name":"database","color":"bfd4f2","description":"Area: schema, queries, migrations"},
+  {"name":"auth","color":"b60205","description":"Area: identity, sessions, authorization"},
+  {"name":"logging","color":"f9d0c4","description":"Area: telemetry, logs, observability"},
+
+  {"name":"P0","color":"b60205","description":"Priority: urgent / release-blocking"},
+  {"name":"P1","color":"d93f0b","description":"Priority: high"},
+  {"name":"P2","color":"fbca04","description":"Priority: normal"},
+
+  {"name":"status:triage","color":"ededed","description":"Status: new/unreviewed"},
+  {"name":"status:planned","color":"c5def5","description":"Status: accepted and queued"},
+  {"name":"status:working","color":"0e8a16","description":"Status: currently in progress"},
+  {"name":"status:blocked","color":"d876e3","description":"Status: blocked by dependency/decision"},
+
+  {"name":"needs-investigation","color":"fef2c0","description":"Special: flaky/unclear root cause"}
+]

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,19 @@
+name: Issue triage label guard
+
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  ensure-triage-label:
+    name: Ensure status:triage is present
+    runs-on: ubuntu-latest
+    steps:
+      # This keeps issue intake consistent: all new/reopened issues must enter triage.
+      - name: Apply status:triage label
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: status:triage

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -1,0 +1,148 @@
+# Sentinel Solo-Dev GitHub Workflow
+
+A lightweight workflow designed to keep bugs from disappearing while you continue shipping features.
+
+## Core operating rules
+
+1. **Every bug becomes an issue** (even tiny bugs).
+2. **Everything starts in 🧪 Inbox** (new issues always get `status:triage`).
+3. **Only one issue in ⚙️ Working at a time**.
+4. If you task-switch: move current work back to 📌 Planned, pull the next item into ⚙️ Working.
+5. Use `needs-investigation` when root cause is unclear, flaky, or hardware behavior is intermittent.
+
+---
+
+## Label system (minimal + consistent)
+
+- **Type**: `bug`, `feature`, `task`, `refactor`
+- **Area**: `backend`, `frontend`, `hardware`, `infra`, `database`, `auth`, `logging`
+- **Priority**: `P0`, `P1`, `P2`
+- **Status**: `status:triage`, `status:planned`, `status:working`, `status:blocked`
+- **Special**: `needs-investigation`
+
+Source-of-truth file: `.github/labels.solo-workflow.json`
+
+---
+
+## Milestone versioning strategy (v0.6 / v0.7 / v1.0)
+
+Use milestones as release containers:
+
+- **v0.6**: next release target (active planning)
+- **v0.7**: near-future release bucket
+- **v1.0**: stabilization + launch-level completion
+
+Rules:
+
+- Every planned issue should have one milestone (or explicit reason it does not).
+- P0 bugs always get assigned to the nearest viable release milestone.
+- During release planning, triage Inbox first, then set milestone as item moves to Planned.
+- At release cut: close milestone when all critical items are done or intentionally deferred.
+
+---
+
+## Setup options
+
+### Option A: one-command setup (recommended)
+
+#### Bash
+
+```bash
+scripts/github/setup-solo-workflow.sh DeadshotOMEGA/sentinel
+```
+
+#### PowerShell
+
+```powershell
+pwsh ./scripts/github/setup-solo-workflow.ps1 -Repo DeadshotOMEGA/sentinel
+```
+
+What scripts do:
+
+- Upsert canonical labels from `.github/labels.solo-workflow.json`
+- Create milestones `v0.6`, `v0.7`, `v1.0` (idempotent)
+- Create/link project `Sentinel Development` (idempotent)
+
+### Option B: manual GitHub UI checklist
+
+Use this for project board details that are easier in UI.
+
+1. Open **Projects** → create project **Sentinel Development**.
+2. Set board columns/status options to:
+   - `🧪 Inbox`
+   - `📌 Planned`
+   - `⚙️ Working`
+   - `🚧 Blocked`
+   - `✅ Done`
+3. Add custom fields:
+   - `Priority` (single-select: P0, P1, P2)
+   - `Area` (single-select: backend, frontend, hardware, infra, database, auth, logging, unknown)
+   - `Release` (single-select: v0.6, v0.7, v1.0)
+4. Enable **Auto-add** workflow: auto-add issues from `DeadshotOMEGA/sentinel`.
+5. Create saved views:
+   - **Bug Hotlist**: `label:bug is:open`, sort by Priority, show Area + Release
+   - **Release View (v0.6)**: `is:open milestone:v0.6 -status:Done`
+   - **Weird stuff**: `label:needs-investigation is:open`
+   - **Inbox**: `label:status:triage is:open`
+
+---
+
+## Suggested daily flow (5 minutes)
+
+1. Check **Inbox** view.
+2. Triage each item:
+   - Add `Type`, `Area`, `Priority`
+   - If ready, move to **Planned** and set milestone/release.
+3. Keep only one **Working** item.
+4. When blocked, move to **Blocked** and note blocker in issue.
+5. Close completed work and move to **Done**.
+
+---
+
+## GitHub CLI/API quick commands
+
+### Labels import (direct)
+
+```bash
+jq -c '.[]' .github/labels.solo-workflow.json | while read -r l; do
+  n=$(jq -r '.name' <<<"$l")
+  c=$(jq -r '.color' <<<"$l")
+  d=$(jq -r '.description' <<<"$l")
+  gh label create "$n" --color "$c" --description "$d" --repo DeadshotOMEGA/sentinel 2>/dev/null || \
+  gh label edit "$n" --color "$c" --description "$d" --repo DeadshotOMEGA/sentinel
+ done
+```
+
+### Milestones (idempotent)
+
+```bash
+for m in v0.6 v0.7 v1.0; do
+  gh api repos/DeadshotOMEGA/sentinel/milestones?state=all --jq '.[].title' | grep -Fxq "$m" || \
+  gh api --method POST repos/DeadshotOMEGA/sentinel/milestones -f title="$m"
+done
+```
+
+### Create project if missing
+
+```bash
+OWNER=DeadshotOMEGA
+TITLE='Sentinel Development'
+NUM=$(gh project list --owner "$OWNER" --format json --jq ".projects[] | select(.title == \"$TITLE\") | .number" | head -n1)
+if [ -z "$NUM" ]; then
+  gh project create --owner "$OWNER" --title "$TITLE"
+fi
+```
+
+---
+
+## Verification checklist
+
+1. Open a test bug via **Bug report** template.
+2. Confirm issue starts with labels: `bug` + `status:triage`.
+3. Reopen the issue; confirm triage workflow re-applies `status:triage` if removed.
+4. Confirm issue is auto-added to **Sentinel Development** project.
+5. Set Priority/Area/Release; confirm item appears in:
+   - Bug Hotlist (for bug label)
+   - Release View (v0.6) when milestone/release matches
+   - Weird stuff when `needs-investigation` is applied
+6. Move item through Inbox → Planned → Working → Done to confirm board behavior.

--- a/scripts/github/setup-solo-workflow.ps1
+++ b/scripts/github/setup-solo-workflow.ps1
@@ -1,0 +1,57 @@
+#!/usr/bin/env pwsh
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+param(
+  [string]$Repo = ""
+)
+
+if ([string]::IsNullOrWhiteSpace($Repo)) {
+  $Repo = gh repo view --json nameWithOwner --jq .nameWithOwner
+}
+
+$Owner = $Repo.Split('/')[0]
+$ProjectTitle = 'Sentinel Development'
+$LabelsPath = '.github/labels.solo-workflow.json'
+
+if (-not (Test-Path $LabelsPath)) {
+  throw "Labels file not found: $LabelsPath"
+}
+
+$labels = Get-Content $LabelsPath | ConvertFrom-Json
+$existing = gh label list --repo $Repo --limit 500 --json name --jq '.[].name'
+
+foreach ($label in $labels) {
+  if ($existing -contains $label.name) {
+    gh label edit $label.name --repo $Repo --color $label.color --description $label.description | Out-Null
+    Write-Host "Updated label: $($label.name)"
+  }
+  else {
+    gh label create $label.name --repo $Repo --color $label.color --description $label.description | Out-Null
+    Write-Host "Created label: $($label.name)"
+  }
+}
+
+foreach ($ms in @('v0.6', 'v0.7', 'v1.0')) {
+  $milestones = gh api "repos/$Repo/milestones?state=all&per_page=100" --jq '.[].title'
+  if ($milestones -contains $ms) {
+    Write-Host "Milestone exists: $ms"
+  }
+  else {
+    gh api --method POST "repos/$Repo/milestones" -f "title=$ms" | Out-Null
+    Write-Host "Created milestone: $ms"
+  }
+}
+
+$projectNumber = gh project list --owner $Owner --limit 100 --format json --jq ".projects[] | select(.title == \"$ProjectTitle\") | .number" | Select-Object -First 1
+if ([string]::IsNullOrWhiteSpace($projectNumber)) {
+  gh project create --owner $Owner --title $ProjectTitle | Out-Null
+  $projectNumber = gh project list --owner $Owner --limit 100 --format json --jq ".projects[] | select(.title == \"$ProjectTitle\") | .number" | Select-Object -First 1
+  Write-Host "Created project: $ProjectTitle (#$projectNumber)"
+} else {
+  Write-Host "Project exists: $ProjectTitle (#$projectNumber)"
+}
+
+gh project link $projectNumber --owner $Owner --repo $Repo | Out-Null
+
+Write-Host "Done. Complete columns, auto-add workflow, and saved views via docs/WORKFLOW.md checklist."

--- a/scripts/github/setup-solo-workflow.sh
+++ b/scripts/github/setup-solo-workflow.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Idempotent GitHub setup for Sentinel's solo-dev workflow.
+# Requires: gh auth login, jq
+# Usage:
+#   scripts/github/setup-solo-workflow.sh [owner/repo]
+#   scripts/github/setup-solo-workflow.sh DeadshotOMEGA/sentinel
+
+REPO="${1:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
+OWNER="${REPO%%/*}"
+PROJECT_TITLE="Sentinel Development"
+LABELS_FILE=".github/labels.solo-workflow.json"
+PRUNE_UNUSED="${PRUNE_UNUSED:-false}"
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || { echo "Missing dependency: $1" >&2; exit 1; }
+}
+
+require gh
+require jq
+
+if [[ ! -f "$LABELS_FILE" ]]; then
+  echo "Labels file not found: $LABELS_FILE" >&2
+  exit 1
+fi
+
+echo "Configuring repo: $REPO"
+
+# Optional conservative remaps from common old labels.
+declare -A REMAP=(
+  [enhancement]=feature
+  [chore]=task
+  [tech-debt]=refactor
+  [investigate]=needs-investigation
+)
+
+for old in "${!REMAP[@]}"; do
+  new="${REMAP[$old]}"
+  if gh label list --repo "$REPO" --limit 200 --json name --jq '.[].name' | grep -Fxq "$old"; then
+    if ! gh label list --repo "$REPO" --limit 200 --json name --jq '.[].name' | grep -Fxq "$new"; then
+      echo "Renaming label: $old -> $new"
+      gh label edit "$old" --repo "$REPO" --name "$new" >/dev/null
+    else
+      echo "Keeping both labels for safety (old exists): $old"
+    fi
+  fi
+done
+
+# Upsert canonical labels.
+while IFS= read -r label; do
+  name="$(jq -r '.name' <<<"$label")"
+  color="$(jq -r '.color' <<<"$label")"
+  description="$(jq -r '.description' <<<"$label")"
+
+  if gh label list --repo "$REPO" --limit 300 --json name --jq '.[].name' | grep -Fxq "$name"; then
+    gh label edit "$name" --repo "$REPO" --color "$color" --description "$description" >/dev/null
+    echo "Updated label: $name"
+  else
+    gh label create "$name" --repo "$REPO" --color "$color" --description "$description" >/dev/null
+    echo "Created label: $name"
+  fi
+done < <(jq -c '.[]' "$LABELS_FILE")
+
+if [[ "$PRUNE_UNUSED" == "true" ]]; then
+  echo "PRUNE_UNUSED=true: deleting labels not in canonical pack (except default GitHub labels)"
+  canonical="$(jq -r '.[].name' "$LABELS_FILE" | sort)"
+  gh label list --repo "$REPO" --limit 500 --json name --jq '.[].name' | while IFS= read -r existing; do
+    if grep -Fxq "$existing" <(printf '%s\n' "$canonical"); then
+      continue
+    fi
+    case "$existing" in
+      "good first issue"|"help wanted") continue ;;
+    esac
+    gh label delete "$existing" --repo "$REPO" --yes >/dev/null || true
+    echo "Deleted label: $existing"
+  done
+fi
+
+# Milestones (idempotent)
+for ms in v0.6 v0.7 v1.0; do
+  if gh api "repos/$REPO/milestones?state=all&per_page=100" --jq '.[].title' | grep -Fxq "$ms"; then
+    echo "Milestone exists: $ms"
+  else
+    gh api --method POST "repos/$REPO/milestones" -f title="$ms" >/dev/null
+    echo "Created milestone: $ms"
+  fi
+done
+
+# Project (idempotent)
+project_number="$(gh project list --owner "$OWNER" --limit 100 --format json --jq ".projects[] | select(.title == \"$PROJECT_TITLE\") | .number" | head -n1 || true)"
+if [[ -z "${project_number:-}" ]]; then
+  gh project create --owner "$OWNER" --title "$PROJECT_TITLE" >/dev/null
+  project_number="$(gh project list --owner "$OWNER" --limit 100 --format json --jq ".projects[] | select(.title == \"$PROJECT_TITLE\") | .number" | head -n1)"
+  echo "Created project: $PROJECT_TITLE (#$project_number)"
+else
+  echo "Project exists: $PROJECT_TITLE (#$project_number)"
+fi
+
+gh project link "$project_number" --owner "$OWNER" --repo "$REPO" >/dev/null || true
+
+# Best-effort field creation (safe if command unavailable on older gh versions)
+if gh project field-list "$project_number" --owner "$OWNER" >/dev/null 2>&1; then
+  if ! gh project field-list "$project_number" --owner "$OWNER" --format json --jq '.fields[]?.name' | grep -Fxq "Priority"; then
+    gh project field-create "$project_number" --owner "$OWNER" --name "Priority" --data-type "SINGLE_SELECT" --single-select-options "P0,P1,P2" >/dev/null || true
+  fi
+  if ! gh project field-list "$project_number" --owner "$OWNER" --format json --jq '.fields[]?.name' | grep -Fxq "Area"; then
+    gh project field-create "$project_number" --owner "$OWNER" --name "Area" --data-type "SINGLE_SELECT" --single-select-options "backend,frontend,hardware,infra,database,auth,logging,unknown" >/dev/null || true
+  fi
+  if ! gh project field-list "$project_number" --owner "$OWNER" --format json --jq '.fields[]?.name' | grep -Fxq "Release"; then
+    gh project field-create "$project_number" --owner "$OWNER" --name "Release" --data-type "SINGLE_SELECT" --single-select-options "v0.6,v0.7,v1.0" >/dev/null || true
+  fi
+fi
+
+echo "Done."
+echo "Next: apply manual UI checklist in docs/WORKFLOW.md for board columns, saved views, and auto-add workflow."


### PR DESCRIPTION
## Summary
Implemented a minimal, high-leverage GitHub workflow to prevent bugs from getting lost while feature work continues.

### Repo file changes
1. **Issue templates + config**
   - Added `.github/ISSUE_TEMPLATE/config.yml`
   - Added `.github/ISSUE_TEMPLATE/bug.yml`
   - Added `.github/ISSUE_TEMPLATE/feature.yml`
   - Added `.github/labels.solo-workflow.json` (canonical labels import pack)

2. **Triage automation**
   - Added `.github/workflows/issue-triage.yml`
   - Ensures `status:triage` is applied on issue `opened` and `reopened`
   - Uses minimal permission scope: `issues: write`

3. **Workflow documentation + setup scripts**
   - Added `docs/WORKFLOW.md`
   - Added `scripts/github/setup-solo-workflow.sh` (one-command bash setup)
   - Added `scripts/github/setup-solo-workflow.ps1` (PowerShell setup)

## What this delivers
- Required label taxonomy (Type/Area/Priority/Status/Special)
- Bug and feature issue forms with required fields
- Hardware debugging fields in bug form
- Milestone strategy for `v0.6`, `v0.7`, `v1.0`
- Idempotent scripts for labels, milestones, and project bootstrap
- Manual UI checklist for board columns, auto-add workflow, and saved views
- CLI snippets for direct API-based setup

## Notes
- Project saved views and auto-add workflow configuration are documented for manual setup in `docs/WORKFLOW.md` because those settings are often fastest/clearest in the UI and can vary by GitHub plan/permissions.
- Bash script includes optional conservative cleanup via `PRUNE_UNUSED=true`.

## Verification guidance
See `docs/WORKFLOW.md` → **Verification checklist** for end-to-end validation:
- template defaults
- triage re-labeling on reopen
- project auto-add
- release and hotlist filtering
- board status flow


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f256b3670832e845a3e8249cb03c8)