### PR TITLE
feat(workflow): add issue ops skills, templates, and release sync automation

### DIFF
--- a/.codex/skills/sentinel-github-issue-flow/SKILL.md
+++ b/.codex/skills/sentinel-github-issue-flow/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: sentinel-github-issue-flow
+description: Manage Sentinel issue lifecycle transitions (triage/planned/working/blocked/done) with release-milestone alignment and warn-only working-limit policy.
+---
+
+# Sentinel GitHub Issue Flow
+
+## Use This Skill When
+
+- A user asks to triage/reprioritize/release-align/update issue status.
+- A user asks to move an issue to planned, working, blocked, or done.
+- A user asks to repair milestone/release mismatch.
+
+## Required Behavior
+
+1. Read current issue + project state.
+2. Compute transition plan and output preview first.
+3. Apply status label hygiene (remove conflicting `status:*` labels).
+4. Keep milestone and Release aligned.
+5. For `working`:
+   - check open `status:working` load
+   - warn when one already exists (warn-only policy)
+6. Mutate only on explicit confirmation (`confirm=true` or `--confirm`).
+
+## Script Workflow
+
+```bash
+# 1) Preview transition
+.codex/skills/sentinel-github-issue-flow/scripts/transition-issue.sh \
+  --payload-file /tmp/transition.json
+
+# 2) Execute transition on confirmation
+.codex/skills/sentinel-github-issue-flow/scripts/transition-issue.sh \
+  --payload-file /tmp/transition.json \
+  --confirm
+```
+
+## Payload Contract
+
+```json
+{
+  "repo": "DeadshotOMEGA/sentinel",
+  "issueNumber": 123,
+  "targetState": "triage|planned|working|blocked|done",
+  "warnOnlyWorkingLimit": true,
+  "milestone": "vX.Y.Z|null",
+  "release": "vX.Y.Z|null",
+  "confirm": false
+}
+```
+
+## References
+
+- `references/workflow-rules.md`
+- `references/status-transition-matrix.md`

--- a/.codex/skills/sentinel-github-issue-flow/agents/openai.yaml
+++ b/.codex/skills/sentinel-github-issue-flow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Sentinel Issue Flow"
+  short_description: "Issue lifecycle transitions with release alignment"
+  default_prompt: "Plan and apply Sentinel issue transitions with explicit confirmation, status-label hygiene, and milestone-release alignment."

--- a/.codex/skills/sentinel-github-issue-flow/references/status-transition-matrix.md
+++ b/.codex/skills/sentinel-github-issue-flow/references/status-transition-matrix.md
@@ -1,0 +1,35 @@
+# Status Transition Matrix
+
+## triage
+
+- Set label: `status:triage`
+- Remove other status labels.
+- Require one type label (`bug|feature|task|refactor`).
+- Project status: `🧪 Inbox`
+
+## planned
+
+- Set label: `status:planned`
+- Remove other status labels.
+- Require milestone/release pair (or existing milestone that can be aligned).
+- Project status: `📌 Planned`
+
+## working
+
+- Set label: `status:working`
+- Remove other status labels.
+- Run working-load check and warn if another issue is already working.
+- Project status: `⚙️ Working`
+
+## blocked
+
+- Set label: `status:blocked`
+- Remove other status labels.
+- Require blocker note.
+- Project status: `🚧 Blocked`
+
+## done
+
+- Remove all status labels.
+- Project status: `✅ Done`
+- Suggest closing issue after acceptance is met.

--- a/.codex/skills/sentinel-github-issue-flow/references/workflow-rules.md
+++ b/.codex/skills/sentinel-github-issue-flow/references/workflow-rules.md
@@ -1,0 +1,23 @@
+# Sentinel Workflow Rules (Issue Flow)
+
+Derived from `docs/WORKFLOW.md`.
+
+## Status Semantics
+
+- `status:triage` -> issue is in Inbox.
+- `status:planned` -> issue is scoped and queued with release target.
+- `status:working` -> active implementation.
+- `status:blocked` -> blocked by external dependency/decision.
+- `✅ Done` -> completion state in project field (issue may then be closed).
+
+## Working-Limit Policy
+
+- Target policy: one active Working issue at a time.
+- Enforcement mode for Codex skills: warn-only.
+- Moving to Working requires explicit confirmation if warning is raised.
+
+## Alignment Rules
+
+1. Milestone set and Release empty -> set Release = milestone.
+2. Release set and Milestone empty -> set Milestone = release.
+3. Mismatch -> propose repair and require confirmation.

--- a/.codex/skills/sentinel-github-issue-flow/scripts/align-milestone-release.sh
+++ b/.codex/skills/sentinel-github-issue-flow/scripts/align-milestone-release.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: align-milestone-release.sh --repo <owner/repo> --issue-number <n> [options]
+
+Options:
+  --project-owner <owner>      Defaults to repo owner
+  --project-number <number>    Defaults to 3
+  --project-title <title>      Defaults to Sentinel Development
+  --prefer-source <milestone|release>  Defaults to milestone
+  --dry-run
+  --confirm
+USAGE
+}
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+SET_FIELDS_SCRIPT="${SCRIPT_DIR}/../../sentinel-github-issue-intake/scripts/set-project-fields.sh"
+
+REPO=""
+ISSUE_NUMBER=""
+PROJECT_OWNER=""
+PROJECT_NUMBER="3"
+PROJECT_TITLE="Sentinel Development"
+PREFER_SOURCE="milestone"
+DRY_RUN="false"
+CONFIRM="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      REPO="${2:-}"
+      shift 2
+      ;;
+    --issue-number)
+      ISSUE_NUMBER="${2:-}"
+      shift 2
+      ;;
+    --project-owner)
+      PROJECT_OWNER="${2:-}"
+      shift 2
+      ;;
+    --project-number)
+      PROJECT_NUMBER="${2:-}"
+      shift 2
+      ;;
+    --project-title)
+      PROJECT_TITLE="${2:-}"
+      shift 2
+      ;;
+    --prefer-source)
+      PREFER_SOURCE="${2:-}"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      shift
+      ;;
+    --confirm)
+      CONFIRM="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+command -v gh >/dev/null 2>&1 || { echo "Missing dependency: gh" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "Missing dependency: jq" >&2; exit 1; }
+[[ -x "${SET_FIELDS_SCRIPT}" ]] || { echo "Missing helper script: ${SET_FIELDS_SCRIPT}" >&2; exit 1; }
+
+[[ -n "${REPO}" ]] || { echo "--repo is required" >&2; exit 1; }
+[[ -n "${ISSUE_NUMBER}" ]] || { echo "--issue-number is required" >&2; exit 1; }
+
+if [[ -z "${PROJECT_OWNER}" ]]; then
+  PROJECT_OWNER="${REPO%%/*}"
+fi
+
+if [[ "${DRY_RUN}" == "true" ]]; then
+  CONFIRM="false"
+fi
+
+case "${PREFER_SOURCE}" in
+  milestone|release)
+    ;;
+  *)
+    echo "--prefer-source must be milestone or release" >&2
+    exit 1
+    ;;
+esac
+
+ISSUE_JSON="$(gh issue view "${ISSUE_NUMBER}" --repo "${REPO}" --json number,title,url,milestone)"
+MILESTONE_VALUE="$(jq -r '.milestone.title // empty' <<<"${ISSUE_JSON}")"
+
+# shellcheck disable=SC2016
+ALIGN_QUERY='query($owner:String!, $repo:String!, $issue:Int!){repository(owner:$owner,name:$repo){issue(number:$issue){projectItems(first:50){nodes{id project{__typename ... on ProjectV2{id number owner{__typename ... on User{login} ... on Organization{login}}}} fieldValues(first:50){nodes{... on ProjectV2ItemFieldSingleSelectValue{name field{... on ProjectV2SingleSelectField{name}}}}}}}}}}'
+
+ALIGN_DATA="$(gh api graphql -f query="${ALIGN_QUERY}" -F owner="${REPO%%/*}" -F repo="${REPO##*/}" -F issue="${ISSUE_NUMBER}")"
+
+RELEASE_VALUE="$(jq -r --arg owner "${PROJECT_OWNER}" --argjson number "${PROJECT_NUMBER}" '
+  .data.repository.issue.projectItems.nodes[]?
+  | select(.project.__typename == "ProjectV2")
+  | select(.project.number == $number)
+  | select(.project.owner.login == $owner)
+  | .fieldValues.nodes[]?
+  | select(.field.name == "Release")
+  | .name
+' <<<"${ALIGN_DATA}" | head -n1)"
+
+TARGET_MILESTONE=""
+TARGET_RELEASE=""
+ACTION="none"
+
+if [[ -n "${MILESTONE_VALUE}" && -z "${RELEASE_VALUE}" ]]; then
+  TARGET_RELEASE="${MILESTONE_VALUE}"
+  ACTION="set_release_from_milestone"
+elif [[ -z "${MILESTONE_VALUE}" && -n "${RELEASE_VALUE}" ]]; then
+  TARGET_MILESTONE="${RELEASE_VALUE}"
+  ACTION="set_milestone_from_release"
+elif [[ -n "${MILESTONE_VALUE}" && -n "${RELEASE_VALUE}" && "${MILESTONE_VALUE}" != "${RELEASE_VALUE}" ]]; then
+  ACTION="repair_mismatch"
+  if [[ "${PREFER_SOURCE}" == "milestone" ]]; then
+    TARGET_RELEASE="${MILESTONE_VALUE}"
+  else
+    TARGET_MILESTONE="${RELEASE_VALUE}"
+  fi
+fi
+
+PLAN_JSON="$(jq -n \
+  --arg repo "${REPO}" \
+  --arg issueNumber "${ISSUE_NUMBER}" \
+  --arg currentMilestone "${MILESTONE_VALUE}" \
+  --arg currentRelease "${RELEASE_VALUE}" \
+  --arg targetMilestone "${TARGET_MILESTONE}" \
+  --arg targetRelease "${TARGET_RELEASE}" \
+  --arg action "${ACTION}" \
+  --arg dryRun "${DRY_RUN}" \
+  --arg confirm "${CONFIRM}" \
+  '{
+    repo: $repo,
+    issueNumber: ($issueNumber | tonumber),
+    action: $action,
+    current: {
+      milestone: (if ($currentMilestone|length)>0 then $currentMilestone else null end),
+      release: (if ($currentRelease|length)>0 then $currentRelease else null end)
+    },
+    target: {
+      milestone: (if ($targetMilestone|length)>0 then $targetMilestone else null end),
+      release: (if ($targetRelease|length)>0 then $targetRelease else null end)
+    },
+    dryRun: ($dryRun == "true"),
+    confirm: ($confirm == "true")
+  }')"
+
+if [[ "${ACTION}" == "none" || "${CONFIRM}" != "true" ]]; then
+  jq '. + {mutated:false}' <<<"${PLAN_JSON}"
+  exit 0
+fi
+
+if [[ -n "${TARGET_MILESTONE}" ]]; then
+  gh issue edit "${ISSUE_NUMBER}" --repo "${REPO}" --milestone "${TARGET_MILESTONE}" >/dev/null
+fi
+
+if [[ -n "${TARGET_RELEASE}" ]]; then
+  "${SET_FIELDS_SCRIPT}" \
+    --repo "${REPO}" \
+    --issue-number "${ISSUE_NUMBER}" \
+    --project-owner "${PROJECT_OWNER}" \
+    --project-number "${PROJECT_NUMBER}" \
+    --project-title "${PROJECT_TITLE}" \
+    --release "${TARGET_RELEASE}" \
+    --confirm >/dev/null
+fi
+
+jq '. + {mutated:true}' <<<"${PLAN_JSON}"

