### PR TITLE
feat(dev-tools): add sentinel-system simulate scan and member/badge transfer

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -10,6 +10,8 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "sentinel:bootstrap-account": "tsx scripts/bootstrap-sentinel-account.ts",
+    "sentinel:export-members-badges": "tsx scripts/export-members-badges.ts",
+    "sentinel:import-members-badges": "tsx scripts/import-members-badges.ts",
     "sentinel:seed-default-enums": "tsx scripts/seed-default-enums.ts",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src",

--- a/apps/backend/scripts/export-members-badges.ts
+++ b/apps/backend/scripts/export-members-badges.ts
@@ -1,0 +1,130 @@
+#!/usr/bin/env tsx
+import 'dotenv/config'
+import { writeFile } from 'node:fs/promises'
+import { prisma } from '@sentinel/database'
+import {
+  SENTINEL_BOOTSTRAP_BADGE_SERIAL,
+  SENTINEL_BOOTSTRAP_SERVICE_NUMBER,
+} from '../src/lib/system-bootstrap.js'
+
+interface ExportMember {
+  serviceNumber: string
+  employeeNumber: string | null
+  firstName: string
+  lastName: string
+  displayName: string | null
+  initials: string | null
+  rank: string
+  divisionCode: string | null
+  mess: string | null
+  moc: string | null
+  memberType: string
+  status: string
+  classDetails: string | null
+  notes: string | null
+  contractStart: string | null
+  contractEnd: string | null
+  email: string | null
+  homePhone: string | null
+  mobilePhone: string | null
+  accountLevel: number
+}
+
+interface ExportBadge {
+  serialNumber: string
+  assignmentType: string
+  status: string
+  assignedServiceNumber: string | null
+}
+
+interface ExportPayload {
+  exportedAt: string
+  source: string
+  members: ExportMember[]
+  badges: ExportBadge[]
+}
+
+function getArgValue(flag: string): string | undefined {
+  const index = process.argv.indexOf(flag)
+  if (index === -1) return undefined
+  return process.argv[index + 1]
+}
+
+async function main() {
+  const outputPath = getArgValue('--output') ?? './members-badges-export.json'
+
+  try {
+    const members = await prisma.member.findMany({
+      where: {
+        serviceNumber: { not: SENTINEL_BOOTSTRAP_SERVICE_NUMBER },
+      },
+      include: {
+        division: {
+          select: {
+            code: true,
+          },
+        },
+      },
+      orderBy: [{ lastName: 'asc' }, { firstName: 'asc' }],
+    })
+
+    const memberIdToServiceNumber = new Map(
+      members.map((member) => [member.id, member.serviceNumber])
+    )
+
+    const badges = await prisma.badge.findMany({
+      where: {
+        serialNumber: { not: SENTINEL_BOOTSTRAP_BADGE_SERIAL },
+      },
+      orderBy: [{ serialNumber: 'asc' }],
+    })
+
+    const payload: ExportPayload = {
+      exportedAt: new Date().toISOString(),
+      source: 'sentinel-backend',
+      members: members.map((member) => ({
+        serviceNumber: member.serviceNumber,
+        employeeNumber: member.employeeNumber ?? null,
+        firstName: member.firstName,
+        lastName: member.lastName,
+        displayName: member.displayName ?? null,
+        initials: member.initials ?? null,
+        rank: member.rank,
+        divisionCode: member.division?.code ?? null,
+        mess: member.mess ?? null,
+        moc: member.moc ?? null,
+        memberType: member.memberType,
+        status: member.status,
+        classDetails: member.classDetails ?? null,
+        notes: member.notes ?? null,
+        contractStart: member.contract_start ? member.contract_start.toISOString() : null,
+        contractEnd: member.contract_end ? member.contract_end.toISOString() : null,
+        email: member.email ?? null,
+        homePhone: member.homePhone ?? null,
+        mobilePhone: member.mobilePhone ?? null,
+        accountLevel: member.accountLevel,
+      })),
+      badges: badges.map((badge) => ({
+        serialNumber: badge.serialNumber,
+        assignmentType: badge.assignmentType,
+        status: badge.status,
+        assignedServiceNumber: badge.assignedToId
+          ? (memberIdToServiceNumber.get(badge.assignedToId) ?? null)
+          : null,
+      })),
+    }
+
+    await writeFile(outputPath, JSON.stringify(payload, null, 2), 'utf8')
+
+    console.log(
+      `export complete: members=${payload.members.length} badges=${payload.badges.length} output=${outputPath}`
+    )
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error('export failed:', error)
+  process.exit(1)
+})

