### PR TITLE
feat(workflow): add testing status between working and done

### DIFF
--- a/.codex/skills/sentinel-github-issue-flow/SKILL.md
+++ b/.codex/skills/sentinel-github-issue-flow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentinel-github-issue-flow
-description: Manage Sentinel issue lifecycle transitions (triage/planned/working/blocked/done) with release-milestone alignment and warn-only working-limit policy.
+description: Manage Sentinel issue lifecycle transitions (triage/planned/working/testing/blocked/done) with release-milestone alignment and warn-only working-limit policy.
 ---
 
 # Sentinel GitHub Issue Flow
@@ -8,7 +8,7 @@ description: Manage Sentinel issue lifecycle transitions (triage/planned/working
 ## Use This Skill When
 
 - A user asks to triage/reprioritize/release-align/update issue status.
-- A user asks to move an issue to planned, working, blocked, or done.
+- A user asks to move an issue to planned, working, testing, blocked, or done.
 - A user asks to repair milestone/release mismatch.
 
 ## Required Behavior
@@ -44,7 +44,7 @@ mkdir -p .codex/tmp
 {
   "repo": "DeadshotOMEGA/sentinel",
   "issueNumber": 123,
-  "targetState": "triage|planned|working|blocked|done",
+  "targetState": "triage|planned|working|testing|blocked|done",
   "warnOnlyWorkingLimit": true,
   "blockedLabel": "blocked:external|blocked:dependency|blocked:decision|null",
   "blockerNote": "string|null",

--- a/.codex/skills/sentinel-github-issue-flow/references/status-transition-matrix.md
+++ b/.codex/skills/sentinel-github-issue-flow/references/status-transition-matrix.md
@@ -21,6 +21,13 @@
 - Run working-load check and warn if another issue is already working.
 - Project status: `⚙️ Working`
 
+## testing
+
+- Set label: `status:testing`
+- Remove other status labels.
+- Keep milestone/release aligned for follow-up fixes in same release cycle.
+- Project status: `🧪 Testing`
+
 ## blocked
 
 - Set label: `status:blocked`

--- a/.codex/skills/sentinel-github-issue-flow/references/workflow-rules.md
+++ b/.codex/skills/sentinel-github-issue-flow/references/workflow-rules.md
@@ -7,6 +7,7 @@ Derived from `docs/WORKFLOW.md`.
 - `status:triage` -> issue is in Inbox.
 - `status:planned` -> issue is scoped and queued with release target.
 - `status:working` -> active implementation.
+- `status:testing` -> implementation is merged/in validation and may still need follow-up fixes.
 - `status:blocked` -> blocked by external dependency/decision and must include one `blocked:*` label.
 - `✅ Done` -> completion state in project field (issue may then be closed).
 

--- a/.codex/skills/sentinel-github-issue-flow/scripts/transition-issue.sh
+++ b/.codex/skills/sentinel-github-issue-flow/scripts/transition-issue.sh
@@ -108,7 +108,7 @@ fi
 [[ -n "${TARGET_STATE}" ]] || { echo "Payload.targetState is required" >&2; exit 1; }
 
 case "${TARGET_STATE}" in
-  triage|planned|working|blocked|done)
+  triage|planned|working|testing|blocked|done)
     ;;
   *)
     echo "Unsupported targetState: ${TARGET_STATE}" >&2
@@ -144,6 +144,10 @@ case "${TARGET_STATE}" in
   working)
     DESIRED_STATUS_LABEL="status:working"
     DESIRED_PROJECT_STATUS="⚙️ Working"
+    ;;
+  testing)
+    DESIRED_STATUS_LABEL="status:testing"
+    DESIRED_PROJECT_STATUS="🧪 Testing"
     ;;
   blocked)
     DESIRED_STATUS_LABEL="status:blocked"
@@ -238,7 +242,7 @@ fi
 STATUS_LABELS_TO_REMOVE=()
 for existing in "${CURRENT_LABELS[@]:-}"; do
   case "${existing}" in
-    status:triage|status:planned|status:working|status:blocked|status:done)
+    status:triage|status:planned|status:working|status:testing|status:blocked|status:done)
       if [[ -n "${DESIRED_STATUS_LABEL}" && "${existing}" == "${DESIRED_STATUS_LABEL}" ]]; then
         continue
       fi

