### PR TITLE
chore(release): prepare v2.4.2

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/components/settings/dashboard-person-card-sort-settings-panel.tsx
+++ b/apps/frontend-admin/src/components/settings/dashboard-person-card-sort-settings-panel.tsx
@@ -46,9 +46,30 @@ import {
 } from '@/lib/dashboard-person-card-sort'
 import { cn } from '@/lib/utils'
 
+function createCriterionId(): string {
+  if (
+    typeof globalThis.crypto !== 'undefined' &&
+    typeof globalThis.crypto.randomUUID === 'function'
+  ) {
+    return globalThis.crypto.randomUUID()
+  }
+
+  return `dashboard-sort-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+function cloneDashboardSortConfig(
+  config: DashboardPersonCardSortConfig
+): DashboardPersonCardSortConfig {
+  if (typeof globalThis.structuredClone === 'function') {
+    return globalThis.structuredClone(config)
+  }
+
+  return JSON.parse(JSON.stringify(config)) as DashboardPersonCardSortConfig
+}
+
 function createCriterion(type: DashboardSortCriterionType): DashboardSortCriterion {
   return {
-    id: globalThis.crypto.randomUUID(),
+    id: createCriterionId(),
     type,
     note: '',
     children: [],
@@ -443,12 +464,12 @@ export function DashboardPersonCardSortSettingsPanel() {
   )
 
   const beginEdit = () => {
-    setDraft(globalThis.structuredClone(effectiveConfig))
+    setDraft(cloneDashboardSortConfig(effectiveConfig))
     setIsEditing(true)
   }
 
   const cancelEdit = () => {
-    setDraft(globalThis.structuredClone(effectiveConfig))
+    setDraft(cloneDashboardSortConfig(effectiveConfig))
     setIsEditing(false)
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

Prepare `v2.4.2` with a quick frontend compatibility fix for the Dashboard Sorting editor.

## Root Cause

On the deployment/development laptop browser runtime, adding a dashboard sorting criterion failed with:

- `Uncaught TypeError: globalThis.crypto.randomUUID is not a function`

The editor assumed both `crypto.randomUUID()` and `structuredClone()` were always present.

## Fix

- guard dashboard sort criterion id creation behind a feature check
- fall back to a deterministic timestamp/random string id when `crypto.randomUUID()` is unavailable
- add a safe config clone fallback when `structuredClone()` is unavailable

## Release Prep

- bump root version to `2.4.2`
- sync workspace package versions to `2.4.2`

## Commits

- `11c5489` fix(frontend-admin): guard dashboard sort browser APIs
- `6a46472` chore(release): prepare v2.4.2

## Validation

- `pnpm --filter frontend-admin typecheck`
- `pnpm version:sync`
- `pnpm version:check`