--- a/.codex/skills/sentinel-github-issue-flow/scripts/check-working-load.sh
+++ b/.codex/skills/sentinel-github-issue-flow/scripts/check-working-load.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: check-working-load.sh --repo <owner/repo> [--exclude-issue <n>] [--limit <n>]
+USAGE
+}
+
+REPO=""
+EXCLUDE_ISSUE=""
+LIMIT="200"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      REPO="${2:-}"
+      shift 2
+      ;;
+    --exclude-issue)
+      EXCLUDE_ISSUE="${2:-}"
+      shift 2
+      ;;
+    --limit)
+      LIMIT="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+command -v gh >/dev/null 2>&1 || { echo "Missing dependency: gh" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "Missing dependency: jq" >&2; exit 1; }
+
+[[ -n "${REPO}" ]] || { echo "--repo is required" >&2; exit 1; }
+
+ISSUES_JSON="$(gh issue list --repo "${REPO}" --state open --label status:working --limit "${LIMIT}" --json number,title,url)"
+
+if [[ -n "${EXCLUDE_ISSUE}" ]]; then
+  ISSUES_JSON="$(jq --argjson exclude "${EXCLUDE_ISSUE}" '[ .[] | select(.number != $exclude) ]' <<<"${ISSUES_JSON}")"
+fi
+
+COUNT="$(jq 'length' <<<"${ISSUES_JSON}")"
+
+jq -n --arg repo "${REPO}" --argjson count "${COUNT}" --argjson issues "${ISSUES_JSON}" '{repo:$repo,count:$count,issues:$issues}'

--- a/.codex/skills/sentinel-github-issue-flow/scripts/transition-issue.sh
+++ b/.codex/skills/sentinel-github-issue-flow/scripts/transition-issue.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: transition-issue.sh --payload-file <path> [--dry-run] [--confirm]
+       transition-issue.sh --payload-json '<json>' [--dry-run] [--confirm]
+USAGE
+}
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+CHECK_WORKING_SCRIPT="${SCRIPT_DIR}/check-working-load.sh"
+ALIGN_SCRIPT="${SCRIPT_DIR}/align-milestone-release.sh"
+SET_FIELDS_SCRIPT="${SCRIPT_DIR}/../../sentinel-github-issue-intake/scripts/set-project-fields.sh"
+
+PAYLOAD_FILE=""
+PAYLOAD_JSON=""
+DRY_RUN="false"
+CONFIRM_OVERRIDE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --payload-file)
+      PAYLOAD_FILE="${2:-}"
+      shift 2
+      ;;
+    --payload-json)
+      PAYLOAD_JSON="${2:-}"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      shift
+      ;;
+    --confirm)
+      CONFIRM_OVERRIDE="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+command -v gh >/dev/null 2>&1 || { echo "Missing dependency: gh" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "Missing dependency: jq" >&2; exit 1; }
+[[ -x "${CHECK_WORKING_SCRIPT}" ]] || { echo "Missing helper script: ${CHECK_WORKING_SCRIPT}" >&2; exit 1; }
+[[ -x "${ALIGN_SCRIPT}" ]] || { echo "Missing helper script: ${ALIGN_SCRIPT}" >&2; exit 1; }
+[[ -x "${SET_FIELDS_SCRIPT}" ]] || { echo "Missing helper script: ${SET_FIELDS_SCRIPT}" >&2; exit 1; }
+
+if [[ -n "${PAYLOAD_FILE}" ]]; then
+  [[ -f "${PAYLOAD_FILE}" ]] || { echo "Payload file not found: ${PAYLOAD_FILE}" >&2; exit 1; }
+  PAYLOAD_JSON="$(cat "${PAYLOAD_FILE}")"
+elif [[ -z "${PAYLOAD_JSON}" ]]; then
+  if [[ ! -t 0 ]]; then
+    PAYLOAD_JSON="$(cat)"
+  else
+    echo "Provide --payload-file or --payload-json" >&2
+    exit 1
+  fi
+fi
+
+jq -e . >/dev/null 2>&1 <<<"${PAYLOAD_JSON}" || {
+  echo "Payload is not valid JSON" >&2
+  exit 1
+}
+
+REPO="$(jq -r '.repo // "DeadshotOMEGA/sentinel"' <<<"${PAYLOAD_JSON}")"
+ISSUE_NUMBER="$(jq -r '.issueNumber // empty' <<<"${PAYLOAD_JSON}")"
+TARGET_STATE="$(jq -r '.targetState // empty' <<<"${PAYLOAD_JSON}")"
+PROJECT_TITLE="$(jq -r '.projectTitle // "Sentinel Development"' <<<"${PAYLOAD_JSON}")"
+PROJECT_NUMBER="$(jq -r '.projectNumber // 3' <<<"${PAYLOAD_JSON}")"
+PROJECT_OWNER="$(jq -r '.projectOwner // empty' <<<"${PAYLOAD_JSON}")"
+WARN_ONLY_WORKING_LIMIT="$(jq -r '.warnOnlyWorkingLimit // true' <<<"${PAYLOAD_JSON}")"
+BLOCKER_NOTE="$(jq -r '.blockerNote // empty' <<<"${PAYLOAD_JSON}")"
+MILESTONE_VALUE="$(jq -r '.milestone // empty' <<<"${PAYLOAD_JSON}")"
+RELEASE_VALUE="$(jq -r '.release // empty' <<<"${PAYLOAD_JSON}")"
+PREFER_SOURCE="$(jq -r '.preferSource // "milestone"' <<<"${PAYLOAD_JSON}")"
+PAYLOAD_CONFIRM="$(jq -r '.confirm // false' <<<"${PAYLOAD_JSON}")"
+
+if [[ -n "${CONFIRM_OVERRIDE}" ]]; then
+  CONFIRM="${CONFIRM_OVERRIDE}"
+else
+  CONFIRM="${PAYLOAD_CONFIRM}"
+fi
+if [[ "${DRY_RUN}" == "true" ]]; then
+  CONFIRM="false"
+fi
+
+[[ -n "${ISSUE_NUMBER}" ]] || { echo "Payload.issueNumber is required" >&2; exit 1; }
+[[ -n "${TARGET_STATE}" ]] || { echo "Payload.targetState is required" >&2; exit 1; }
+
+case "${TARGET_STATE}" in
+  triage|planned|working|blocked|done)
+    ;;
+  *)
+    echo "Unsupported targetState: ${TARGET_STATE}" >&2
+    exit 1
+    ;;
+esac
+
+if [[ -z "${PROJECT_OWNER}" ]]; then
+  PROJECT_OWNER="${REPO%%/*}"
+fi
+
+ISSUE_JSON="$(gh issue view "${ISSUE_NUMBER}" --repo "${REPO}" --json number,title,url,labels,milestone)"
+
+mapfile -t CURRENT_LABELS < <(jq -r '.labels[].name' <<<"${ISSUE_JSON}")
+TYPE_LABELS=(bug feature task refactor)
+
+has_label() {
+  local label="${1}"
+  printf '%s\n' "${CURRENT_LABELS[@]:-}" | grep -Fxq "${label}"
+}
+
+DESIRED_STATUS_LABEL=""
+DESIRED_PROJECT_STATUS=""
+case "${TARGET_STATE}" in
+  triage)
+    DESIRED_STATUS_LABEL="status:triage"
+    DESIRED_PROJECT_STATUS="🧪 Inbox"
+    ;;
+  planned)
+    DESIRED_STATUS_LABEL="status:planned"
+    DESIRED_PROJECT_STATUS="📌 Planned"
+    ;;
+  working)
+    DESIRED_STATUS_LABEL="status:working"
+    DESIRED_PROJECT_STATUS="⚙️ Working"
+    ;;
+  blocked)
+    DESIRED_STATUS_LABEL="status:blocked"
+    DESIRED_PROJECT_STATUS="🚧 Blocked"
+    ;;
+  done)
+    DESIRED_PROJECT_STATUS="✅ Done"
+    ;;
+esac
+
+if [[ "${TARGET_STATE}" == "triage" ]]; then
+  HAS_TYPE="false"
+  for type_label in "${TYPE_LABELS[@]}"; do
+    if has_label "${type_label}"; then
+      HAS_TYPE="true"
+      break
+    fi
+  done
+  if [[ "${HAS_TYPE}" != "true" ]]; then
+    echo "Issue lacks a type label (bug|feature|task|refactor); triage transition requires one." >&2
+    exit 1
+  fi
+fi
+
+if [[ "${TARGET_STATE}" == "blocked" && -z "${BLOCKER_NOTE}" ]]; then
+  echo "blocked transition requires blockerNote" >&2
+  exit 1
+fi
+
+if [[ "${TARGET_STATE}" == "planned" ]]; then
+  if [[ -z "${MILESTONE_VALUE}" ]]; then
+    MILESTONE_VALUE="$(jq -r '.milestone.title // empty' <<<"${ISSUE_JSON}")"
+  fi
+  if [[ -z "${RELEASE_VALUE}" && -n "${MILESTONE_VALUE}" ]]; then
+    RELEASE_VALUE="${MILESTONE_VALUE}"
+  fi
+  if [[ -z "${MILESTONE_VALUE}" || -z "${RELEASE_VALUE}" ]]; then
+    echo "planned transition requires milestone and release (or existing milestone on issue)." >&2
+    exit 1
+  fi
+fi
+
+if [[ -n "${MILESTONE_VALUE}" && -z "${RELEASE_VALUE}" ]]; then
+  RELEASE_VALUE="${MILESTONE_VALUE}"
+fi
+if [[ -z "${MILESTONE_VALUE}" && -n "${RELEASE_VALUE}" ]]; then
+  MILESTONE_VALUE="${RELEASE_VALUE}"
+fi
+
+MISMATCH_REPAIR=""
+if [[ -n "${MILESTONE_VALUE}" && -n "${RELEASE_VALUE}" && "${MILESTONE_VALUE}" != "${RELEASE_VALUE}" ]]; then
+  if [[ "${PREFER_SOURCE}" == "release" ]]; then
+    MISMATCH_REPAIR="milestone<=${RELEASE_VALUE}"
+    MILESTONE_VALUE="${RELEASE_VALUE}"
+  else
+    MISMATCH_REPAIR="release<=${MILESTONE_VALUE}"
+    RELEASE_VALUE="${MILESTONE_VALUE}"
+  fi
+fi
+
+WORKING_LOAD_JSON='{"count":0,"issues":[]}'
+WORKING_WARNING=""
+if [[ "${TARGET_STATE}" == "working" ]]; then
+  WORKING_LOAD_JSON="$(${CHECK_WORKING_SCRIPT} --repo "${REPO}" --exclude-issue "${ISSUE_NUMBER}")"
+  if [[ "$(jq -r '.count' <<<"${WORKING_LOAD_JSON}")" != "0" ]]; then
+    WORKING_WARNING="Another issue is already in status:working"
+  fi
+fi
+
+STATUS_LABELS_TO_REMOVE=()
+for existing in "${CURRENT_LABELS[@]:-}"; do
+  case "${existing}" in
+    status:triage|status:planned|status:working|status:blocked)
+      if [[ -n "${DESIRED_STATUS_LABEL}" && "${existing}" == "${DESIRED_STATUS_LABEL}" ]]; then
+        continue
+      fi
+      STATUS_LABELS_TO_REMOVE+=("${existing}")
+      ;;
+  esac
+done
+
+AREA_VALUE=""
+PRIORITY_VALUE=""
+for existing in "${CURRENT_LABELS[@]:-}"; do
+  case "${existing}" in
+    backend|frontend|hardware|infra|database|auth|logging|unknown)
+      AREA_VALUE="${existing}"
+      ;;
+    P0|P1|P2)
+      PRIORITY_VALUE="${existing}"
+      ;;
+  esac
+done
+
+PLAN_JSON="$(jq -n \
+  --arg repo "${REPO}" \
+  --arg issueNumber "${ISSUE_NUMBER}" \
+  --arg targetState "${TARGET_STATE}" \
+  --arg desiredStatusLabel "${DESIRED_STATUS_LABEL}" \
+  --arg desiredProjectStatus "${DESIRED_PROJECT_STATUS}" \
+  --arg milestone "${MILESTONE_VALUE}" \
+  --arg release "${RELEASE_VALUE}" \
+  --arg mismatchRepair "${MISMATCH_REPAIR}" \
+  --arg workingWarning "${WORKING_WARNING}" \
+  --arg dryRun "${DRY_RUN}" \
+  --arg confirm "${CONFIRM}" \
+  --argjson removeLabels "$(printf '%s\n' "${STATUS_LABELS_TO_REMOVE[@]:-}" | sed '/^$/d' | jq -R . | jq -s .)" \
+  --argjson workingLoad "${WORKING_LOAD_JSON}" \
+  '{
+    repo: $repo,
+    issueNumber: ($issueNumber|tonumber),
+    targetState: $targetState,
+    statusLabel: (if ($desiredStatusLabel|length)>0 then $desiredStatusLabel else null end),
+    projectStatus: (if ($desiredProjectStatus|length)>0 then $desiredProjectStatus else null end),
+    milestone: (if ($milestone|length)>0 then $milestone else null end),
+    release: (if ($release|length)>0 then $release else null end),
+    mismatchRepair: (if ($mismatchRepair|length)>0 then $mismatchRepair else null end),
+    removeLabels: $removeLabels,
+    workingLoad: $workingLoad,
+    warnings: ( [($workingWarning|select(length>0))] ),
+    dryRun: ($dryRun == "true"),
+    confirm: ($confirm == "true")
+  }')"
+
+if [[ "${CONFIRM}" != "true" ]]; then
+  jq '. + {mutated:false, note:"Preview only. Re-run with --confirm or payload.confirm=true to execute."}' <<<"${PLAN_JSON}"
+  exit 0
+fi
+
+if [[ -n "${WORKING_WARNING}" && "${WARN_ONLY_WORKING_LIMIT}" != "true" ]]; then
+  echo "Working limit exceeded and warnOnlyWorkingLimit=false" >&2
+  exit 1
+fi
+
+edit_cmd=(gh issue edit "${ISSUE_NUMBER}" --repo "${REPO}")
+HAS_ISSUE_EDIT_MUTATION="false"
+if [[ -n "${DESIRED_STATUS_LABEL}" ]]; then
+  edit_cmd+=(--add-label "${DESIRED_STATUS_LABEL}")
+  HAS_ISSUE_EDIT_MUTATION="true"
+fi
+for remove_label in "${STATUS_LABELS_TO_REMOVE[@]:-}"; do
+  [[ -n "${remove_label}" ]] || continue
+  edit_cmd+=(--remove-label "${remove_label}")
+  HAS_ISSUE_EDIT_MUTATION="true"
+done
+if [[ -n "${MILESTONE_VALUE}" ]]; then
+  edit_cmd+=(--milestone "${MILESTONE_VALUE}")
+  HAS_ISSUE_EDIT_MUTATION="true"
+fi
+if [[ "${HAS_ISSUE_EDIT_MUTATION}" == "true" ]]; then
+  "${edit_cmd[@]}" >/dev/null
+fi
+
+if [[ "${TARGET_STATE}" == "blocked" && -n "${BLOCKER_NOTE}" ]]; then
+  gh issue comment "${ISSUE_NUMBER}" --repo "${REPO}" --body "Blocked reason: ${BLOCKER_NOTE}" >/dev/null
+fi
+
+"${SET_FIELDS_SCRIPT}" \
+  --repo "${REPO}" \
+  --issue-number "${ISSUE_NUMBER}" \
+  --project-owner "${PROJECT_OWNER}" \
+  --project-number "${PROJECT_NUMBER}" \
+  --project-title "${PROJECT_TITLE}" \
+  --status "${DESIRED_PROJECT_STATUS}" \
+  --area "${AREA_VALUE}" \
+  --priority "${PRIORITY_VALUE}" \
+  --release "${RELEASE_VALUE}" \
+  --confirm >/dev/null
+
+"${ALIGN_SCRIPT}" \
+  --repo "${REPO}" \
+  --issue-number "${ISSUE_NUMBER}" \
+  --project-owner "${PROJECT_OWNER}" \
+  --project-number "${PROJECT_NUMBER}" \
+  --project-title "${PROJECT_TITLE}" \
+  --prefer-source "${PREFER_SOURCE}" \
+  --confirm >/dev/null
+
+jq '. + {mutated:true}' <<<"${PLAN_JSON}"

