### PR TITLE
fix(workflow): allow explicit project owner override in sync job

### DIFF
--- a/.github/workflows/sync-release-tracks.yml
+++ b/.github/workflows/sync-release-tracks.yml
@@ -21,6 +21,10 @@ on:
         description: 'owner/repo target (defaults to current repository).'
         required: false
         type: string
+      project_owner:
+        description: 'Project owner login override (defaults to repo var SENTINEL_PROJECT_OWNER or repo owner).'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -35,6 +39,7 @@ jobs:
       INPUT_CURRENT_VERSION: ${{ github.event.inputs.current_version }}
       INPUT_PROJECT_NUMBER: ${{ github.event.inputs.project_number }}
       INPUT_REPOSITORY: ${{ github.event.inputs.repository }}
+      INPUT_PROJECT_OWNER: ${{ github.event.inputs.project_owner }}
       DEFAULT_REPOSITORY: ${{ github.repository }}
       SENTINEL_PROJECT_NUMBER: ${{ vars.SENTINEL_PROJECT_NUMBER }}
       SENTINEL_PROJECT_OWNER: ${{ vars.SENTINEL_PROJECT_OWNER }}
@@ -65,7 +70,9 @@ jobs:
           else
             export PROJECT_NUMBER="3"
           fi
-          if [[ -n "${SENTINEL_PROJECT_OWNER}" ]]; then
+          if [[ -n "${INPUT_PROJECT_OWNER}" ]]; then
+            export PROJECT_OWNER="${INPUT_PROJECT_OWNER}"
+          elif [[ -n "${SENTINEL_PROJECT_OWNER}" ]]; then
             export PROJECT_OWNER="${SENTINEL_PROJECT_OWNER}"
           fi
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -105,6 +105,10 @@ Optional repo variable:
 
 - `SENTINEL_PROJECT_OWNER` if your project owner differs from repository owner casing/login resolution. Example: `deadshotomega`.
 
+Workflow dispatch override:
+
+- `project_owner` input can be set at run time for one-off owner overrides.
+
 ### Option D: Codex issue-ops skills (VS Code)
 
 Repo-scoped skills:

--- a/scripts/github/sync-release-tracks.sh
+++ b/scripts/github/sync-release-tracks.sh
@@ -87,20 +87,19 @@ resolve_project_owner() {
   local configured_owner="${PROJECT_OWNER}"
 
   if [[ -n "${configured_owner}" ]]; then
-    if gh project view "${PROJECT_NUMBER}" --owner "${configured_owner}" --format json >/dev/null 2>&1; then
-      RESOLVED_PROJECT_OWNER="${configured_owner}"
-      return 0
-    fi
+    # Trust explicit owner override to avoid gh project view owner-type false negatives in CI.
+    RESOLVED_PROJECT_OWNER="${configured_owner}"
+    return 0
   fi
 
   for candidate in "${OWNER,,}" "${OWNER}" "@me"; do
-    if gh project view "${PROJECT_NUMBER}" --owner "${candidate}" --format json >/dev/null 2>&1; then
+    if gh project field-list "${PROJECT_NUMBER}" --owner "${candidate}" --format json >/dev/null 2>&1; then
       RESOLVED_PROJECT_OWNER="${candidate}"
       return 0
     fi
   done
 
-  die "Unable to resolve project owner for project #${PROJECT_NUMBER}. Set PROJECT_OWNER (or repo variable SENTINEL_PROJECT_OWNER) and verify PROJECTS_TOKEN scopes."
+  die "Unable to resolve project owner for project #${PROJECT_NUMBER}. Set PROJECT_OWNER (or SENTINEL_PROJECT_OWNER) and verify PROJECTS_TOKEN scopes/SSO."
 }
 
 fetch_milestones() {


### PR DESCRIPTION
## Summary
Fixes persistent sync workflow failures where owner resolution aborted before project field sync in GitHub Actions.

## Changes
- Trust explicit `PROJECT_OWNER` override in `scripts/github/sync-release-tracks.sh`.
- Resolve fallback owners using `gh project field-list` instead of `gh project view`.
- Add `workflow_dispatch` input `project_owner` to `.github/workflows/sync-release-tracks.yml`.
- Wire owner precedence: `project_owner` input -> `SENTINEL_PROJECT_OWNER` repo variable.
- Document one-off `project_owner` override in `docs/WORKFLOW.md`.

## Validation
- `bash -n scripts/github/sync-release-tracks.sh`
- `shellcheck scripts/github/sync-release-tracks.sh`
- Local run succeeded with explicit owner:
  - `CURRENT_RELEASE_VERSION=1.3.0 PROJECT_NUMBER=3 PROJECT_OWNER=deadshotomega bash scripts/github/sync-release-tracks.sh DeadshotOMEGA/sentinel`