--- a/.github/labels.solo-workflow.json
+++ b/.github/labels.solo-workflow.json
@@ -48,6 +48,11 @@
   { "name": "status:planned", "color": "c5def5", "description": "Status: accepted and queued" },
   { "name": "status:working", "color": "0e8a16", "description": "Status: currently in progress" },
   {
+    "name": "status:testing",
+    "color": "1d76db",
+    "description": "Status: in validation/testing before final completion"
+  },
+  {
     "name": "status:blocked",
     "color": "d876e3",
     "description": "Status: blocked by dependency/decision"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,6 +24,6 @@ jobs:
           stale-issue-label: bot:stale
           stale-issue-message: >-
             This issue has been inactive for 30 days. Remove `bot:stale` or comment with an update to keep it active.
-          exempt-issue-labels: status:working,priority:p0
+          exempt-issue-labels: status:working,status:testing,priority:p0
           remove-issue-stale-when-updated: true
           operations-per-run: 200

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -7,8 +7,9 @@ A lightweight workflow designed to keep bugs from disappearing while you continu
 1. **Every bug becomes an issue** (even tiny bugs).
 2. **Everything starts in 🧪 Inbox** (new issues always get `status:triage`).
 3. **Target one issue in ⚙️ Working at a time** (Codex automation is warn-only, not hard-blocking).
-4. If you task-switch: move current work back to 📌 Planned, pull the next item into ⚙️ Working.
-5. Use `needs-investigation` when root cause is unclear, flaky, or hardware behavior is intermittent.
+4. Move finished implementation to 🧪 Testing until validation is complete; only then mark ✅ Done.
+5. If you task-switch: move current work back to 📌 Planned, pull the next item into ⚙️ Working.
+6. Use `needs-investigation` when root cause is unclear, flaky, or hardware behavior is intermittent.
 
 ---
 
@@ -17,7 +18,7 @@ A lightweight workflow designed to keep bugs from disappearing while you continu
 - **Type**: `type:bug`, `type:feature`, `type:task`, `type:refactor`
 - **Area**: `area:backend`, `area:frontend`, `area:hardware`, `area:infra`, `area:database`, `area:auth`, `area:logging`
 - **Priority**: `priority:p0`, `priority:p1`, `priority:p2`
-- **Status**: `status:triage`, `status:planned`, `status:working`, `status:blocked`, `status:done`
+- **Status**: `status:triage`, `status:planned`, `status:working`, `status:testing`, `status:blocked`, `status:done`
 - **Blocked reason** (required with `status:blocked`): `blocked:external`, `blocked:dependency`, `blocked:decision`
 - **Special**: `needs-investigation`
 - **Bot-managed**: `bot:stale`, `bot:conflict`
@@ -169,6 +170,7 @@ Use this for project board details that are easier in UI.
    - `🧪 Inbox`
    - `📌 Planned`
    - `⚙️ Working`
+   - `🧪 Testing`
    - `🚧 Blocked`
    - `✅ Done`
 3. Add custom fields:
@@ -191,8 +193,9 @@ Use this for project board details that are easier in UI.
    - Add `Type`, `Area`, `Priority`
    - If ready, move to **Planned** and set milestone/release.
 3. Keep only one **Working** item.
-4. When blocked, move to **Blocked** and note blocker in issue.
-5. Close completed work and move to **Done**.
+4. Move completed implementation to **Testing** while you validate.
+5. When blocked, move to **Blocked** and note blocker in issue.
+6. Close completed/validated work and move to **Done**.
 
 ---
 
@@ -239,4 +242,4 @@ fi
    - Bug Hotlist (for `type:bug` label)
    - Release View (next patch milestone) when milestone/release matches
    - Weird stuff when `needs-investigation` is applied
-6. Move item through Inbox → Planned → Working → Done to confirm board behavior.
+6. Move item through Inbox → Planned → Working → Testing → Done to confirm board behavior.

--- a/docs/wiki/labeling-and-automation/automation-rules.md
+++ b/docs/wiki/labeling-and-automation/automation-rules.md
@@ -21,4 +21,4 @@
 
 - Add `bot:stale` after 30 days of issue inactivity.
 - Do not auto-close.
-- Exempt labels: `status:working`, `priority:p0`.
+- Exempt labels: `status:working`, `status:testing`, `priority:p0`.

--- a/docs/wiki/labeling-and-automation/label-meanings-and-examples.md
+++ b/docs/wiki/labeling-and-automation/label-meanings-and-examples.md
@@ -22,6 +22,7 @@
 - `status:triage`: new/reopened intake.
 - `status:planned`: accepted and queued.
 - `status:working`: currently being implemented.
+- `status:testing`: implementation complete and under validation before final close-out.
 - `status:blocked`: cannot proceed due blocker.
 - `status:done`: implementation complete.
 

--- a/docs/wiki/labeling-and-automation/label-taxonomy.md
+++ b/docs/wiki/labeling-and-automation/label-taxonomy.md
@@ -4,7 +4,7 @@
 
 - `type:*`: `type:bug`, `type:feature`, `type:task`, `type:refactor`
 - `area:*`: `area:backend`, `area:frontend`, `area:database`, `area:infra`, `area:auth`, `area:logging`, `area:hardware`
-- `status:*`: `status:triage`, `status:planned`, `status:working`, `status:blocked`, `status:done`
+- `status:*`: `status:triage`, `status:planned`, `status:working`, `status:testing`, `status:blocked`, `status:done`
 - `priority:*`: `priority:p0`, `priority:p1`, `priority:p2`
 
 ## Special labels


### PR DESCRIPTION
## Summary
- add a formal `testing` workflow state between `working` and `done`
- wire the new state into Codex issue-flow automation
- update workflow docs and label taxonomy to include `status:testing`
- exempt `status:testing` from stale marking

## Changes
- issue-flow transition script now supports `targetState=testing`
- project status mapping includes `🧪 Testing`
- status label hygiene now includes `status:testing`
- label catalog adds `status:testing`
- docs updated across workflow and labeling references

## Why
This preserves visibility for items under validation after implementation, before final closure.