--- a/.codex/skills/sentinel-github-issue-intake/SKILL.md
+++ b/.codex/skills/sentinel-github-issue-intake/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: sentinel-github-issue-intake
+description: Create Sentinel issues using strict GitHub templates (bug/feature/task/refactor), with preview-first planning and explicit confirm-before-mutate execution.
+---
+
+# Sentinel GitHub Issue Intake
+
+## Use This Skill When
+
+- A user asks to create/file/open a GitHub issue.
+- The issue type is `bug`, `feature`, `task`, or `refactor`.
+- The user wants milestone/release/project metadata set at creation time.
+
+## Required Behavior
+
+1. Resolve issue type first.
+2. Load authoritative template requirements from `.github/ISSUE_TEMPLATE/<type>.yml` using:
+   - `scripts/extract-template-requirements.sh`
+3. Ask only for missing required fields.
+4. Produce a normalized preview plan before mutation:
+   - title
+   - body
+   - labels
+   - milestone
+   - release
+   - project target and fields
+5. Mutate only on explicit confirmation (`confirm=true` or `--confirm`).
+6. Return issue URL + applied metadata summary.
+
+## Script Workflow
+
+```bash
+# 1) Read template contract (source of truth)
+.codex/skills/sentinel-github-issue-intake/scripts/extract-template-requirements.sh \
+  --type task
+
+# 2) Preview issue creation plan (no mutation)
+.codex/skills/sentinel-github-issue-intake/scripts/create-issue.sh \
+  --payload-file /tmp/intake.json
+
+# 3) Execute creation only after explicit confirmation
+.codex/skills/sentinel-github-issue-intake/scripts/create-issue.sh \
+  --payload-file /tmp/intake.json \
+  --confirm
+```
+
+## Payload Contract
+
+`create-issue.sh` accepts:
+
+```json
+{
+  "repo": "DeadshotOMEGA/sentinel",
+  "type": "bug|feature|task|refactor",
+  "title": "string",
+  "fields": {
+    "area": "backend|frontend|hardware|infra|database|auth|logging",
+    "priority": "P0|P1|P2"
+  },
+  "projectTitle": "Sentinel Development",
+  "milestone": "vX.Y.Z|null",
+  "release": "vX.Y.Z|null",
+  "additionalLabels": [],
+  "needsInvestigation": false,
+  "confirm": false
+}
+```
+
+## References
+
+- `references/workflow-rules.md`
+- `references/template-contracts.md`

--- a/.codex/skills/sentinel-github-issue-intake/agents/openai.yaml
+++ b/.codex/skills/sentinel-github-issue-intake/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Sentinel Issue Intake"
+  short_description: "Template-first issue creation with confirm-before-mutate"
+  default_prompt: "Create a Sentinel GitHub issue using the matching template contract, preview first, and mutate only after explicit confirmation."

--- a/.codex/skills/sentinel-github-issue-intake/references/template-contracts.md
+++ b/.codex/skills/sentinel-github-issue-intake/references/template-contracts.md
@@ -1,0 +1,35 @@
+# Template Contracts (Authoritative)
+
+Source templates:
+
+- `.github/ISSUE_TEMPLATE/bug.yml`
+- `.github/ISSUE_TEMPLATE/feature.yml`
+- `.github/ISSUE_TEMPLATE/task.yml`
+- `.github/ISSUE_TEMPLATE/refactor.yml`
+
+The parser script `scripts/extract-template-requirements.sh` is authoritative for required field enforcement.
+
+## Bug
+
+- Default labels: `bug`, `status:triage`
+- Required fields: `area`, `priority`, `happened`, `expected`, `repro`
+
+## Feature
+
+- Default labels: `feature`, `status:triage`
+- Required fields: `area`, `problem`, `proposal`
+
+## Task
+
+- Default labels: `task`, `status:triage`
+- Required fields: `area`, `goal`, `work`
+
+## Refactor
+
+- Default labels: `refactor`, `status:triage`
+- Required fields: `area`, `pain`, `scope`, `safety`
+
+## No-Drift Rule
+
+- Skills must not hardcode required fields.
+- Always resolve required fields from template YAML at runtime.

--- a/.codex/skills/sentinel-github-issue-intake/references/workflow-rules.md
+++ b/.codex/skills/sentinel-github-issue-intake/references/workflow-rules.md
@@ -1,0 +1,23 @@
+# Sentinel Workflow Rules (Issue Intake)
+
+Derived from `docs/WORKFLOW.md`.
+
+## Core Rules
+
+1. Every bug becomes an issue.
+2. New issues start in triage (`status:triage` / project `🧪 Inbox`).
+3. Type labels are mandatory: `bug|feature|task|refactor`.
+4. Area labels should match domain: `backend|frontend|hardware|infra|database|auth|logging`.
+5. Priority labels use `P0|P1|P2`.
+6. Use `needs-investigation` for unclear/flaky/intermittent cases.
+
+## Release Alignment
+
+- Milestone and project `Release` should match version semantics.
+- If only one is provided at intake, align the other to the same value.
+- If both are provided and mismatched, stop and require correction.
+
+## Mutation Safety
+
+- Preview-first is the default.
+- Never mutate GitHub state without explicit confirmation.

