### PR TITLE
chore(deploy): remove NetBird from appliance deployment

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -8,6 +8,8 @@ GHCR_OWNER=deadshotomega
 APP_PUBLIC_URL=http://sentinel.local
 # Public HTTP bind port for Caddy (v1 default: 80)
 APP_HTTP_PORT=80
+# Public HTTPS bind port for Caddy
+APP_HTTPS_PORT=443
 # If you browse by IP, include that IP origin as well (example: http://192.168.1.50)
 CORS_ORIGIN=http://sentinel.local,http://localhost,http://127.0.0.1
 
@@ -64,13 +66,6 @@ GRAFANA_ADMIN_PASSWORD=change-this-grafana-password
 # Used only with --allow-grafana-lan; host port mapping defaults to 3010->3000
 GRAFANA_LAN_PORT=3010
 GRAFANA_ROOT_URL=http://localhost:3010
-
-# NetBird (self-hosted) defaults
-NETBIRD_DOMAIN=netbird.local
-NETBIRD_PROTOCOL=http
-NETBIRD_HTTP_PORT=80
-NETBIRD_AUTH_SECRET=change-this-netbird-auth-secret
-NETBIRD_ENCRYPTION_KEY=change-this-netbird-encryption-key
 
 # Wiki.js routing defaults
 WIKI_DOMAIN=docs.sentinel.local

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -43,26 +43,3 @@ http://{$WIKI_DOMAIN} {
 		}
 	}
 }