--- a/apps/backend/scripts/import-members-badges.ts
+++ b/apps/backend/scripts/import-members-badges.ts
@@ -1,0 +1,210 @@
+#!/usr/bin/env tsx
+import 'dotenv/config'
+import { readFile } from 'node:fs/promises'
+import { prisma } from '@sentinel/database'
+import {
+  SENTINEL_BOOTSTRAP_BADGE_SERIAL,
+  SENTINEL_BOOTSTRAP_SERVICE_NUMBER,
+} from '../src/lib/system-bootstrap.js'
+
+interface ImportMember {
+  serviceNumber: string
+  employeeNumber: string | null
+  firstName: string
+  lastName: string
+  displayName: string | null
+  initials: string | null
+  rank: string
+  divisionCode: string | null
+  mess: string | null
+  moc: string | null
+  memberType: string
+  status: string
+  classDetails: string | null
+  notes: string | null
+  contractStart: string | null
+  contractEnd: string | null
+  email: string | null
+  homePhone: string | null
+  mobilePhone: string | null
+  accountLevel: number
+}
+
+interface ImportBadge {
+  serialNumber: string
+  assignmentType: string
+  status: string
+  assignedServiceNumber: string | null
+}
+
+interface ImportPayload {
+  members: ImportMember[]
+  badges: ImportBadge[]
+}
+
+function getArgValue(flag: string): string | undefined {
+  const index = process.argv.indexOf(flag)
+  if (index === -1) return undefined
+  return process.argv[index + 1]
+}
+
+function parseDate(value: string | null): Date | null {
+  if (!value) return null
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
+async function main() {
+  const inputPath = getArgValue('--input')
+  if (!inputPath) {
+    console.error('Missing required argument: --input <path>')
+    process.exit(1)
+  }
+
+  const raw = await readFile(inputPath, 'utf8')
+  const parsed = JSON.parse(raw) as ImportPayload
+  const members = parsed.members ?? []
+  const badges = parsed.badges ?? []
+
+  const ranks = await prisma.rank.findMany({
+    select: { id: true, code: true },
+  })
+  const rankIdByCode = new Map(ranks.map((rank) => [rank.code, rank.id]))
+
+  const divisions = await prisma.division.findMany({
+    select: { id: true, code: true },
+  })
+  const divisionIdByCode = new Map(divisions.map((division) => [division.code, division.id]))
+
+  const memberIdByServiceNumber = new Map<string, string>()
+  const skippedMembers: string[] = []
+
+  for (const member of members) {
+    if (member.serviceNumber === SENTINEL_BOOTSTRAP_SERVICE_NUMBER) {
+      continue
+    }
+
+    const rankId = rankIdByCode.get(member.rank)
+    if (!rankId) {
+      skippedMembers.push(member.serviceNumber)
+      continue
+    }
+
+    const divisionId = member.divisionCode
+      ? (divisionIdByCode.get(member.divisionCode) ?? null)
+      : null
+
+    const upserted = await prisma.member.upsert({
+      where: { serviceNumber: member.serviceNumber },
+      create: {
+        serviceNumber: member.serviceNumber,
+        employeeNumber: member.employeeNumber,
+        firstName: member.firstName,
+        lastName: member.lastName,
+        displayName: member.displayName,
+        initials: member.initials,
+        rank: member.rank,
+        rankId,
+        divisionId,
+        mess: member.mess,
+        moc: member.moc,
+        memberType: member.memberType,
+        status: member.status,
+        classDetails: member.classDetails,
+        notes: member.notes,
+        contract_start: parseDate(member.contractStart),
+        contract_end: parseDate(member.contractEnd),
+        email: member.email,
+        homePhone: member.homePhone,
+        mobilePhone: member.mobilePhone,
+        accountLevel: member.accountLevel,
+      },
+      update: {
+        employeeNumber: member.employeeNumber,
+        firstName: member.firstName,
+        lastName: member.lastName,
+        displayName: member.displayName,
+        initials: member.initials,
+        rank: member.rank,
+        rankId,
+        divisionId,
+        mess: member.mess,
+        moc: member.moc,
+        memberType: member.memberType,
+        status: member.status,
+        classDetails: member.classDetails,
+        notes: member.notes,
+        contract_start: parseDate(member.contractStart),
+        contract_end: parseDate(member.contractEnd),
+        email: member.email,
+        homePhone: member.homePhone,
+        mobilePhone: member.mobilePhone,
+        accountLevel: member.accountLevel,
+      },
+      select: { id: true, serviceNumber: true },
+    })
+
+    memberIdByServiceNumber.set(upserted.serviceNumber, upserted.id)
+  }
+
+  let badgesUpserted = 0
+  for (const badge of badges) {
+    if (badge.serialNumber === SENTINEL_BOOTSTRAP_BADGE_SERIAL) {
+      continue
+    }
+
+    const assignedMemberId = badge.assignedServiceNumber
+      ? (memberIdByServiceNumber.get(badge.assignedServiceNumber) ?? null)
+      : null
+
+    const upsertedBadge = await prisma.badge.upsert({
+      where: { serialNumber: badge.serialNumber },
+      create: {
+        serialNumber: badge.serialNumber,
+        status: badge.status,
+        assignmentType: assignedMemberId ? 'member' : 'unassigned',
+        assignedToId: assignedMemberId,
+      },
+      update: {
+        status: badge.status,
+        assignmentType: assignedMemberId ? 'member' : 'unassigned',
+        assignedToId: assignedMemberId,
+      },
+      select: { id: true },
+    })
+
+    if (assignedMemberId) {
+      await prisma.member.updateMany({
+        where: {
+          badgeId: upsertedBadge.id,
+          NOT: { id: assignedMemberId },
+        },
+        data: {
+          badgeId: null,
+        },
+      })
+      await prisma.member.update({
+        where: { id: assignedMemberId },
+        data: { badgeId: upsertedBadge.id },
+      })
+    }
+
+    badgesUpserted += 1
+  }
+
+  console.log(
+    `import complete: members_upserted=${memberIdByServiceNumber.size} badges_upserted=${badgesUpserted} members_skipped_missing_rank=${skippedMembers.length}`
+  )
+  if (skippedMembers.length > 0) {
+    console.warn(`skipped members (missing rank code): ${skippedMembers.join(', ')}`)
+  }
+}
+
+main()
+  .catch((error: unknown) => {
+    console.error('import failed:', error)
+    process.exit(1)
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/apps/frontend-admin/src/components/dashboard/quick-action-buttons.tsx
+++ b/apps/frontend-admin/src/components/dashboard/quick-action-buttons.tsx
@@ -13,6 +13,7 @@ import { SimulateScanModal } from '@/components/dev/simulate-scan-modal'
 import { KioskCheckinModal } from '@/components/dashboard/kiosk-checkin-modal'
 import { useLockupStatus, useCheckoutOptions } from '@/hooks/use-lockup'
 import { TID } from '@/lib/test-ids'
+import { isSentinelBootstrapServiceNumber } from '@/lib/system-bootstrap'
 
 export function QuickActionButtons() {
   const member = useAuthStore((state) => state.member)
@@ -24,6 +25,7 @@ export function QuickActionButtons() {
   const [isOpenBuildingOpen, setIsOpenBuildingOpen] = useState(false)
   const [isTransferScanModalOpen, setIsTransferScanModalOpen] = useState(false)
   const isDevMode = process.env.NODE_ENV === 'development'
+  const isSentinelSystem = isSentinelBootstrapServiceNumber(member?.serviceNumber)
 
   const { data: lockupStatus } = useLockupStatus()
   const currentHolder = lockupStatus?.currentHolder
@@ -73,10 +75,7 @@ export function QuickActionButtons() {
         </button>
       </div>
 
-      <button
-        className={`${actionBaseClass} btn-outline btn-primary`}
-        disabled
-      >
+      <button className={`${actionBaseClass} btn-outline btn-primary`} disabled>
         <FileText className="h-4 w-4" />
         Reports
       </button>
@@ -127,7 +126,7 @@ export function QuickActionButtons() {
         </div>
       )}
 
-      {isDevMode && (
+      {(isDevMode || isSentinelSystem) && (
         <button
           className={`${actionBaseClass} btn-outline btn-accent`}
           onClick={() => setIsScanModalOpen(true)}
@@ -159,7 +158,9 @@ export function QuickActionButtons() {
           onComplete={() => setIsTransferScanModalOpen(false)}
         />
       )}
-      {isDevMode && <SimulateScanModal open={isScanModalOpen} onOpenChange={setIsScanModalOpen} />}
+      {(isDevMode || isSentinelSystem) && (
+        <SimulateScanModal open={isScanModalOpen} onOpenChange={setIsScanModalOpen} />
+      )}
       <KioskCheckinModal open={isKioskModalOpen} onOpenChange={setIsKioskModalOpen} />
     </div>
   )

--- a/apps/frontend-admin/src/lib/system-bootstrap.ts
+++ b/apps/frontend-admin/src/lib/system-bootstrap.ts
@@ -1,0 +1,8 @@
+export const SENTINEL_BOOTSTRAP_BADGE_SERIAL = '0000000000'
+export const SENTINEL_BOOTSTRAP_SERVICE_NUMBER = 'SENTINEL-SYSTEM'
+
+export function isSentinelBootstrapServiceNumber(
+  serviceNumber: string | null | undefined
+): boolean {
+  return serviceNumber === SENTINEL_BOOTSTRAP_SERVICE_NUMBER
+}


### PR DESCRIPTION
## Summary
- allow Simulate Scan in production for Sentinel System account only
- keep dev route protections for all other production users
- add export/import scripts to migrate Members + Badges from local to deployed Sentinel

## Simulate Scan changes
- frontend quick action now shows Simulate Scan for:
  - development env, OR
  - Sentinel bootstrap account (`SENTINEL-SYSTEM`)
- backend `/api/dev/*` production blocks now allow only Sentinel bootstrap account
- dev mock scan now resolves member by `badge.assignedToId` first, with fallback

## Data transfer tooling
Added backend scripts:
- `sentinel:export-members-badges`
- `sentinel:import-members-badges`

Export/Import behavior:
- excludes protected bootstrap account/badge
- upserts members by `serviceNumber`
- upserts badges by `serialNumber`
- re-links assigned badges to target members
- reports skipped members when rank codes are missing on target

## Docs
- Added members+badges transfer section to deploy README with local/deployed commands

## Validation
- `pnpm --filter @sentinel/backend typecheck`
- `pnpm --filter @sentinel/backend lint` (warnings only)
- `pnpm --filter frontend-admin build`
