### PR TITLE
fix(auth): repair sentinel bootstrap badge member resolution

### DIFF
--- a/apps/backend/src/services/sentinel-bootstrap-integrity-service.ts
+++ b/apps/backend/src/services/sentinel-bootstrap-integrity-service.ts
@@ -133,6 +133,16 @@ export class SentinelBootstrapIntegrityService {
         },
       })
 
+      await tx.member.updateMany({
+        where: {
+          badgeId: badgeRecord.id,
+          NOT: { id: memberRecord.id },
+        },
+        data: {
+          badgeId: null,
+        },
+      })
+
       await tx.member.update({
         where: { id: memberRecord.id },
         data: { badgeId: badgeRecord.id },


### PR DESCRIPTION
## Summary
Fix bootstrap login failure for badge `0000000000` by making auth use `badges.assigned_to_id` as the authoritative member mapping.

## Root cause
`AuthService.login` selected `badge.members[0]`, but `Badge -> Member` is one-to-many in schema. If stale member rows still reference the same badge, the first row could be the wrong member, causing PIN/login failure.

## Fix
- Prefer `badge.assignedToId` member lookup in login flow.
- Fallback to active related member only when `assignedToId` is missing.
- During bootstrap integrity repair, clear conflicting `members.badgeId` references for non-bootstrap members before re-linking the protected bootstrap member.

## Validation
- `pnpm --filter @sentinel/backend typecheck`
