### PR TITLE
fix(workflow): resolve project owner for release sync automation

### DIFF
--- a/.github/workflows/align-release-milestone.yml
+++ b/.github/workflows/align-release-milestone.yml
@@ -27,6 +27,7 @@ jobs:
       INPUT_ISSUE_NUMBER: ${{ github.event.inputs.issue_number }}
       INPUT_PROJECT_NUMBER: ${{ github.event.inputs.project_number }}
       DEFAULT_PROJECT_NUMBER: ${{ vars.SENTINEL_PROJECT_NUMBER }}
+      DEFAULT_PROJECT_OWNER: ${{ vars.SENTINEL_PROJECT_OWNER }}
 
     steps:
       - name: Validate token
@@ -42,6 +43,10 @@ jobs:
           github-token: ${{ secrets.PROJECTS_TOKEN }}
           script: |
             const owner = context.repo.owner
+            const normalizedRepoOwner = owner.toLowerCase()
+            const configuredProjectOwner = process.env.DEFAULT_PROJECT_OWNER
+              ? process.env.DEFAULT_PROJECT_OWNER.toLowerCase()
+              : normalizedRepoOwner
             const repo = context.repo.repo
             const fallbackProjectNumber = Number(process.env.DEFAULT_PROJECT_NUMBER || 3)
             const projectNumber = Number(process.env.INPUT_PROJECT_NUMBER || fallbackProjectNumber)
@@ -108,11 +113,12 @@ jobs:
             const matchingItem = (issue.projectItems?.nodes ?? []).find((node) => {
               const project = node.project
               if (!project || project.__typename !== 'ProjectV2') return false
-              return Number(project.number) === projectNumber && project.owner?.login === owner
+              const itemOwner = project.owner?.login?.toLowerCase()
+              return Number(project.number) === projectNumber && itemOwner === configuredProjectOwner
             })
 
             if (!matchingItem) {
-              core.info(`Issue #${issueNumber} is not in project #${projectNumber}; nothing to align.`)
+              core.info(`Issue #${issueNumber} is not in project #${projectNumber} (owner: ${configuredProjectOwner}); nothing to align.`)
               return
             }
 

--- a/.github/workflows/sync-release-tracks.yml
+++ b/.github/workflows/sync-release-tracks.yml
@@ -37,6 +37,7 @@ jobs:
       INPUT_REPOSITORY: ${{ github.event.inputs.repository }}
       DEFAULT_REPOSITORY: ${{ github.repository }}
       SENTINEL_PROJECT_NUMBER: ${{ vars.SENTINEL_PROJECT_NUMBER }}
+      SENTINEL_PROJECT_OWNER: ${{ vars.SENTINEL_PROJECT_OWNER }}
       PROJECTS_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
 
     steps:
@@ -63,6 +64,9 @@ jobs:
             export PROJECT_NUMBER="${SENTINEL_PROJECT_NUMBER}"
           else
             export PROJECT_NUMBER="3"
+          fi
+          if [[ -n "${SENTINEL_PROJECT_OWNER}" ]]; then
+            export PROJECT_OWNER="${SENTINEL_PROJECT_OWNER}"
           fi
 
           if [[ -n "${INPUT_CURRENT_VERSION}" ]]; then

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -101,6 +101,10 @@ Required secret:
 
 - `PROJECTS_TOKEN` with scopes: `project`, `read:project` (and repo issue write access for alignment updates).
 
+Optional repo variable:
+
+- `SENTINEL_PROJECT_OWNER` if your project owner differs from repository owner casing/login resolution. Example: `deadshotomega`.
+
 ### Option D: Codex issue-ops skills (VS Code)
 
 Repo-scoped skills:


### PR DESCRIPTION
## Summary\nFixes workflow failures like `unknown owner type` during release-track sync by making project owner resolution robust in scripts and Actions.\n\n## Changes\n- Add project owner resolution/fallback in `scripts/github/sync-release-tracks.sh`\n- Normalize project owner handling in setup scripts (bash + powershell)\n- Support optional repo variable `SENTINEL_PROJECT_OWNER` in workflows\n- Make align workflow owner matching case-insensitive and owner-configurable\n- Document optional `SENTINEL_PROJECT_OWNER` in `docs/WORKFLOW.md`\n\n## Validation\n- `bash -n` + `shellcheck` on updated bash scripts\n- Local run succeeded:\n  - `CURRENT_RELEASE_VERSION=1.3.0 PROJECT_NUMBER=3 bash scripts/github/sync-release-tracks.sh DeadshotOMEGA/sentinel`\n\n## Ops note\nIf project-owner resolution is still ambiguous in your environment, set repo variable:\n- `SENTINEL_PROJECT_OWNER=deadshotomega`