--- a/.codex/skills/sentinel-github-issue-intake/scripts/create-issue.sh
+++ b/.codex/skills/sentinel-github-issue-intake/scripts/create-issue.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: create-issue.sh --payload-file <path> [--dry-run] [--confirm]
+       create-issue.sh --payload-json '<json>' [--dry-run] [--confirm]
+
+Payload shape:
+{
+  "repo": "DeadshotOMEGA/sentinel",
+  "type": "bug|feature|task|refactor",
+  "title": "string",
+  "body": "string",
+  "area": "backend|frontend|hardware|infra|database|auth|logging",
+  "priority": "P0|P1|P2|null",
+  "labels": ["string"],
+  "fields": { "area": "frontend", "...": "..." },
+  "projectTitle": "Sentinel Development",
+  "milestone": "vX.Y.Z|null",
+  "release": "vX.Y.Z|null",
+  "needsInvestigation": false,
+  "additionalLabels": ["string"],
+  "confirm": false
+}
+USAGE
+}
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "${REPO_ROOT}" ]]; then
+  REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../../" && pwd)"
+fi
+
+PAYLOAD_FILE=""
+PAYLOAD_JSON=""
+DRY_RUN="false"
+CONFIRM_OVERRIDE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --payload-file)
+      PAYLOAD_FILE="${2:-}"
+      shift 2
+      ;;
+    --payload-json)
+      PAYLOAD_JSON="${2:-}"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      shift
+      ;;
+    --confirm)
+      CONFIRM_OVERRIDE="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+command -v gh >/dev/null 2>&1 || { echo "Missing dependency: gh" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "Missing dependency: jq" >&2; exit 1; }
+
+if [[ -n "${PAYLOAD_FILE}" ]]; then
+  [[ -f "${PAYLOAD_FILE}" ]] || { echo "Payload file not found: ${PAYLOAD_FILE}" >&2; exit 1; }
+  PAYLOAD_JSON="$(cat "${PAYLOAD_FILE}")"
+elif [[ -z "${PAYLOAD_JSON}" ]]; then
+  if [[ ! -t 0 ]]; then
+    PAYLOAD_JSON="$(cat)"
+  else
+    echo "Provide --payload-file or --payload-json" >&2
+    exit 1
+  fi
+fi
+
+jq -e . >/dev/null 2>&1 <<<"${PAYLOAD_JSON}" || {
+  echo "Payload is not valid JSON" >&2
+  exit 1
+}
+
+TYPE="$(jq -r '.type // empty' <<<"${PAYLOAD_JSON}")"
+TITLE="$(jq -r '.title // empty' <<<"${PAYLOAD_JSON}")"
+REPO="$(jq -r '.repo // "DeadshotOMEGA/sentinel"' <<<"${PAYLOAD_JSON}")"
+PROJECT_TITLE="$(jq -r '.projectTitle // "Sentinel Development"' <<<"${PAYLOAD_JSON}")"
+MILESTONE="$(jq -r '.milestone // empty' <<<"${PAYLOAD_JSON}")"
+RELEASE="$(jq -r '.release // empty' <<<"${PAYLOAD_JSON}")"
+NEEDS_INVESTIGATION="$(jq -r '.needsInvestigation // false' <<<"${PAYLOAD_JSON}")"
+PAYLOAD_CONFIRM="$(jq -r '.confirm // false' <<<"${PAYLOAD_JSON}")"
+
+if [[ -n "${CONFIRM_OVERRIDE}" ]]; then
+  CONFIRM="${CONFIRM_OVERRIDE}"
+else
+  CONFIRM="${PAYLOAD_CONFIRM}"
+fi
+
+if [[ "${DRY_RUN}" == "true" ]]; then
+  CONFIRM="false"
+fi
+
+[[ -n "${TYPE}" ]] || { echo "Payload.type is required" >&2; exit 1; }
+[[ -n "${TITLE}" ]] || { echo "Payload.title is required" >&2; exit 1; }
+
+TEMPLATE_META="$("${SCRIPT_DIR}"/extract-template-requirements.sh --type "${TYPE}" --repo-root "${REPO_ROOT}")"
+ALL_FIELD_IDS_JSON="$(jq -c '.allFieldIds' <<<"${TEMPLATE_META}")"
+FIELD_VALUES_JSON="$(jq -c --argjson allFieldIds "${ALL_FIELD_IDS_JSON}" '
+  . as $root
+  | reduce $allFieldIds[] as $id (
+      {};
+      ( ($root.fields[$id] // $root[$id]) ) as $value
+      | if $value == null then . else .[$id] = $value end
+    )
+' <<<"${PAYLOAD_JSON}")"
+
+validate_required_field() {
+  local field_id="${1}"
+  jq -e --arg id "${field_id}" '.[$id] != null and (.[$id] | tostring | gsub("^\\s+|\\s+$"; "") | length > 0)' <<<"${FIELD_VALUES_JSON}" >/dev/null
+}
+
+MISSING_REQUIRED=()
+while IFS= read -r required_id; do
+  [[ -n "${required_id}" ]] || continue
+  if ! validate_required_field "${required_id}"; then
+    MISSING_REQUIRED+=("${required_id}")
+  fi
+done < <(jq -r '.requiredFieldIds[]' <<<"${TEMPLATE_META}")
+
+if [[ "${#MISSING_REQUIRED[@]}" -gt 0 ]]; then
+  echo "Missing required template field(s): ${MISSING_REQUIRED[*]}" >&2
+  exit 1
+fi
+
+if [[ -n "${MILESTONE}" && -z "${RELEASE}" ]]; then
+  RELEASE="${MILESTONE}"
+elif [[ -z "${MILESTONE}" && -n "${RELEASE}" ]]; then
+  MILESTONE="${RELEASE}"
+fi
+
+if [[ -n "${MILESTONE}" && -n "${RELEASE}" && "${MILESTONE}" != "${RELEASE}" ]]; then
+  echo "Milestone/release mismatch (${MILESTONE} vs ${RELEASE}); resolve before create." >&2
+  exit 1
+fi
+
+AREA_VALUE="$(jq -r '.fields.area // .area // empty' <<<"${PAYLOAD_JSON}")"
+PRIORITY_VALUE="$(jq -r '.fields.priority // .priority // empty' <<<"${PAYLOAD_JSON}")"
+EXTRA_LABELS_JSON="$(jq -c '((.labels // []) + (.additionalLabels // []))' <<<"${PAYLOAD_JSON}")"
+
+LABELS_JSON="$(jq -n --argjson defaults "$(jq -c '.defaultLabels' <<<"${TEMPLATE_META}")" --arg area "${AREA_VALUE}" --arg priority "${PRIORITY_VALUE}" --arg needsInvestigation "${NEEDS_INVESTIGATION}" --argjson extra "${EXTRA_LABELS_JSON}" '
+  (
+    ($defaults +
+      (if ($area | length) > 0 then [$area] else [] end) +
+      (if ($priority | test("^P[0-9]+$")) then [$priority] else [] end) +
+      (if $needsInvestigation == "true" then ["needs-investigation"] else [] end) +
+      $extra
+    )
+    | map(select(length > 0))
+    | unique
+  )
+')"
+
+BODY_CONTENT="$(jq -r '.body // empty' <<<"${PAYLOAD_JSON}")"
+if [[ -z "${BODY_CONTENT}" ]]; then
+  BODY_CONTENT="$(jq -r '
+    to_entries
+    | map(select(.value != null and (.value|tostring|length) > 0))
+    | map("### " + .key + "\n" + (.value|tostring) + "\n")
+    | join("\n")
+  ' <<<"${FIELD_VALUES_JSON}")"
+fi
+
+if [[ -z "${BODY_CONTENT}" ]]; then
+  echo "No issue body content generated (provide payload.body or template field values)." >&2
+  exit 1
+fi
+
+PLAN_JSON="$(jq -n \
+  --arg repo "${REPO}" \
+  --arg type "${TYPE}" \
+  --arg title "${TITLE}" \
+  --arg projectTitle "${PROJECT_TITLE}" \
+  --arg milestone "${MILESTONE}" \
+  --arg release "${RELEASE}" \
+  --arg area "${AREA_VALUE}" \
+  --arg priority "${PRIORITY_VALUE}" \
+  --arg dryRun "${DRY_RUN}" \
+  --arg confirm "${CONFIRM}" \
+  --argjson labels "${LABELS_JSON}" \
+  '{
+    repo: $repo,
+    type: $type,
+    title: $title,
+    labels: $labels,
+    projectTitle: $projectTitle,
+    milestone: (if ($milestone|length)>0 then $milestone else null end),
+    release: (if ($release|length)>0 then $release else null end),
+    area: (if ($area|length)>0 then $area else null end),
+    priority: (if ($priority|length)>0 then $priority else null end),
+    dryRun: ($dryRun == "true"),
+    confirm: ($confirm == "true")
+  }')"
+
+if [[ "${CONFIRM}" != "true" ]]; then
+  jq '. + {mutated:false, note:"Preview only. Re-run with --confirm or payload.confirm=true to execute."}' <<<"${PLAN_JSON}"
+  exit 0
+fi
+
+TMP_BODY_FILE="$(mktemp)"
+printf '%s\n' "${BODY_CONTENT}" > "${TMP_BODY_FILE}"
+
+create_cmd=(gh issue create --repo "${REPO}" --title "${TITLE}" --body-file "${TMP_BODY_FILE}")
+if [[ -n "${MILESTONE}" ]]; then
+  create_cmd+=(--milestone "${MILESTONE}")
+fi
+if [[ -n "${PROJECT_TITLE}" ]]; then
+  create_cmd+=(--project "${PROJECT_TITLE}")
+fi
+while IFS= read -r label; do
+  [[ -n "${label}" ]] || continue
+  create_cmd+=(--label "${label}")
+done < <(jq -r '.[]' <<<"${LABELS_JSON}")
+
+ISSUE_URL="$("${create_cmd[@]}")"
+rm -f "${TMP_BODY_FILE}"
+
+ISSUE_NUMBER="${ISSUE_URL##*/}"
+
+STATUS_OPTION="🧪 Inbox"
+
+"${SCRIPT_DIR}"/set-project-fields.sh \
+  --repo "${REPO}" \
+  --issue-number "${ISSUE_NUMBER}" \
+  --project-title "${PROJECT_TITLE}" \
+  --status "${STATUS_OPTION}" \
+  --area "${AREA_VALUE}" \
+  --priority "${PRIORITY_VALUE}" \
+  --release "${RELEASE}" \
+  --confirm >/dev/null
+
+jq -n \
+  --argjson plan "${PLAN_JSON}" \
+  --arg issueUrl "${ISSUE_URL}" \
+  --arg issueNumber "${ISSUE_NUMBER}" \
+  '{
+    mutated: true,
+    issueUrl: $issueUrl,
+    issueNumber: ($issueNumber|tonumber),
+    applied: $plan
+  }'

