### PR TITLE
docs(agents): define release branch workflow

### DIFF
--- a/.codex/skills/git-commit-push/SKILL.md
+++ b/.codex/skills/git-commit-push/SKILL.md
@@ -54,20 +54,26 @@ When splitting commits:
 
 ## Branch Policy (Git Flow)
 
-- Treat these as protected by default: `main`, `master`, `production`, `release/*`.
+- Treat these as protected by default: `main`, `master`, `production`.
 - Do not push directly to protected branches unless the user explicitly asks for a direct push.
+- Treat `release/*` as stabilization branches: avoid direct commits when possible and prefer PRs from `feature/*`/`fix/*` into `release/*`.
 - Allow normal push flow on working branches such as `rebuild`, `develop`, `feature/*`, `bugfix/*`, and `hotfix/*`.
 - If currently on a protected branch and direct push was not explicitly requested, stop and ask how to proceed.
 
 ```bash
 branch="$(git branch --show-current)"
 case "$branch" in
-  main|master|production|release/*)
+  main|master|production)
     echo "Protected branch detected: $branch. Ask for explicit direct-push approval."
     exit 1
     ;;
 esac
 ```
+
+Release branch note:
+
+- Use `release/vX.Y.Z` only for short-lived release coordination.
+- Merge release PRs into `release/vX.Y.Z`, then merge `release/vX.Y.Z` to `main`, then tag `vX.Y.Z`.
 
 ## Commit Signing Preference
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,19 @@ This file migrates project guidance from Claude-style rules into Codex.
 - Use Conventional Commits.
 - Never push directly to `main`; use PRs from `feature/*` to `main`.
 
+## Release Branch Policy
+
+- MUST keep `main` as the long-lived integration branch.
+- MUST NOT create long-lived `major/*` or `minor/*` lanes.
+- MAY create short-lived release stabilization branches named `release/vX.Y.Z` when a release needs batching or hardening.
+- MUST branch `release/vX.Y.Z` from the current `main`.
+- MUST target `release/vX.Y.Z` (not `main`) for PRs intended for that specific release while stabilization is active.
+- SHOULD keep release-branch PRs narrowly scoped to release readiness (fixes, docs, versioning, deploy scripts, tests).
+- MUST merge `release/vX.Y.Z` back to `main` through a PR before tagging.
+- MUST create and push tag `vX.Y.Z` from the merge result on `main`.
+- SHOULD delete `release/vX.Y.Z` after successful merge/tag to avoid branch drift.
+- MUST continue using `feature/*` (or `fix/*`/`hotfix/*`) as working branches; release branches are aggregation branches, not daily development branches.
+
 ## Port Allocation Policy (Host/LAN)
 
 - MUST keep Sentinel service host ports within their assigned ranges:


### PR DESCRIPTION
## Summary
- add a formal release branch policy to AGENTS.md
- define short-lived `release/vX.Y.Z` stabilization branch workflow
- align `git-commit-push` skill guidance with the new release branch policy

## Why
This ensures multi-PR releases (like v1.4.0) can be coordinated on a release branch without introducing long-lived major/minor branch drift.

## Validation
- docs/skill only changes
- pre-commit formatting hooks passed