-
-http://{$NETBIRD_DOMAIN} {
-	# Relay (WebSocket)
-	reverse_proxy /relay* netbird-server:80
-
-	# WebSocket proxy
-	reverse_proxy /ws-proxy/* netbird-server:80
-
-	# Signal gRPC (h2c for plaintext HTTP/2)
-	reverse_proxy /signalexchange.SignalExchange/* h2c://netbird-server:80
-
-	# Management API
-	reverse_proxy /api/* netbird-server:80
-
-	# Management gRPC
-	reverse_proxy /management.ManagementService/* h2c://netbird-server:80
-
-	# Embedded IdP OAuth2
-	reverse_proxy /oauth2/* netbird-server:80
-
-	# Dashboard (catch-all)
-	reverse_proxy /* netbird-dashboard:80
-}

--- a/deploy/README_DEPLOY.md
+++ b/deploy/README_DEPLOY.md
@@ -4,12 +4,11 @@ This bundle installs Sentinel as a LAN appliance using Docker Compose v2 and GHC
 
 ## What gets deployed
 
-- Caddy reverse proxy on `80:80` (only published service)
+- Caddy reverse proxy on `80:80` + `443:443`
 - Backend API on internal Docker network (`3000`)
 - Frontend Next runtime on internal Docker network (`3001`)
 - PostgreSQL with persistent volume
 - Wiki.js + dedicated Wiki PostgreSQL on internal Docker network
-- NetBird server + dashboard (self-hosted) with STUN on `3478/udp`
 - Optional observability profile (`obs`): Loki, Prometheus, Promtail, Grafana
 
 Canonical public routes:
@@ -19,7 +18,6 @@ Canonical public routes:
 - `/socket.io*` -> backend (path preserved)
 - `/healthz` -> backend `/health`
 - `http://docs.sentinel.local/*` -> Wiki.js
-- `http://netbird.local/*` -> NetBird (dashboard + API)
 
 ## Debian package launcher (recommended for non-technical users)
 
@@ -100,9 +98,7 @@ Optional flags:
 Port defaults in `.env`:
 
 - `APP_HTTP_PORT=80` (Caddy appliance entrypoint)
-- `NETBIRD_DOMAIN=netbird.local`
-- `NETBIRD_PROTOCOL=http`
-- `NETBIRD_HTTP_PORT=80`
+- `APP_HTTPS_PORT=443` (Caddy HTTPS bind port)
 - `GRAFANA_LAN_PORT=3010` (only used if `--allow-grafana-lan`)
 - `GRAFANA_ROOT_URL=http://localhost:3010` (matches Grafana LAN port when enabled)
 - `WIKI_DOMAIN=docs.sentinel.local`
@@ -234,11 +230,8 @@ sudo systemctl restart sentinel-appliance.service
 
 - mDNS (best effort): `http://sentinel.local`
 - Wiki docs host: `http://docs.sentinel.local`
-- NetBird dashboard: `http://netbird.local`
 - LAN fallback: `http://<server-ip>`
 - Optional direct Wiki LAN URL (if enabled): `http://<server-ip>:3020`
-
-For NetBird, ensure `netbird.local` resolves to the appliance IP (use your LAN DNS or add a hosts entry on each client).
 
 ## Health check
 
@@ -250,7 +243,6 @@ curl -f http://127.0.0.1/healthz
 
 - Compose v2 is required (`docker compose`).
 - `SENTINEL_VERSION` must be explicit (never `latest`).
-- NetBird STUN listens on `3478/udp`; ensure LAN clients can reach it.
 - Installer auto-runs:
   - `sudo systemctl daemon-reload`
   - `sudo systemctl enable sentinel-appliance.service`

--- a/deploy/_common.sh
+++ b/deploy/_common.sh
@@ -226,18 +226,6 @@ bootstrap_env_defaults() {
     fi
   done
 
-  if is_placeholder_env_value "$(env_value NETBIRD_AUTH_SECRET)"; then
-    generated_value="$(generate_random_secret 40)"
-    upsert_env "NETBIRD_AUTH_SECRET" "${generated_value}"
-    generated_count=$((generated_count + 1))
-  fi
-
-  if is_placeholder_env_value "$(env_value NETBIRD_ENCRYPTION_KEY)"; then
-    generated_value="$(generate_random_secret 32)"
-    upsert_env "NETBIRD_ENCRYPTION_KEY" "${generated_value}"
-    generated_count=$((generated_count + 1))
-  fi
-
   if is_placeholder_env_value "$(env_value GHCR_OWNER)"; then
     upsert_env "GHCR_OWNER" "deadshotomega"
   fi
@@ -246,8 +234,8 @@ bootstrap_env_defaults() {
     upsert_env "APP_PUBLIC_URL" "http://sentinel.local"
   fi
 
-  if is_placeholder_env_value "$(env_value NETBIRD_DOMAIN)"; then
-    upsert_env "NETBIRD_DOMAIN" "netbird.local"
+  if is_placeholder_env_value "$(env_value APP_HTTPS_PORT)"; then
+    upsert_env "APP_HTTPS_PORT" "443"
   fi
 
   if is_placeholder_env_value "$(env_value WIKI_DOMAIN)"; then
@@ -276,14 +264,6 @@ bootstrap_env_defaults() {
 
   if is_placeholder_env_value "$(env_value WIKI_LAN_PORT)"; then
     upsert_env "WIKI_LAN_PORT" "3020"
-  fi
-
-  if is_placeholder_env_value "$(env_value NETBIRD_PROTOCOL)"; then
-    upsert_env "NETBIRD_PROTOCOL" "http"
-  fi
-
-  if is_placeholder_env_value "$(env_value NETBIRD_HTTP_PORT)"; then
-    upsert_env "NETBIRD_HTTP_PORT" "80"
   fi
 
   if [[ "${generated_count}" -gt 0 ]]; then
@@ -315,8 +295,6 @@ SWAGGER_USERNAME=$(env_value SWAGGER_USERNAME admin)
 SWAGGER_PASSWORD=$(env_value SWAGGER_PASSWORD)
 GRAFANA_ADMIN_USER=$(env_value GRAFANA_ADMIN_USER admin)
 GRAFANA_ADMIN_PASSWORD=$(env_value GRAFANA_ADMIN_PASSWORD)
-NETBIRD_AUTH_SECRET=$(env_value NETBIRD_AUTH_SECRET)
-NETBIRD_ENCRYPTION_KEY=$(env_value NETBIRD_ENCRYPTION_KEY)
 SNAPSHOT
 
   run_root install -d -m 700 "${credentials_dir}"
@@ -324,75 +302,6 @@ SNAPSHOT
   rm -f "${tmp_file}"
 
   log "Service credential snapshot saved to ${credentials_file} (root-only)."
-}
-
-ensure_netbird_config() {
-  local config_dir="${DEPLOY_DIR}/netbird"
-  local config_file="${config_dir}/config.yaml"
-  local dashboard_env="${config_dir}/dashboard.env"
-
-  if [[ -f "${config_file}" && -f "${dashboard_env}" ]]; then
-    return 0
-  fi
-
-  local domain protocol port auth_secret encryption_key exposed_address issuer
-  domain="$(env_value NETBIRD_DOMAIN netbird.local)"
-  protocol="$(env_value NETBIRD_PROTOCOL http)"
-  port="$(env_value NETBIRD_HTTP_PORT 80)"
-  auth_secret="$(env_value NETBIRD_AUTH_SECRET)"
-  encryption_key="$(env_value NETBIRD_ENCRYPTION_KEY)"
-
-  if [[ -z "${auth_secret}" || -z "${encryption_key}" ]]; then
-    die "NETBIRD_AUTH_SECRET and NETBIRD_ENCRYPTION_KEY must be set before generating NetBird config."
-  fi
-
-  exposed_address="${protocol}://${domain}:${port}"
-  issuer="${protocol}://${domain}:${port}/oauth2"
-
-  mkdir -p "${config_dir}"
-  if [[ ! -f "${config_file}" ]]; then
-    cat >"${config_file}" <<YAML
-server:
-  listenAddress: ":80"
-  exposedAddress: "${exposed_address}"
-  stunPorts:
-    - 3478
-  metricsPort: 9090
-  healthcheckAddress: ":9000"
-  logLevel: "info"
-  logFile: "console"
-
-  authSecret: "${auth_secret}"
-  dataDir: "/var/lib/netbird"
-
-  auth:
-    issuer: "${issuer}"
-    signKeyRefreshEnabled: true
-    dashboardRedirectURIs:
-      - "${protocol}://${domain}:${port}/nb-auth"
-      - "${protocol}://${domain}:${port}/nb-silent-auth"
-    cliRedirectURIs:
-      - "http://localhost:53000/"
-
-  store:
-    engine: "sqlite"
-    dsn: ""
-    encryptionKey: "${encryption_key}"
-YAML
-    log "Generated NetBird config at ${config_file}."
-  fi
-
-  if [[ ! -f "${dashboard_env}" ]]; then
-    cat >"${dashboard_env}" <<ENV
-# Endpoints
-NETBIRD_MGMT_API_ENDPOINT=${exposed_address}
-NETBIRD_MGMT_GRPC_API_ENDPOINT=${exposed_address}
-
-# SSL - disabled when behind reverse proxy
-LETSENCRYPT_DOMAIN=none
-ENV
-    log "Generated NetBird dashboard config at ${dashboard_env}."
-  fi
 }
 
 upsert_env() {
@@ -682,6 +591,7 @@ configure_firewall() {
   run_root ufw default deny incoming
   run_root ufw default allow outgoing
   run_root ufw allow from "${cidr}" to any port 80 proto tcp >/dev/null || true
+  run_root ufw allow from "${cidr}" to any port 443 proto tcp >/dev/null || true
   local grafana_lan_port
   grafana_lan_port="$(env_value GRAFANA_LAN_PORT 3010)"
   run_root ufw --force delete allow from "${cidr}" to any port "${grafana_lan_port}" proto tcp >/dev/null || true
@@ -698,13 +608,8 @@ configure_firewall() {
     run_root ufw allow from "${cidr}" to any port "${wiki_lan_port}" proto tcp >/dev/null || true
     run_root ufw deny in to any port "${wiki_lan_port}" proto tcp >/dev/null || true
   fi
-  local netbird_http_port
-  netbird_http_port="$(env_value NETBIRD_HTTP_PORT 80)"
-  if [[ "${netbird_http_port}" != "80" ]]; then
-    run_root ufw allow from "${cidr}" to any port "${netbird_http_port}" proto tcp >/dev/null || true
-  fi
-  run_root ufw allow from "${cidr}" to any port 3478 proto udp >/dev/null || true
   run_root ufw deny in to any port 80 proto tcp >/dev/null || true
+  run_root ufw deny in to any port 443 proto tcp >/dev/null || true
   run_root ufw --force enable >/dev/null
 
   local firewall_extras=""
@@ -715,7 +620,7 @@ configure_firewall() {
     firewall_extras+=", optional Wiki LAN"
   fi
 
-  log "UFW inbound policy applied: allow ${cidr} -> tcp/80, udp/3478${firewall_extras}"
+  log "UFW inbound policy applied: allow ${cidr} -> tcp/80,tcp/443${firewall_extras}"
 }
 
 ensure_compose_pull_with_login_fallback() {
@@ -730,7 +635,7 @@ ensure_compose_pull_with_login_fallback() {
 
 print_health_diagnostics() {
   compose ps || true
-  compose logs --tail=80 caddy backend frontend postgres wikijs-postgres wikijs netbird-server netbird-dashboard || true
+  compose logs --tail=80 caddy backend frontend postgres wikijs-postgres wikijs || true
 }
 
 env_value() {

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -155,12 +155,12 @@ services:
         condition: service_healthy
     ports:
       - '${APP_HTTP_PORT:-80}:80'
+      - '${APP_HTTPS_PORT:-443}:443'
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
       - caddy_config:/config
     environment:
-      NETBIRD_DOMAIN: ${NETBIRD_DOMAIN:-netbird.local}
       WIKI_DOMAIN: ${WIKI_DOMAIN:-docs.sentinel.local}
     healthcheck:
       test: ['CMD-SHELL', 'wget --no-verbose --tries=1 --spider http://127.0.0.1/healthz || exit 1']
@@ -237,30 +237,6 @@ services:
     networks:
       - sentinel_net
 
-  netbird-server:
-    image: netbirdio/netbird-server:latest
-    container_name: sentinel-netbird-server
-    restart: unless-stopped
-    command: ['--config', '/etc/netbird/config.yaml']
-    volumes:
-      - ./netbird/config.yaml:/etc/netbird/config.yaml:ro
-      - netbird_data:/var/lib/netbird
-    ports:
-      - '3478:3478/udp'
-    networks:
-      - sentinel_net
-
-  netbird-dashboard:
-    image: netbirdio/dashboard:latest
-    container_name: sentinel-netbird-dashboard
-    restart: unless-stopped
-    depends_on:
-      - netbird-server
-    env_file:
-      - ./netbird/dashboard.env
-    networks:
-      - sentinel_net
-
 volumes:
   postgres_data:
   wikijs_postgres_data:
@@ -270,7 +246,6 @@ volumes:
   loki_data:
   prometheus_data:
   grafana_data:
-  netbird_data:
 
 networks:
   sentinel_net:

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -156,7 +156,6 @@ fi
 
 ensure_env_file
 bootstrap_env_defaults
-ensure_netbird_config
 write_admin_credentials_snapshot
 
 if [[ -z "${TARGET_VERSION}" ]]; then

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -106,7 +106,6 @@ fi
 
 ensure_env_file
 bootstrap_env_defaults
-ensure_netbird_config
 write_admin_credentials_snapshot
 load_state
 


### PR DESCRIPTION
## Summary
This PR removes all NetBird deployment/runtime integration from Sentinel so the appliance stack is aligned with the move to Tailscale.

## Changes
- Removed NetBird services and volume from Docker Compose:
  - `netbird-server`
  - `netbird-dashboard`
  - `netbird_data`
- Removed NetBird reverse proxy routes from Caddy.
- Removed all `NETBIRD_*` environment defaults from deploy env template.
- Removed NetBird installer/update/bootstrap/config generation hooks.
- Removed NetBird firewall and diagnostics references.
- Updated deployment docs to remove NetBird routes, URLs, and operational notes.

## Files Updated
- `deploy/docker-compose.yml`
- `deploy/Caddyfile`
- `deploy/.env.example`
- `deploy/_common.sh`
- `deploy/install.sh`
- `deploy/update.sh`
- `deploy/README_DEPLOY.md`

## Validation
- `rg -n --hidden -g '!.git' 'netbird|NetBird|NETBIRD' .` returns no matches.
- `bash -n deploy/_common.sh deploy/install.sh deploy/update.sh` passes.
- `docker compose -f deploy/docker-compose.yml config` validates when required env vars are provided.

## Notes
GitHub Actions `Build` and `Test` are currently configured with:

- `paths-ignore: ['deploy/**', 'docs/**']`

Because this PR only modifies `deploy/**`, those workflows are skipped by design.