--- a/.codex/skills/sentinel-github-issue-intake/scripts/extract-template-requirements.sh
+++ b/.codex/skills/sentinel-github-issue-intake/scripts/extract-template-requirements.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: extract-template-requirements.sh --type <bug|feature|task|refactor> [--repo-root <path>]
+USAGE
+}
+
+TYPE=""
+REPO_ROOT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --type)
+      TYPE="${2:-}"
+      shift 2
+      ;;
+    --repo-root)
+      REPO_ROOT="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+command -v jq >/dev/null 2>&1 || {
+  echo "Missing dependency: jq" >&2
+  exit 1
+}
+
+if [[ -z "${TYPE}" ]]; then
+  echo "--type is required" >&2
+  exit 1
+fi
+
+case "${TYPE}" in
+  bug|feature|task|refactor)
+    ;;
+  *)
+    echo "Unsupported type: ${TYPE}" >&2
+    exit 1
+    ;;
+esac
+
+if [[ -z "${REPO_ROOT}" ]]; then
+  SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+  REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -z "${REPO_ROOT}" ]]; then
+    REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../../" && pwd)"
+  fi
+fi
+
+TEMPLATE_PATH="${REPO_ROOT}/.github/ISSUE_TEMPLATE/${TYPE}.yml"
+[[ -f "${TEMPLATE_PATH}" ]] || {
+  echo "Template not found: ${TEMPLATE_PATH}" >&2
+  exit 1
+}
+
+TITLE_PREFIX="$(awk -F': ' '/^title:/ {gsub(/^"|"$/, "", $2); print $2; exit}' "${TEMPLATE_PATH}")"
+
+json_array_from_lines() {
+  if [[ $# -eq 0 ]]; then
+    printf '[]\n'
+    return
+  fi
+  printf '%s\n' "$@" | jq -R . | jq -s .
+}
+
+mapfile -t DEFAULT_LABELS < <(
+  awk '
+    /^labels:/ {in_labels=1; next}
+    in_labels && /^  - / {sub(/^  - /, ""); print; next}
+    in_labels {in_labels=0}
+  ' "${TEMPLATE_PATH}"
+)
+
+mapfile -t ALL_FIELD_IDS < <(
+  awk '
+    /^  - type:/ {
+      if (id != "") print id;
+      id="";
+      next
+    }
+    /^    id:[[:space:]]*/ {
+      sub(/^    id:[[:space:]]*/, "");
+      id=$0;
+      next
+    }
+    END {
+      if (id != "") print id;
+    }
+  ' "${TEMPLATE_PATH}"
+)
+
+mapfile -t REQUIRED_FIELD_IDS < <(
+  awk '
+    /^  - type:/ {
+      if (id != "" && required == 1) print id;
+      id="";
+      required=0;
+      next
+    }
+    /^    id:[[:space:]]*/ {
+      sub(/^    id:[[:space:]]*/, "");
+      id=$0;
+      next
+    }
+    /^[[:space:]]+required:[[:space:]]*true[[:space:]]*$/ {
+      required=1;
+      next
+    }
+    END {
+      if (id != "" && required == 1) print id;
+    }
+  ' "${TEMPLATE_PATH}"
+)
+
+DEFAULT_LABELS_JSON="$(json_array_from_lines "${DEFAULT_LABELS[@]:-}")"
+ALL_FIELD_IDS_JSON="$(json_array_from_lines "${ALL_FIELD_IDS[@]:-}")"
+REQUIRED_FIELD_IDS_JSON="$(json_array_from_lines "${REQUIRED_FIELD_IDS[@]:-}")"
+
+jq -n \
+  --arg type "${TYPE}" \
+  --arg templatePath "${TEMPLATE_PATH#"${REPO_ROOT}"/}" \
+  --arg titlePrefix "${TITLE_PREFIX}" \
+  --argjson defaultLabels "${DEFAULT_LABELS_JSON}" \
+  --argjson allFieldIds "${ALL_FIELD_IDS_JSON}" \
+  --argjson requiredFieldIds "${REQUIRED_FIELD_IDS_JSON}" \
+  '{
+    type: $type,
+    templatePath: $templatePath,
+    titlePrefix: $titlePrefix,
+    defaultLabels: $defaultLabels,
+    allFieldIds: $allFieldIds,
+    requiredFieldIds: $requiredFieldIds
+  }'

--- a/.codex/skills/sentinel-github-issue-intake/scripts/set-project-fields.sh
+++ b/.codex/skills/sentinel-github-issue-intake/scripts/set-project-fields.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: set-project-fields.sh --repo <owner/repo> --issue-number <n> [options]
+
+Options:
+  --project-owner <owner>           Defaults to repo owner
+  --project-number <number>         Defaults to 3
+  --project-title <title>           Defaults to "Sentinel Development"
+  --status <status-option-name>
+  --priority <P0|P1|P2>
+  --area <backend|frontend|hardware|infra|database|auth|logging|unknown>
+  --release <vX.Y.Z>
+  --dry-run                         Print planned actions only
+  --confirm                         Execute mutations
+USAGE
+}
+
+REPO=""
+ISSUE_NUMBER=""
+PROJECT_OWNER=""
+PROJECT_NUMBER="3"
+PROJECT_TITLE="Sentinel Development"
+STATUS_VALUE=""
+PRIORITY_VALUE=""
+AREA_VALUE=""
+RELEASE_VALUE=""
+DRY_RUN="false"
+CONFIRM="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      REPO="${2:-}"
+      shift 2
+      ;;
+    --issue-number)
+      ISSUE_NUMBER="${2:-}"
+      shift 2
+      ;;
+    --project-owner)
+      PROJECT_OWNER="${2:-}"
+      shift 2
+      ;;
+    --project-number)
+      PROJECT_NUMBER="${2:-}"
+      shift 2
+      ;;
+    --project-title)
+      PROJECT_TITLE="${2:-}"
+      shift 2
+      ;;
+    --status)
+      STATUS_VALUE="${2:-}"
+      shift 2
+      ;;
+    --priority)
+      PRIORITY_VALUE="${2:-}"
+      shift 2
+      ;;
+    --area)
+      AREA_VALUE="${2:-}"
+      shift 2
+      ;;
+    --release)
+      RELEASE_VALUE="${2:-}"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      shift
+      ;;
+    --confirm)
+      CONFIRM="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+command -v gh >/dev/null 2>&1 || { echo "Missing dependency: gh" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "Missing dependency: jq" >&2; exit 1; }
+
+[[ -n "${REPO}" ]] || { echo "--repo is required" >&2; exit 1; }
+[[ -n "${ISSUE_NUMBER}" ]] || { echo "--issue-number is required" >&2; exit 1; }
+
+if [[ -z "${PROJECT_OWNER}" ]]; then
+  PROJECT_OWNER="${REPO%%/*}"
+fi
+
+if [[ "${DRY_RUN}" == "true" ]]; then
+  CONFIRM="false"
+fi
+
+PROJECT_VIEW_JSON="$(gh project view "${PROJECT_NUMBER}" --owner "${PROJECT_OWNER}" --format json)"
+PROJECT_ID="$(jq -r '.id' <<<"${PROJECT_VIEW_JSON}")"
+[[ -n "${PROJECT_ID}" && "${PROJECT_ID}" != "null" ]] || {
+  echo "Unable to resolve project id for owner=${PROJECT_OWNER} number=${PROJECT_NUMBER}" >&2
+  exit 1
+}
+
+PROJECT_FIELDS_JSON="$(gh project field-list "${PROJECT_NUMBER}" --owner "${PROJECT_OWNER}" --format json)"
+
+# shellcheck disable=SC2016
+ISSUE_ITEM_QUERY='query($owner:String!, $repo:String!, $issue:Int!){repository(owner:$owner,name:$repo){issue(number:$issue){projectItems(first:50){nodes{id project{__typename ... on ProjectV2{id number owner{__typename ... on User{login} ... on Organization{login}}}}}}}}}'
+
+fetch_issue_item_id() {
+  gh api graphql -f query="${ISSUE_ITEM_QUERY}" -F owner="${REPO%%/*}" -F repo="${REPO##*/}" -F issue="${ISSUE_NUMBER}" \
+    | jq -r --arg owner "${PROJECT_OWNER}" --argjson number "${PROJECT_NUMBER}" '
+      .data.repository.issue.projectItems.nodes[]?
+      | select(.project.__typename == "ProjectV2")
+      | select(.project.number == $number)
+      | select(.project.owner.login == $owner)
+      | .id
+    ' \
+    | head -n1
+}
+
+ISSUE_ITEM_ID="$(fetch_issue_item_id || true)"
+
+if [[ -z "${ISSUE_ITEM_ID}" ]]; then
+  if [[ "${CONFIRM}" == "true" ]]; then
+    gh issue edit "${ISSUE_NUMBER}" --repo "${REPO}" --add-project "${PROJECT_TITLE}" >/dev/null
+    ISSUE_ITEM_ID="$(fetch_issue_item_id || true)"
+  fi
+fi
+
+if [[ -z "${ISSUE_ITEM_ID}" ]]; then
+  jq -n \
+    --arg repo "${REPO}" \
+    --arg issueNumber "${ISSUE_NUMBER}" \
+    --arg projectTitle "${PROJECT_TITLE}" \
+    --arg dryRun "${DRY_RUN}" \
+    --arg confirm "${CONFIRM}" \
+    '{
+      repo: $repo,
+      issueNumber: ($issueNumber | tonumber),
+      projectTitle: $projectTitle,
+      dryRun: ($dryRun == "true"),
+      confirm: ($confirm == "true"),
+      changed: false,
+      warning: "Issue is not in project; project-link required before field updates"
+    }'
+  exit 0
+fi
+
+get_field_id() {
+  local field_name="${1}"
+  jq -r --arg fieldName "${field_name}" '.fields[] | select(.name == $fieldName) | .id' <<<"${PROJECT_FIELDS_JSON}" | head -n1
+}
+
+get_option_id() {
+  local field_name="${1}"
+  local option_name="${2}"
+  jq -r --arg fieldName "${field_name}" --arg optionName "${option_name}" '.fields[] | select(.name == $fieldName) | .options[]? | select(.name == $optionName) | .id' <<<"${PROJECT_FIELDS_JSON}" | head -n1
+}
+
+apply_single_select() {
+  local field_name="${1}"
+  local field_value="${2}"
+
+  [[ -n "${field_value}" ]] || return 0
+
+  local field_id option_id
+  field_id="$(get_field_id "${field_name}")"
+  if [[ -z "${field_id}" ]]; then
+    echo "Field '${field_name}' not found in project ${PROJECT_NUMBER}" >&2
+    return 1
+  fi
+
+  option_id="$(get_option_id "${field_name}" "${field_value}")"
+  if [[ -z "${option_id}" ]]; then
+    echo "Option '${field_value}' not found for field '${field_name}'" >&2
+    return 1
+  fi
+
+  if [[ "${CONFIRM}" == "true" ]]; then
+    gh project item-edit \
+      --id "${ISSUE_ITEM_ID}" \
+      --project-id "${PROJECT_ID}" \
+      --field-id "${field_id}" \
+      --single-select-option-id "${option_id}" >/dev/null
+  fi
+
+  echo "${field_name}=${field_value}"
+}
+
+APPLIED=()
+WARNINGS=()
+
+if output="$(apply_single_select "Status" "${STATUS_VALUE}" 2>&1)"; then
+  [[ -n "${output}" ]] && APPLIED+=("${output}")
+elif [[ -n "${STATUS_VALUE}" ]]; then
+  WARNINGS+=("${output}")
+fi
+if output="$(apply_single_select "Priority" "${PRIORITY_VALUE}" 2>&1)"; then
+  [[ -n "${output}" ]] && APPLIED+=("${output}")
+elif [[ -n "${PRIORITY_VALUE}" ]]; then
+  WARNINGS+=("${output}")
+fi
+if output="$(apply_single_select "Area" "${AREA_VALUE}" 2>&1)"; then
+  [[ -n "${output}" ]] && APPLIED+=("${output}")
+elif [[ -n "${AREA_VALUE}" ]]; then
+  WARNINGS+=("${output}")
+fi
+if output="$(apply_single_select "Release" "${RELEASE_VALUE}" 2>&1)"; then
+  [[ -n "${output}" ]] && APPLIED+=("${output}")
+elif [[ -n "${RELEASE_VALUE}" ]]; then
+  WARNINGS+=("${output}")
+fi
+
+jq -n \
+  --arg repo "${REPO}" \
+  --arg issueNumber "${ISSUE_NUMBER}" \
+  --arg projectOwner "${PROJECT_OWNER}" \
+  --arg projectNumber "${PROJECT_NUMBER}" \
+  --arg dryRun "${DRY_RUN}" \
+  --arg confirm "${CONFIRM}" \
+  --argjson applied "$(printf '%s\n' "${APPLIED[@]:-}" | sed '/^$/d' | jq -R . | jq -s .)" \
+  --argjson warnings "$(printf '%s\n' "${WARNINGS[@]:-}" | sed '/^$/d' | jq -R . | jq -s .)" \
+  '{
+    repo: $repo,
+    issueNumber: ($issueNumber | tonumber),
+    projectOwner: $projectOwner,
+    projectNumber: ($projectNumber | tonumber),
+    dryRun: ($dryRun == "true"),
+    confirm: ($confirm == "true"),
+    changed: (($confirm == "true") and ($applied | length > 0)),
+    plannedUpdates: $applied,
+    warnings: $warnings
+  }'

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,0 +1,88 @@
+name: Refactor
+description: Track internal structural improvements without changing intended behavior.
+title: "[Refactor]: "
+labels:
+  - refactor
+  - status:triage
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Primary domain this refactor affects.
+      options:
+        - backend
+        - frontend
+        - hardware
+        - infra
+        - database
+        - auth
+        - logging
+    validations:
+      required: true
+
+  - type: textarea
+    id: pain
+    attributes:
+      label: Current pain
+      description: What technical problem is this refactor addressing?
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Refactor scope
+      description: Explicit in-scope and out-of-scope boundaries.
+      placeholder: |
+        In scope:
+        - ...
+        Out of scope:
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: safety
+    attributes:
+      label: Safety / behavioral guarantee
+      description: Confirm what behavior must remain unchanged.
+      placeholder: |
+        This refactor should not change runtime behavior except:
+        - ...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: Impact and urgency
+      options:
+        - P0
+        - P1
+        - P2
+
+  - type: textarea
+    id: risk
+    attributes:
+      label: Risks
+      description: Main technical risks and likely failure modes.
+
+  - type: textarea
+    id: rollback
+    attributes:
+      label: Rollback plan
+      description: How to revert if refactor causes regression.
+
+  - type: textarea
+    id: test-notes
+    attributes:
+      label: Test notes
+      description: Verification strategy and regression checks.
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies / blockers
+      description: External dependencies or ordering constraints.

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,80 @@
+name: Task
+description: Track implementation work that is not a feature or refactor.
+title: "[Task]: "
+labels:
+  - task
+  - status:triage
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Primary domain this task affects.
+      options:
+        - backend
+        - frontend
+        - hardware
+        - infra
+        - database
+        - auth
+        - logging
+    validations:
+      required: true
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What outcome is needed?
+      placeholder: Describe the concrete result this task should produce.
+    validations:
+      required: true
+
+  - type: textarea
+    id: work
+    attributes:
+      label: Proposed work
+      description: Implementation steps at an actionable level.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: Impact and urgency
+      options:
+        - P0
+        - P1
+        - P2
+
+  - type: checkboxes
+    id: acceptance
+    attributes:
+      label: Acceptance checklist
+      options:
+        - label: Scope is specific and testable.
+        - label: Owner/next action is clear.
+        - label: Docs/update notes were considered.
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies / blockers
+      description: External dependencies, sequencing, or approvals.
+
+  - type: textarea
+    id: test-notes
+    attributes:
+      label: Test notes
+      description: How this task should be verified.
+
+  - type: textarea
+    id: release-impact
+    attributes:
+      label: Release impact
+      description: Any release/version implication if known.

--- a/.github/workflows/align-release-milestone.yml
+++ b/.github/workflows/align-release-milestone.yml
@@ -1,0 +1,233 @@
+name: Align Issue Release and Milestone
+
+on:
+  issues:
+    types: [opened, reopened, edited, milestoned, demilestoned]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Issue number to align'
+        required: true
+        type: string
+      project_number:
+        description: 'GitHub Project number (defaults to repo var SENTINEL_PROJECT_NUMBER or 3).'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  align:
+    name: Keep Release field and milestone synchronized
+    runs-on: ubuntu-latest
+    env:
+      PROJECTS_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
+      INPUT_ISSUE_NUMBER: ${{ github.event.inputs.issue_number }}
+      INPUT_PROJECT_NUMBER: ${{ github.event.inputs.project_number }}
+      DEFAULT_PROJECT_NUMBER: ${{ vars.SENTINEL_PROJECT_NUMBER }}
+
+    steps:
+      - name: Validate token
+        run: |
+          if [[ -z "${PROJECTS_TOKEN}" ]]; then
+            echo "::error::Missing secret PROJECTS_TOKEN (requires project + read:project scopes)."
+            exit 1
+          fi
+
+      - name: Align issue release and milestone
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PROJECTS_TOKEN }}
+          script: |
+            const owner = context.repo.owner
+            const repo = context.repo.repo
+            const fallbackProjectNumber = Number(process.env.DEFAULT_PROJECT_NUMBER || 3)
+            const projectNumber = Number(process.env.INPUT_PROJECT_NUMBER || fallbackProjectNumber)
+            const issueNumber = context.eventName === 'workflow_dispatch'
+              ? Number(process.env.INPUT_ISSUE_NUMBER)
+              : Number(context.payload.issue?.number)
+
+            if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+              core.setFailed('Could not resolve a valid issue number.')
+              return
+            }
+
+            const issueQuery = `
+              query($owner:String!, $repo:String!, $issueNumber:Int!) {
+                repository(owner:$owner, name:$repo) {
+                  issue(number:$issueNumber) {
+                    id
+                    number
+                    milestone { title number }
+                    projectItems(first:20) {
+                      nodes {
+                        id
+                        project {
+                          __typename
+                          ... on ProjectV2 {
+                            id
+                            number
+                            title
+                            owner {
+                              __typename
+                              ... on User { login }
+                              ... on Organization { login }
+                            }
+                          }
+                        }
+                        fieldValues(first:50) {
+                          nodes {
+                            ... on ProjectV2ItemFieldSingleSelectValue {
+                              name
+                              optionId
+                              field {
+                                ... on ProjectV2SingleSelectField {
+                                  id
+                                  name
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `
+
+            const issueData = await github.graphql(issueQuery, { owner, repo, issueNumber })
+            const issue = issueData.repository?.issue
+            if (!issue) {
+              core.warning(`Issue #${issueNumber} not found.`)
+              return
+            }
+
+            const matchingItem = (issue.projectItems?.nodes ?? []).find((node) => {
+              const project = node.project
+              if (!project || project.__typename !== 'ProjectV2') return false
+              return Number(project.number) === projectNumber && project.owner?.login === owner
+            })
+
+            if (!matchingItem) {
+              core.info(`Issue #${issueNumber} is not in project #${projectNumber}; nothing to align.`)
+              return
+            }
+
+            const projectId = matchingItem.project.id
+            const itemId = matchingItem.id
+            const milestoneTitle = issue.milestone?.title ?? null
+
+            const releaseValue = (matchingItem.fieldValues?.nodes ?? []).find((node) => {
+              return node?.field?.name === 'Release'
+            })
+            const releaseName = releaseValue?.name ?? null
+
+            const fieldQuery = `
+              query($projectId:ID!) {
+                node(id:$projectId) {
+                  ... on ProjectV2 {
+                    fields(first:50) {
+                      nodes {
+                        ... on ProjectV2SingleSelectField {
+                          id
+                          name
+                          options {
+                            id
+                            name
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `
+            const fieldData = await github.graphql(fieldQuery, { projectId })
+            const releaseField = (fieldData.node?.fields?.nodes ?? []).find((node) => node?.name === 'Release')
+            if (!releaseField) {
+              core.warning(`Project #${projectNumber} has no Release field; skipping.`)
+              return
+            }
+
+            const optionsByName = new Map((releaseField.options ?? []).map((opt) => [opt.name, opt.id]))
+            const releaseOptionId = releaseName ? optionsByName.get(releaseName) : null
+            const milestoneOptionId = milestoneTitle ? optionsByName.get(milestoneTitle) : null
+
+            const updateItemField = async (optionId) => {
+              await github.graphql(
+                `mutation($projectId:ID!, $itemId:ID!, $fieldId:ID!, $optionId:String!) {
+                  updateProjectV2ItemFieldValue(input:{
+                    projectId:$projectId,
+                    itemId:$itemId,
+                    fieldId:$fieldId,
+                    value:{ singleSelectOptionId:$optionId }
+                  }) { projectV2Item { id } }
+                }`,
+                {
+                  projectId,
+                  itemId,
+                  fieldId: releaseField.id,
+                  optionId,
+                }
+              )
+            }
+
+            const listMilestones = async () => {
+              return await github.paginate(github.rest.issues.listMilestones, {
+                owner,
+                repo,
+                state: 'all',
+                per_page: 100,
+              })
+            }
+
+            const setIssueMilestoneByTitle = async (title) => {
+              const milestones = await listMilestones()
+              const target = milestones.find((ms) => ms.title === title)
+              if (!target) {
+                core.warning(`Milestone '${title}' does not exist in ${owner}/${repo}; cannot align issue milestone.`)
+                return false
+              }
+
+              if (issue.milestone?.number === target.number) {
+                return true
+              }
+
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                milestone: target.number,
+              })
+              core.info(`Aligned issue #${issueNumber} milestone -> ${title}`)
+              return true
+            }
+
+            if (milestoneTitle && milestoneOptionId) {
+              if (releaseName !== milestoneTitle) {
+                await updateItemField(milestoneOptionId)
+                core.info(`Aligned project Release field -> ${milestoneTitle}`)
+              } else {
+                core.info('Release field already matches milestone.')
+              }
+              return
+            }
+
+            if (milestoneTitle && !milestoneOptionId) {
+              core.warning(`Milestone '${milestoneTitle}' is not available in project Release options.`)
+              return
+            }
+
+            if (releaseName) {
+              if (!releaseOptionId) {
+                core.warning(`Release field value '${releaseName}' has no matching option id.`)
+                return
+              }
+              await setIssueMilestoneByTitle(releaseName)
+              return
+            }
+
+            core.info('Neither milestone nor Release field value is set; nothing to align.')

--- a/.github/workflows/sync-release-tracks.yml
+++ b/.github/workflows/sync-release-tracks.yml
@@ -1,0 +1,74 @@
+name: Sync Release Tracks
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'package.json'
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      current_version:
+        description: 'Current release version (X.Y.Z or vX.Y.Z). Defaults to package.json/release tag.'
+        required: false
+        type: string
+      project_number:
+        description: 'GitHub Project number (defaults to repo var SENTINEL_PROJECT_NUMBER or 3).'
+        required: false
+        type: string
+      repository:
+        description: 'owner/repo target (defaults to current repository).'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    name: Sync project Release options and milestones
+    runs-on: ubuntu-latest
+    env:
+      EVENT_NAME: ${{ github.event_name }}
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
+      INPUT_CURRENT_VERSION: ${{ github.event.inputs.current_version }}
+      INPUT_PROJECT_NUMBER: ${{ github.event.inputs.project_number }}
+      INPUT_REPOSITORY: ${{ github.event.inputs.repository }}
+      DEFAULT_REPOSITORY: ${{ github.repository }}
+      SENTINEL_PROJECT_NUMBER: ${{ vars.SENTINEL_PROJECT_NUMBER }}
+      PROJECTS_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate token
+        run: |
+          if [[ -z "${PROJECTS_TOKEN}" ]]; then
+            echo "::error::Missing secret PROJECTS_TOKEN (requires project + read:project scopes)."
+            exit 1
+          fi
+
+      - name: Sync release tracks
+        env:
+          GH_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          target_repo="${INPUT_REPOSITORY:-$DEFAULT_REPOSITORY}"
+          if [[ -n "${INPUT_PROJECT_NUMBER}" ]]; then
+            export PROJECT_NUMBER="${INPUT_PROJECT_NUMBER}"
+          elif [[ -n "${SENTINEL_PROJECT_NUMBER}" ]]; then
+            export PROJECT_NUMBER="${SENTINEL_PROJECT_NUMBER}"
+          else
+            export PROJECT_NUMBER="3"
+          fi
+
+          if [[ -n "${INPUT_CURRENT_VERSION}" ]]; then
+            export CURRENT_RELEASE_VERSION="${INPUT_CURRENT_VERSION}"
+          elif [[ "${EVENT_NAME}" == "release" && -n "${RELEASE_TAG}" ]]; then
+            export CURRENT_RELEASE_VERSION="${RELEASE_TAG}"
+          fi
+
+          bash scripts/github/sync-release-tracks.sh "${target_repo}"

--- a/scripts/github/setup-solo-workflow.ps1
+++ b/scripts/github/setup-solo-workflow.ps1
@@ -6,17 +6,45 @@ param(
   [string]$Repo = ""
 )
 
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot = ""
+try {
+  $RepoRoot = (git -C $ScriptDir rev-parse --show-toplevel).Trim()
+}
+catch {
+  $RepoRoot = (Resolve-Path (Join-Path $ScriptDir '..\..')).Path
+}
+Set-Location $RepoRoot
+
 if ([string]::IsNullOrWhiteSpace($Repo)) {
   $Repo = gh repo view --json nameWithOwner --jq .nameWithOwner
 }
 
 $Owner = $Repo.Split('/')[0]
 $ProjectTitle = 'Sentinel Development'
-$LabelsPath = '.github/labels.solo-workflow.json'
+$LabelsPath = Join-Path $RepoRoot '.github/labels.solo-workflow.json'
+$CurrentReleaseVersion = if ($env:CURRENT_RELEASE_VERSION) { $env:CURRENT_RELEASE_VERSION } else { (Get-Content package.json | ConvertFrom-Json).version }
+$CurrentReleaseVersion = $CurrentReleaseVersion.TrimStart('v')
+if ($CurrentReleaseVersion -notmatch '^\d+\.\d+\.\d+$') {
+  throw "CURRENT_RELEASE_VERSION must be SemVer X.Y.Z; got: $CurrentReleaseVersion"
+}
+$versionParts = $CurrentReleaseVersion.Split('.')
+$major = [int]$versionParts[0]
+$minor = [int]$versionParts[1]
+$patch = [int]$versionParts[2]
+$ReleaseMilestones = @(
+  "v$major.$minor.$patch",
+  "v$major.$minor.$($patch + 1)",
+  "v$major.$($minor + 1).0",
+  "v$($major + 1).0.0"
+)
 
 if (-not (Test-Path $LabelsPath)) {
   throw "Labels file not found: $LabelsPath"
 }
+
+Write-Host "Configuring repo: $Repo"
+Write-Host "Release set: $($ReleaseMilestones -join ', ')"
 
 $labels = Get-Content $LabelsPath | ConvertFrom-Json
 $existing = gh label list --repo $Repo --limit 500 --json name --jq '.[].name'
@@ -32,7 +60,7 @@ foreach ($label in $labels) {
   }
 }
 
-foreach ($ms in @('v0.6', 'v0.7', 'v1.0')) {
+foreach ($ms in $ReleaseMilestones) {
   $milestones = gh api "repos/$Repo/milestones?state=all&per_page=100" --jq '.[].title'
   if ($milestones -contains $ms) {
     Write-Host "Milestone exists: $ms"
@@ -53,5 +81,43 @@ if ([string]::IsNullOrWhiteSpace($projectNumber)) {
 }
 
 gh project link $projectNumber --owner $Owner --repo $Repo | Out-Null
+
+$releaseFieldId = gh project field-list $projectNumber --owner $Owner --format json --jq '.fields[] | select(.name == "Release") | .id' | Select-Object -First 1
+if ([string]::IsNullOrWhiteSpace($releaseFieldId)) {
+  gh project field-create $projectNumber --owner $Owner --name 'Release' --data-type 'SINGLE_SELECT' --single-select-options ($ReleaseMilestones -join ',') | Out-Null
+  $releaseFieldId = gh project field-list $projectNumber --owner $Owner --format json --jq '.fields[] | select(.name == "Release") | .id' | Select-Object -First 1
+}
+
+if (-not [string]::IsNullOrWhiteSpace($releaseFieldId)) {
+  $current = $ReleaseMilestones[0]
+  $nextPatch = $ReleaseMilestones[1]
+  $nextMinor = $ReleaseMilestones[2]
+  $nextMajor = $ReleaseMilestones[3]
+  $mutation = @'
+mutation($fieldId:ID!){
+  updateProjectV2Field(input:{
+    fieldId:$fieldId,
+    name:"Release",
+    singleSelectOptions:[
+      {name:"__CURRENT__",description:"Current release",color:GRAY},
+      {name:"__PATCH__",description:"Patch release",color:BLUE},
+      {name:"__MINOR__",description:"Minor release",color:YELLOW},
+      {name:"__MAJOR__",description:"Major release",color:RED}
+    ]
+  }){
+    projectV2Field{
+      ... on ProjectV2SingleSelectField{
+        id
+        name
+        options{ id name }
+      }
+    }
+  }
+}
+'@
+  $mutation = $mutation.Replace('__CURRENT__', $current).Replace('__PATCH__', $nextPatch).Replace('__MINOR__', $nextMinor).Replace('__MAJOR__', $nextMajor)
+  gh api graphql -f query="$mutation" -f fieldId="$releaseFieldId" | Out-Null
+  Write-Host "Synced Release field options: $($ReleaseMilestones -join ', ')"
+}
 
 Write-Host "Done. Complete columns, auto-add workflow, and saved views via docs/WORKFLOW.md checklist."

--- a/scripts/github/setup-solo-workflow.sh
+++ b/scripts/github/setup-solo-workflow.sh
@@ -7,25 +7,92 @@ set -euo pipefail
 #   scripts/github/setup-solo-workflow.sh [owner/repo]
 #   scripts/github/setup-solo-workflow.sh DeadshotOMEGA/sentinel
 
-REPO="${1:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
-OWNER="${REPO%%/*}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
 PROJECT_TITLE="Sentinel Development"
-LABELS_FILE=".github/labels.solo-workflow.json"
 PRUNE_UNUSED="${PRUNE_UNUSED:-false}"
+CURRENT_RELEASE_VERSION="${CURRENT_RELEASE_VERSION:-}"
+RELEASE_MILESTONES=()
 
 require() {
   command -v "$1" >/dev/null 2>&1 || { echo "Missing dependency: $1" >&2; exit 1; }
 }
 
+die() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+warn() {
+  echo "Warning: $*" >&2
+}
+
+info() {
+  echo "$*"
+}
+
+build_release_milestones() {
+  local raw_version="${CURRENT_RELEASE_VERSION}"
+  local major minor patch next_patch minor_release major_release
+
+  if [[ -z "${raw_version}" ]]; then
+    raw_version="$(jq -r '.version' "${REPO_ROOT}/package.json" 2>/dev/null || true)"
+  fi
+  raw_version="${raw_version#v}"
+
+  if [[ ! "${raw_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    die "CURRENT_RELEASE_VERSION must be SemVer (X.Y.Z); got: ${raw_version:-<empty>}"
+  fi
+
+  IFS='.' read -r major minor patch <<<"${raw_version}"
+  next_patch=$((patch + 1))
+  minor_release=$((minor + 1))
+  major_release=$((major + 1))
+
+  RELEASE_MILESTONES=(
+    "v${major}.${minor}.${patch}"
+    "v${major}.${minor}.${next_patch}"
+    "v${major}.${minor_release}.0"
+    "v${major_release}.0.0"
+  )
+}
+
 require gh
 require jq
 
+if [[ -z "${REPO_ROOT}" ]]; then
+  REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+fi
+cd "$REPO_ROOT"
+build_release_milestones
+
+REPO="${1:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
+OWNER="${REPO%%/*}"
+LABELS_FILE="${REPO_ROOT}/.github/labels.solo-workflow.json"
+
 if [[ ! -f "$LABELS_FILE" ]]; then
-  echo "Labels file not found: $LABELS_FILE" >&2
-  exit 1
+  die "Labels file not found: $LABELS_FILE"
 fi
 
-echo "Configuring repo: $REPO"
+if ! gh auth status >/dev/null 2>&1; then
+  die "GitHub CLI is not authenticated. Run: gh auth login"
+fi
+
+if ! jq -e 'type == "array"' "$LABELS_FILE" >/dev/null 2>&1; then
+  die "Invalid labels file format (expected JSON array): $LABELS_FILE"
+fi
+
+info "Configuring repo: $REPO"
+info "Release set: $(IFS=', '; echo "${RELEASE_MILESTONES[*]}")"
+
+fetch_existing_labels() {
+  gh label list --repo "$REPO" --limit 500 --json name --jq '.[].name'
+}
+
+label_exists() {
+  local label_name="${1}"
+  grep -Fxq "$label_name" <<<"$EXISTING_LABELS"
+}
 
 # Optional conservative remaps from common old labels.
 declare -A REMAP=(
@@ -35,14 +102,17 @@ declare -A REMAP=(
   [investigate]=needs-investigation
 )
 
+EXISTING_LABELS="$(fetch_existing_labels)"
+
 for old in "${!REMAP[@]}"; do
   new="${REMAP[$old]}"
-  if gh label list --repo "$REPO" --limit 200 --json name --jq '.[].name' | grep -Fxq "$old"; then
-    if ! gh label list --repo "$REPO" --limit 200 --json name --jq '.[].name' | grep -Fxq "$new"; then
-      echo "Renaming label: $old -> $new"
+  if label_exists "$old"; then
+    if ! label_exists "$new"; then
+      info "Renaming label: $old -> $new"
       gh label edit "$old" --repo "$REPO" --name "$new" >/dev/null
+      EXISTING_LABELS="$(fetch_existing_labels)"
     else
-      echo "Keeping both labels for safety (old exists): $old"
+      info "Keeping both labels for safety (old exists): $old"
     fi
   fi
 done
@@ -53,37 +123,66 @@ while IFS= read -r label; do
   color="$(jq -r '.color' <<<"$label")"
   description="$(jq -r '.description' <<<"$label")"
 
-  if gh label list --repo "$REPO" --limit 300 --json name --jq '.[].name' | grep -Fxq "$name"; then
+  if label_exists "$name"; then
     gh label edit "$name" --repo "$REPO" --color "$color" --description "$description" >/dev/null
-    echo "Updated label: $name"
+    info "Updated label: $name"
   else
     gh label create "$name" --repo "$REPO" --color "$color" --description "$description" >/dev/null
-    echo "Created label: $name"
+    info "Created label: $name"
+    EXISTING_LABELS+=$'\n'"$name"
   fi
 done < <(jq -c '.[]' "$LABELS_FILE")
 
 if [[ "$PRUNE_UNUSED" == "true" ]]; then
-  echo "PRUNE_UNUSED=true: deleting labels not in canonical pack (except default GitHub labels)"
-  canonical="$(jq -r '.[].name' "$LABELS_FILE" | sort)"
-  gh label list --repo "$REPO" --limit 500 --json name --jq '.[].name' | while IFS= read -r existing; do
-    if grep -Fxq "$existing" <(printf '%s\n' "$canonical"); then
+  info "PRUNE_UNUSED=true: deleting labels not in canonical pack (except default GitHub labels)"
+  declare -A CANONICAL_LABELS=()
+  while IFS= read -r canonical_name; do
+    [[ -n "${canonical_name}" ]] || continue
+    CANONICAL_LABELS["$canonical_name"]=1
+  done < <(jq -r '.[].name' "$LABELS_FILE")
+
+  while IFS= read -r existing; do
+    [[ -n "${existing}" ]] || continue
+    if [[ -n "${CANONICAL_LABELS[$existing]+x}" ]]; then
       continue
     fi
     case "$existing" in
       "good first issue"|"help wanted") continue ;;
     esac
     gh label delete "$existing" --repo "$REPO" --yes >/dev/null || true
-    echo "Deleted label: $existing"
-  done
+    info "Deleted label: $existing"
+  done < <(printf '%s\n' "$EXISTING_LABELS")
+
+  EXISTING_LABELS="$(fetch_existing_labels)"
 fi
 
 # Milestones (idempotent)
-for ms in v0.6 v0.7 v1.0; do
-  if gh api "repos/$REPO/milestones?state=all&per_page=100" --jq '.[].title' | grep -Fxq "$ms"; then
-    echo "Milestone exists: $ms"
+fetch_milestones() {
+  gh api --paginate "repos/$REPO/milestones?state=all&per_page=100" --jq '.[].title'
+}
+
+milestone_exists() {
+  local milestone_title="${1}"
+  grep -Fxq "$milestone_title" <<<"$EXISTING_MILESTONES"
+}
+
+EXISTING_MILESTONES="$(fetch_milestones)"
+
+for ms in "${RELEASE_MILESTONES[@]}"; do
+  if milestone_exists "$ms"; then
+    info "Milestone exists: $ms"
   else
-    gh api --method POST "repos/$REPO/milestones" -f title="$ms" >/dev/null
-    echo "Created milestone: $ms"
+    if gh api --method POST "repos/$REPO/milestones" -f title="$ms" >/dev/null 2>&1; then
+      info "Created milestone: $ms"
+      EXISTING_MILESTONES+=$'\n'"$ms"
+    else
+      EXISTING_MILESTONES="$(fetch_milestones)"
+      if milestone_exists "$ms"; then
+        warn "Milestone already exists after create attempt: $ms"
+      else
+        die "Failed to create milestone: $ms"
+      fi
+    fi
   fi
 done
 
@@ -92,25 +191,105 @@ project_number="$(gh project list --owner "$OWNER" --limit 100 --format json --j
 if [[ -z "${project_number:-}" ]]; then
   gh project create --owner "$OWNER" --title "$PROJECT_TITLE" >/dev/null
   project_number="$(gh project list --owner "$OWNER" --limit 100 --format json --jq ".projects[] | select(.title == \"$PROJECT_TITLE\") | .number" | head -n1)"
-  echo "Created project: $PROJECT_TITLE (#$project_number)"
+  info "Created project: $PROJECT_TITLE (#$project_number)"
 else
-  echo "Project exists: $PROJECT_TITLE (#$project_number)"
+  info "Project exists: $PROJECT_TITLE (#$project_number)"
 fi
 
-gh project link "$project_number" --owner "$OWNER" --repo "$REPO" >/dev/null || true
+if gh project link "$project_number" --owner "$OWNER" --repo "$REPO" >/dev/null 2>&1; then
+  info "Linked project #$project_number to repo: $REPO"
+else
+  warn "Could not link project #$project_number to $REPO (may already be linked or missing permissions)"
+fi
 
 # Best-effort field creation (safe if command unavailable on older gh versions)
+fetch_project_fields() {
+  gh project field-list "$project_number" --owner "$OWNER" --format json --jq '.fields[]?.name'
+}
+
+ensure_project_field() {
+  local field_name="${1}"
+  local field_options="${2}"
+
+  if grep -Fxq "$field_name" <<<"$PROJECT_FIELDS"; then
+    return 0
+  fi
+
+  if gh project field-create "$project_number" --owner "$OWNER" --name "$field_name" --data-type "SINGLE_SELECT" --single-select-options "$field_options" >/dev/null 2>&1; then
+    info "Created project field: $field_name"
+    PROJECT_FIELDS+=$'\n'"$field_name"
+    return 0
+  fi
+
+  PROJECT_FIELDS="$(fetch_project_fields || true)"
+  if grep -Fxq "$field_name" <<<"$PROJECT_FIELDS"; then
+    warn "Project field already exists after create attempt: $field_name"
+  else
+    warn "Failed to create project field '$field_name'. Configure it manually."
+  fi
+}
+
+sync_release_field_options() {
+  local release_field_id
+  local release_mutation
+  local current_release next_patch next_minor next_major
+  current_release="${RELEASE_MILESTONES[0]}"
+  next_patch="${RELEASE_MILESTONES[1]}"
+  next_minor="${RELEASE_MILESTONES[2]}"
+  next_major="${RELEASE_MILESTONES[3]}"
+  release_field_id="$(
+    gh project field-list "$project_number" --owner "$OWNER" --format json --jq '.fields[] | select(.name == "Release") | .id' | head -n1
+  )"
+
+  if [[ -z "${release_field_id}" ]]; then
+    warn "Release field not found; skipping Release option sync."
+    return 0
+  fi
+
+  release_mutation="$(cat <<'GRAPHQL'
+mutation($fieldId:ID!){
+  updateProjectV2Field(input:{
+    fieldId:$fieldId,
+    name:"Release",
+    singleSelectOptions:[
+      {name:"__CURRENT__",description:"Current release",color:GRAY},
+      {name:"__PATCH__",description:"Patch release",color:BLUE},
+      {name:"__MINOR__",description:"Minor release",color:YELLOW},
+      {name:"__MAJOR__",description:"Major release",color:RED}
+    ]
+  }){
+    projectV2Field{
+      ... on ProjectV2SingleSelectField{
+        id
+        name
+        options{ id name }
+      }
+    }
+  }
+}
+GRAPHQL
+)"
+  release_mutation="${release_mutation//__CURRENT__/${current_release}}"
+  release_mutation="${release_mutation//__PATCH__/${next_patch}}"
+  release_mutation="${release_mutation//__MINOR__/${next_minor}}"
+  release_mutation="${release_mutation//__MAJOR__/${next_major}}"
+
+  if gh api graphql -f query="$release_mutation" -f fieldId="$release_field_id" >/dev/null 2>&1; then
+    info "Synced Release field options: $(IFS=', '; echo "${RELEASE_MILESTONES[*]}")"
+  else
+    warn "Failed to sync Release field options automatically. Update via project UI if needed."
+  fi
+}
+
 if gh project field-list "$project_number" --owner "$OWNER" >/dev/null 2>&1; then
-  if ! gh project field-list "$project_number" --owner "$OWNER" --format json --jq '.fields[]?.name' | grep -Fxq "Priority"; then
-    gh project field-create "$project_number" --owner "$OWNER" --name "Priority" --data-type "SINGLE_SELECT" --single-select-options "P0,P1,P2" >/dev/null || true
-  fi
-  if ! gh project field-list "$project_number" --owner "$OWNER" --format json --jq '.fields[]?.name' | grep -Fxq "Area"; then
-    gh project field-create "$project_number" --owner "$OWNER" --name "Area" --data-type "SINGLE_SELECT" --single-select-options "backend,frontend,hardware,infra,database,auth,logging,unknown" >/dev/null || true
-  fi
-  if ! gh project field-list "$project_number" --owner "$OWNER" --format json --jq '.fields[]?.name' | grep -Fxq "Release"; then
-    gh project field-create "$project_number" --owner "$OWNER" --name "Release" --data-type "SINGLE_SELECT" --single-select-options "v0.6,v0.7,v1.0" >/dev/null || true
-  fi
+  PROJECT_FIELDS="$(fetch_project_fields || true)"
+  ensure_project_field "Priority" "P0,P1,P2"
+  ensure_project_field "Area" "backend,frontend,hardware,infra,database,auth,logging,unknown"
+  ensure_project_field "Release" "$(IFS=,; echo "${RELEASE_MILESTONES[*]}")"
+  sync_release_field_options
+else
+  warn "Skipping field creation; gh project field-list is unavailable in this environment."
 fi
 
-echo "Done."
-echo "Next: apply manual UI checklist in docs/WORKFLOW.md for board columns, saved views, and auto-add workflow."
+info "Done."
+info "Next: apply manual UI checklist in docs/WORKFLOW.md for board columns, saved views, and auto-add workflow."

--- a/scripts/github/sync-release-tracks.sh
+++ b/scripts/github/sync-release-tracks.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Synchronize Sentinel release tracks across:
+# 1) GitHub Project "Release" single-select options
+# 2) Repository milestones
+#
+# Inputs:
+# - arg1: owner/repo (optional; defaults to current gh repo)
+# - env CURRENT_RELEASE_VERSION: X.Y.Z or vX.Y.Z (optional; defaults to package.json version)
+# - env PROJECT_NUMBER: GitHub project number (default: 3)
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
+CURRENT_RELEASE_VERSION="${CURRENT_RELEASE_VERSION:-}"
+PROJECT_NUMBER="${PROJECT_NUMBER:-3}"
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing dependency: $1" >&2
+    exit 1
+  }
+}
+
+die() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+info() {
+  echo "$*"
+}
+
+require gh
+require jq
+
+if [[ -z "${REPO_ROOT}" ]]; then
+  REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+fi
+cd "$REPO_ROOT"
+
+if ! gh auth status >/dev/null 2>&1; then
+  die "GitHub CLI is not authenticated. Run: gh auth login"
+fi
+
+REPO="${1:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
+OWNER="${REPO%%/*}"
+
+resolve_version() {
+  local value="${CURRENT_RELEASE_VERSION}"
+  if [[ -z "${value}" ]]; then
+    value="$(jq -r '.version' "${REPO_ROOT}/package.json" 2>/dev/null || true)"
+  fi
+  value="${value#v}"
+  if [[ ! "${value}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    die "Current release must be SemVer X.Y.Z; got: ${value:-<empty>}"
+  fi
+  printf '%s\n' "${value}"
+}
+
+build_release_tracks() {
+  local semver="${1}"
+  local major minor patch
+  IFS='.' read -r major minor patch <<<"${semver}"
+  printf 'v%s.%s.%s\n' "${major}" "${minor}" "${patch}"
+  printf 'v%s.%s.%s\n' "${major}" "${minor}" "$((patch + 1))"
+  printf 'v%s.%s.0\n' "${major}" "$((minor + 1))"
+  printf 'v%s.0.0\n' "$((major + 1))"
+}
+
+CURRENT_SEMVER="$(resolve_version)"
+mapfile -t RELEASE_TRACKS < <(build_release_tracks "${CURRENT_SEMVER}")
+CURRENT_RELEASE="${RELEASE_TRACKS[0]}"
+PATCH_RELEASE="${RELEASE_TRACKS[1]}"
+MINOR_RELEASE="${RELEASE_TRACKS[2]}"
+MAJOR_RELEASE="${RELEASE_TRACKS[3]}"
+
+info "Repo: ${REPO}"
+info "Project number: ${PROJECT_NUMBER}"
+info "Release tracks: $(IFS=', '; echo "${RELEASE_TRACKS[*]}")"
+
+fetch_milestones() {
+  gh api --paginate "repos/${REPO}/milestones?state=all&per_page=100" --jq '.[].title'
+}
+
+MILESTONES="$(fetch_milestones)"
+for milestone in "${RELEASE_TRACKS[@]}"; do
+  if grep -Fxq "${milestone}" <<<"${MILESTONES}"; then
+    info "Milestone exists: ${milestone}"
+  else
+    gh api --method POST "repos/${REPO}/milestones" -f title="${milestone}" >/dev/null
+    info "Created milestone: ${milestone}"
+    MILESTONES+=$'\n'"${milestone}"
+  fi
+done
+
+RELEASE_FIELD_ID="$(
+  gh project field-list "${PROJECT_NUMBER}" --owner "${OWNER}" --format json --jq '.fields[] | select(.name == "Release") | .id' | head -n1
+)"
+
+if [[ -z "${RELEASE_FIELD_ID}" ]]; then
+  gh project field-create "${PROJECT_NUMBER}" --owner "${OWNER}" --name "Release" --data-type "SINGLE_SELECT" --single-select-options "$(IFS=,; echo "${RELEASE_TRACKS[*]}")" >/dev/null
+  RELEASE_FIELD_ID="$(
+    gh project field-list "${PROJECT_NUMBER}" --owner "${OWNER}" --format json --jq '.fields[] | select(.name == "Release") | .id' | head -n1
+  )"
+fi
+
+[[ -n "${RELEASE_FIELD_ID}" ]] || die "Release field not found and could not be created."
+
+RELEASE_MUTATION="$(cat <<GRAPHQL
+mutation(\$fieldId:ID!){
+  updateProjectV2Field(input:{
+    fieldId:\$fieldId,
+    name:"Release",
+    singleSelectOptions:[
+      {name:"${CURRENT_RELEASE}",description:"Current release",color:GRAY},
+      {name:"${PATCH_RELEASE}",description:"Patch release",color:BLUE},
+      {name:"${MINOR_RELEASE}",description:"Minor release",color:YELLOW},
+      {name:"${MAJOR_RELEASE}",description:"Major release",color:RED}
+    ]
+  }){
+    projectV2Field{
+      ... on ProjectV2SingleSelectField{
+        id
+        name
+        options{
+          id
+          name
+        }
+      }
+    }
+  }
+}
+GRAPHQL
+)"
+
+gh api graphql -f query="${RELEASE_MUTATION}" -f fieldId="${RELEASE_FIELD_ID}" >/dev/null
+info "Synced project Release options."
+info "Done."


### PR DESCRIPTION
## Summary
This PR implements Sentinel's GitHub issue operations foundation for solo workflow execution from Codex, with strict template-backed intake and release alignment automation.

## What Changed
- Added new GitHub issue templates:
  - `.github/ISSUE_TEMPLATE/task.yml`
  - `.github/ISSUE_TEMPLATE/refactor.yml`
- Added repo-scoped Codex skills:
  - `.codex/skills/sentinel-github-issue-intake`
  - `.codex/skills/sentinel-github-issue-flow`
- Added deterministic helper scripts for:
  - template requirement extraction
  - issue creation with confirm-before-mutate
  - project field updates
  - transition orchestration + working-load checks
  - milestone/release alignment
- Added release track automation:
  - `scripts/github/sync-release-tracks.sh`
  - `.github/workflows/sync-release-tracks.yml`
  - `.github/workflows/align-release-milestone.yml`
- Updated setup scripts and workflow guide:
  - `scripts/github/setup-solo-workflow.sh`
  - `scripts/github/setup-solo-workflow.ps1`
  - `docs/WORKFLOW.md`

## Behavior Guarantees
- Template-first strict enforcement for `bug|feature|task|refactor`.
- Confirm-before-mutate by default in skill scripts.
- "One Working issue" policy remains warn-only (not hard block).
- Milestone/Release alignment is automated and repairable.

## Validation Performed
- `bash -n` on all new skill scripts
- `shellcheck` on all new skill scripts
- Dry-run smoke checks for:
  - template extraction (`bug|feature|task|refactor`)
  - intake preview + required-field enforcement
  - transition script help/entrypoint behavior

## Ops Notes
- Requires repo secret `PROJECTS_TOKEN` for workflow automation (`project`, `read:project`, and issue write access).
- Uses project number from `SENTINEL_PROJECT_NUMBER` repo var when set, else defaults to `3`.
