### PR TITLE
release: v2.4.4 start-of-day opening gate

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -14,6 +14,8 @@ import {
   NotFoundError,
   PinPolicyError,
   PinSetupRequiredError,
+  StartOfDayActionRequiredError,
+  InvalidStartOfDayActionError,
 } from '../services/auth-service.js'
 import { getPrismaClient } from '../lib/database.js'
 import { authLogger } from '../lib/logger.js'
@@ -111,7 +113,8 @@ router.post('/login', async (req: Request, res: Response) => {
       })
     }
 
-    const { serialNumber, pin, remoteSystemId, useKioskRemoteSystem } = parsed.output
+    const { serialNumber, pin, remoteSystemId, useKioskRemoteSystem, startOfDayAction } =
+      parsed.output
     const remoteSystemRepository = new RemoteSystemRepository(getPrismaClient())
     const shouldUseKioskRemoteSystem = useKioskRemoteSystem === true
     const shouldForceDeploymentRemoteSystem =
@@ -166,6 +169,7 @@ router.post('/login', async (req: Request, res: Response) => {
         remoteSystemId: resolvedRemoteSystem.id,
         remoteSystemName: resolvedRemoteSystem.name,
       },
+      startOfDayAction,
       getRequestClientIp(req),
       req.headers['user-agent']
     )
@@ -193,6 +197,19 @@ router.post('/login', async (req: Request, res: Response) => {
   } catch (error) {
     if (error instanceof PinSetupRequiredError) {
       return res.status(403).json({
+        error: error.code,
+        message: error.message,
+      })
+    }
+    if (error instanceof StartOfDayActionRequiredError) {
+      return res.status(409).json({
+        error: error.code,
+        message: error.message,
+        responsibilityState: error.requirement.responsibilityState,
+      })
+    }
+    if (error instanceof InvalidStartOfDayActionError) {
+      return res.status(400).json({
         error: error.code,
         message: error.message,
       })

--- a/apps/backend/src/services/auth-service.test.ts
+++ b/apps/backend/src/services/auth-service.test.ts
@@ -9,6 +9,7 @@ import {
   ForbiddenError,
   PinPolicyError,
   PinSetupRequiredError,
+  StartOfDayActionRequiredError,
 } from './auth-service.js'
 
 const TEST_BCRYPT_COST = 4
@@ -44,6 +45,42 @@ function createCheckinRepositoryMock() {
 function createPresenceServiceMock() {
   return {
     broadcastStatsUpdate: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+function createDdsServiceMock() {
+  return {
+    getLoginResponsibilityState: vi.fn().mockResolvedValue({
+      shouldPrompt: false,
+      promptVariant: 'opener_only',
+      isFirstMemberCheckin: false,
+      needsDds: false,
+      needsBuildingOpen: false,
+      buildingStatus: 'open',
+      canAcceptDds: false,
+      canOpenBuilding: false,
+      member: {
+        id: 'member-1',
+        firstName: 'Alex',
+        lastName: 'Example',
+        rank: 'PO2',
+      },
+      expectedDds: null,
+      scheduledDds: null,
+      currentDds: null,
+      currentLockupHolder: null,
+      currentOpenContext: null,
+      presentMembers: [],
+      presentVisitorCount: 0,
+      todayCycles: [],
+    }),
+    acceptDds: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+function createLockupServiceMock() {
+  return {
+    openBuilding: vi.fn().mockResolvedValue(undefined),
   }
 }
 
@@ -122,6 +159,21 @@ function attachPresenceService(service: AuthService) {
   return presenceService
 }
 
+function attachDdsService(service: AuthService) {
+  const ddsService = createDdsServiceMock()
+  ;(service as unknown as { ddsService: ReturnType<typeof createDdsServiceMock> }).ddsService =
+    ddsService
+  return ddsService
+}
+
+function attachLockupService(service: AuthService) {
+  const lockupService = createLockupServiceMock()
+  ;(
+    service as unknown as { lockupService: ReturnType<typeof createLockupServiceMock> }
+  ).lockupService = lockupService
+  return lockupService
+}
+
 describe('AuthService', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
@@ -131,6 +183,8 @@ describe('AuthService', () => {
     const prisma = createPrismaMock({ pinHash: null, mustChangePin: false })
     const service = new AuthService(prisma)
     const sessionRepository = attachSessionRepository(service)
+    attachDdsService(service)
+    attachLockupService(service)
 
     await expect(
       service.login(
@@ -140,6 +194,7 @@ describe('AuthService', () => {
           remoteSystemId: 'remote-1',
           remoteSystemName: 'Deployment Laptop',
         },
+        undefined,
         '127.0.0.1',
         'vitest'
       )
@@ -159,6 +214,8 @@ describe('AuthService', () => {
     })
     const service = new AuthService(prisma)
     const sessionRepository = attachSessionRepository(service)
+    attachDdsService(service)
+    attachLockupService(service)
 
     await expect(
       service.login(
@@ -168,6 +225,7 @@ describe('AuthService', () => {
           remoteSystemId: 'remote-1',
           remoteSystemName: 'Deployment Laptop',
         },
+        undefined,
         '127.0.0.1',
         'vitest'
       )
@@ -252,6 +310,8 @@ describe('AuthService', () => {
     const sessionRepository = attachSessionRepository(service)
     const checkinRepository = attachCheckinRepository(service)
     const presenceService = attachPresenceService(service)
+    const ddsService = attachDdsService(service)
+    const lockupService = attachLockupService(service)
 
     await expect(
       service.login(
@@ -261,6 +321,7 @@ describe('AuthService', () => {
           remoteSystemId: 'remote-1',
           remoteSystemName: 'Deployment Laptop',
         },
+        undefined,
         '127.0.0.1',
         'vitest'
       )
@@ -281,6 +342,8 @@ describe('AuthService', () => {
       })
     )
     expect(presenceService.broadcastStatsUpdate).toHaveBeenCalled()
+    expect(ddsService.acceptDds).not.toHaveBeenCalled()
+    expect(lockupService.openBuilding).not.toHaveBeenCalled()
   })
 
   it('does not create a duplicate login checkin when the member is already present', async () => {
@@ -292,6 +355,8 @@ describe('AuthService', () => {
     const sessionRepository = attachSessionRepository(service)
     const checkinRepository = attachCheckinRepository(service)
     attachPresenceService(service)
+    attachDdsService(service)
+    attachLockupService(service)
 
     checkinRepository.findLatestByMember.mockResolvedValue({
       id: 'existing-checkin',
@@ -306,6 +371,7 @@ describe('AuthService', () => {
         remoteSystemId: 'remote-1',
         remoteSystemName: 'Deployment Laptop',
       },
+      undefined,
       '127.0.0.1',
       'vitest'
     )
@@ -323,6 +389,8 @@ describe('AuthService', () => {
     const sessionRepository = attachSessionRepository(service)
     const checkinRepository = attachCheckinRepository(service)
     attachPresenceService(service)
+    attachDdsService(service)
+    attachLockupService(service)
 
     checkinRepository.create.mockRejectedValue(new Error('insert failed'))
 
@@ -334,12 +402,190 @@ describe('AuthService', () => {
           remoteSystemId: 'remote-1',
           remoteSystemName: 'Deployment Laptop',
         },
+        undefined,
         '127.0.0.1',
         'vitest'
       )
     ).rejects.toThrow('insert failed')
 
     expect(sessionRepository.endById).toHaveBeenCalledWith('session-1', 'auto_checkin_failed')
+  })
+
+  it('requires a start-of-day action before the first member opens the unit', async () => {
+    const prisma = createPrismaMock({
+      pinHash: await bcrypt.hash('2468', TEST_BCRYPT_COST),
+      mustChangePin: false,
+    })
+    const service = new AuthService(prisma)
+    const sessionRepository = attachSessionRepository(service)
+    const checkinRepository = attachCheckinRepository(service)
+    const ddsService = attachDdsService(service)
+    attachLockupService(service)
+
+    ddsService.getLoginResponsibilityState.mockResolvedValue({
+      shouldPrompt: true,
+      promptVariant: 'expected_dds',
+      isFirstMemberCheckin: true,
+      needsDds: true,
+      needsBuildingOpen: true,
+      buildingStatus: 'secured',
+      canAcceptDds: true,
+      canOpenBuilding: true,
+      member: {
+        id: 'member-1',
+        firstName: 'Alex',
+        lastName: 'Example',
+        rank: 'PO2',
+      },
+      expectedDds: {
+        member: {
+          id: 'member-1',
+          firstName: 'Alex',
+          lastName: 'Example',
+          rank: 'PO2',
+        },
+        source: 'scheduled',
+        matchesScannedMember: true,
+      },
+      scheduledDds: null,
+      currentDds: null,
+      currentLockupHolder: null,
+      currentOpenContext: null,
+      presentMembers: [],
+      presentVisitorCount: 0,
+      todayCycles: [],
+    })
+
+    await expect(
+      service.login(
+        'serial-1',
+        '2468',
+        {
+          remoteSystemId: 'remote-1',
+          remoteSystemName: 'Deployment Laptop',
+        },
+        undefined,
+        '127.0.0.1',
+        'vitest'
+      )
+    ).rejects.toBeInstanceOf(StartOfDayActionRequiredError)
+
+    expect(sessionRepository.create).not.toHaveBeenCalled()
+    expect(checkinRepository.create).not.toHaveBeenCalled()
+  })
+
+  it('opens the unit without accepting DDS when the member selects open only', async () => {
+    const prisma = createPrismaMock({
+      pinHash: await bcrypt.hash('2468', TEST_BCRYPT_COST),
+      mustChangePin: false,
+    })
+    const service = new AuthService(prisma)
+    const sessionRepository = attachSessionRepository(service)
+    const checkinRepository = attachCheckinRepository(service)
+    const presenceService = attachPresenceService(service)
+    const ddsService = attachDdsService(service)
+    const lockupService = attachLockupService(service)
+
+    ddsService.getLoginResponsibilityState.mockResolvedValue({
+      shouldPrompt: true,
+      promptVariant: 'opener_only',
+      isFirstMemberCheckin: true,
+      needsDds: true,
+      needsBuildingOpen: true,
+      buildingStatus: 'secured',
+      canAcceptDds: false,
+      canOpenBuilding: true,
+      member: {
+        id: 'member-1',
+        firstName: 'Alex',
+        lastName: 'Example',
+        rank: 'PO2',
+      },
+      expectedDds: null,
+      scheduledDds: null,
+      currentDds: null,
+      currentLockupHolder: null,
+      currentOpenContext: null,
+      presentMembers: [],
+      presentVisitorCount: 0,
+      todayCycles: [],
+    })
+
+    await service.login(
+      'serial-1',
+      '2468',
+      {
+        remoteSystemId: 'remote-1',
+        remoteSystemName: 'Deployment Laptop',
+      },
+      'open_only',
+      '127.0.0.1',
+      'vitest'
+    )
+
+    expect(sessionRepository.create).toHaveBeenCalled()
+    expect(checkinRepository.create).toHaveBeenCalled()
+    expect(lockupService.openBuilding).toHaveBeenCalledWith(
+      'member-1',
+      'Opened during Sentinel sign-in'
+    )
+    expect(ddsService.acceptDds).not.toHaveBeenCalled()
+    expect(presenceService.broadcastStatsUpdate).toHaveBeenCalled()
+  })
+
+  it('accepts DDS when the first member chooses the combined start-of-day action', async () => {
+    const prisma = createPrismaMock({
+      pinHash: await bcrypt.hash('2468', TEST_BCRYPT_COST),
+      mustChangePin: false,
+    })
+    const service = new AuthService(prisma)
+    const sessionRepository = attachSessionRepository(service)
+    const checkinRepository = attachCheckinRepository(service)
+    attachPresenceService(service)
+    const ddsService = attachDdsService(service)
+    const lockupService = attachLockupService(service)
+
+    ddsService.getLoginResponsibilityState.mockResolvedValue({
+      shouldPrompt: true,
+      promptVariant: 'expected_dds',
+      isFirstMemberCheckin: true,
+      needsDds: true,
+      needsBuildingOpen: true,
+      buildingStatus: 'secured',
+      canAcceptDds: true,
+      canOpenBuilding: true,
+      member: {
+        id: 'member-1',
+        firstName: 'Alex',
+        lastName: 'Example',
+        rank: 'PO2',
+      },
+      expectedDds: null,
+      scheduledDds: null,
+      currentDds: null,
+      currentLockupHolder: null,
+      currentOpenContext: null,
+      presentMembers: [],
+      presentVisitorCount: 0,
+      todayCycles: [],
+    })
+
+    await service.login(
+      'serial-1',
+      '2468',
+      {
+        remoteSystemId: 'remote-1',
+        remoteSystemName: 'Deployment Laptop',
+      },
+      'open_and_accept_dds',
+      '127.0.0.1',
+      'vitest'
+    )
+
+    expect(sessionRepository.create).toHaveBeenCalled()
+    expect(checkinRepository.create).toHaveBeenCalled()
+    expect(ddsService.acceptDds).toHaveBeenCalledWith('member-1')
+    expect(lockupService.openBuilding).not.toHaveBeenCalled()
   })
 
   it('rejects blocked replacement PINs', async () => {

--- a/apps/backend/src/services/auth-service.ts
+++ b/apps/backend/src/services/auth-service.ts
@@ -1,7 +1,11 @@
 import bcrypt from 'bcryptjs'
 import type { PrismaClientInstance } from '@sentinel/database'
 import { prisma as defaultPrisma } from '@sentinel/database'
-import { DISALLOWED_MEMBER_PINS } from '@sentinel/contracts'
+import {
+  DISALLOWED_MEMBER_PINS,
+  type KioskResponsibilityStateResponse,
+  type LoginStartOfDayAction,
+} from '@sentinel/contracts'
 import { CheckinRepository } from '../repositories/checkin-repository.js'
 import { SessionRepository } from '../repositories/session-repository.js'
 import type { SessionMetadata, SessionWithMember } from '../repositories/session-repository.js'
@@ -12,6 +16,8 @@ import {
 } from '../lib/system-bootstrap.js'
 import { broadcastCheckin } from '../websocket/broadcast.js'
 import { PresenceService } from './presence-service.js'
+import { DdsService } from './dds-service.js'
+import { LockupService } from './lockup-service.js'
 
 const BCRYPT_COST = 12
 const DISALLOWED_MEMBER_PIN_SET = new Set<string>(DISALLOWED_MEMBER_PINS)
@@ -51,6 +57,11 @@ interface LoginContext {
   setupReason: PinSetupReason | null
 }
 
+interface LoginCheckinResult {
+  created: boolean
+  checkinId: string | null
+}
+
 export interface LoginResult {
   token: string
   sessionId: string
@@ -72,17 +83,25 @@ export interface RemoteSystemSelection {
   remoteSystemName: string
 }
 
+export interface StartOfDayRequirement {
+  responsibilityState: KioskResponsibilityStateResponse
+}
+
 export class AuthService {
   private prisma: PrismaClientInstance
   private sessionRepo: SessionRepository
   private checkinRepo: CheckinRepository
   private presenceService: PresenceService
+  private ddsService: DdsService
+  private lockupService: LockupService
 
   constructor(prisma: PrismaClientInstance = defaultPrisma) {
     this.prisma = prisma
     this.sessionRepo = new SessionRepository(prisma)
     this.checkinRepo = new CheckinRepository(prisma)
     this.presenceService = new PresenceService(prisma)
+    this.ddsService = new DdsService(prisma)
+    this.lockupService = new LockupService(prisma)
   }
 
   /**
@@ -94,6 +113,7 @@ export class AuthService {
     serialNumber: string,
     pin: string,
     remoteSystem: RemoteSystemSelection,
+    startOfDayAction?: LoginStartOfDayAction,
     ipAddress?: string | null,
     userAgent?: string | null
   ): Promise<LoginResult> {
@@ -118,6 +138,21 @@ export class AuthService {
       throw new AuthenticationError('Invalid badge or PIN')
     }
 
+    const startOfDayRequirement = await this.getStartOfDayRequirement(member.id)
+    if (startOfDayRequirement && !startOfDayAction) {
+      authLogger.info('Login paused pending start-of-day action selection', {
+        memberId: member.id,
+        ip: ipAddress,
+      })
+      throw new StartOfDayActionRequiredError(
+        'Choose how to open the unit before signing in',
+        startOfDayRequirement
+      )
+    }
+    if (startOfDayRequirement && startOfDayAction) {
+      this.assertValidStartOfDayAction(startOfDayRequirement, startOfDayAction)
+    }
+
     const session = await this.sessionRepo.create({
       memberId: member.id,
       remoteSystemId: remoteSystem.remoteSystemId,
@@ -126,9 +161,29 @@ export class AuthService {
       userAgent,
     })
 
+    let loginCheckin: LoginCheckinResult = { created: false, checkinId: null }
+
     try {
-      await this.ensureMemberCheckedIn(member.id, remoteSystem.remoteSystemId)
+      loginCheckin = await this.ensureMemberCheckedIn(member.id, remoteSystem.remoteSystemId)
+
+      if (startOfDayRequirement && startOfDayAction) {
+        await this.executeStartOfDayAction(member.id, startOfDayAction)
+      }
     } catch (error) {
+      if (loginCheckin.created && loginCheckin.checkinId) {
+        try {
+          await this.checkinRepo.delete(loginCheckin.checkinId)
+          await this.presenceService.broadcastStatsUpdate()
+        } catch (rollbackError) {
+          authLogger.error('Login rollback failed after start-of-day action error', {
+            memberId: member.id,
+            sessionId: session.id,
+            checkinId: loginCheckin.checkinId,
+            error: rollbackError instanceof Error ? rollbackError.message : 'Unknown error',
+          })
+        }
+      }
+
       await this.sessionRepo.endById(session.id, 'auto_checkin_failed')
       authLogger.error('Login auto check-in failed; session revoked', {
         memberId: member.id,
@@ -463,10 +518,10 @@ export class AuthService {
   private async ensureMemberCheckedIn(
     memberId: string,
     remoteSystemId: string | null
-  ): Promise<void> {
+  ): Promise<LoginCheckinResult> {
     const latestCheckin = await this.checkinRepo.findLatestByMember(memberId)
     if (latestCheckin?.direction === 'in') {
-      return
+      return { created: false, checkinId: latestCheckin.id }
     }
 
     if (!remoteSystemId) {
@@ -514,6 +569,59 @@ export class AuthService {
     })
 
     await this.presenceService.broadcastStatsUpdate()
+
+    return {
+      created: true,
+      checkinId: checkin.id,
+    }
+  }
+
+  private async getStartOfDayRequirement(memberId: string): Promise<StartOfDayRequirement | null> {
+    const latestCheckin = await this.checkinRepo.findLatestByMember(memberId)
+    if (latestCheckin?.direction === 'in') {
+      return null
+    }
+
+    const responsibilityState = await this.ddsService.getLoginResponsibilityState(memberId)
+    if (
+      responsibilityState.isFirstMemberCheckin &&
+      responsibilityState.needsBuildingOpen &&
+      responsibilityState.canOpenBuilding
+    ) {
+      return { responsibilityState }
+    }
+
+    return null
+  }
+
+  private assertValidStartOfDayAction(
+    requirement: StartOfDayRequirement,
+    action: LoginStartOfDayAction
+  ): void {
+    if (action === 'open_only') {
+      if (!requirement.responsibilityState.canOpenBuilding) {
+        throw new InvalidStartOfDayActionError('This badge cannot open the unit right now')
+      }
+      return
+    }
+
+    if (!requirement.responsibilityState.canAcceptDds) {
+      throw new InvalidStartOfDayActionError(
+        'This badge cannot accept DDS right now. Choose open unit only instead.'
+      )
+    }
+  }
+
+  private async executeStartOfDayAction(
+    memberId: string,
+    action: LoginStartOfDayAction
+  ): Promise<void> {
+    if (action === 'open_and_accept_dds') {
+      await this.ddsService.acceptDds(memberId)
+      return
+    }
+
+    await this.lockupService.openBuilding(memberId, 'Opened during Sentinel sign-in')
   }
 }
 
@@ -559,5 +667,27 @@ export class PinSetupRequiredError extends Error {
   constructor(message: string) {
     super(message)
     this.name = 'PinSetupRequiredError'
+  }
+}
+
+export class StartOfDayActionRequiredError extends Error {
+  public statusCode = 409
+  public code = 'START_OF_DAY_ACTION_REQUIRED'
+  public requirement: StartOfDayRequirement
+
+  constructor(message: string, requirement: StartOfDayRequirement) {
+    super(message)
+    this.name = 'StartOfDayActionRequiredError'
+    this.requirement = requirement
+  }
+}
+
+export class InvalidStartOfDayActionError extends Error {
+  public statusCode = 400
+  public code = 'INVALID_START_OF_DAY_ACTION'
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'InvalidStartOfDayActionError'
   }
 }

--- a/apps/backend/src/services/dds-service.ts
+++ b/apps/backend/src/services/dds-service.ts
@@ -730,6 +730,17 @@ export class DdsService {
   }
 
   async getKioskResponsibilityState(memberId: string): Promise<DdsResponsibilityState> {
+    return this.buildResponsibilityState(memberId, false)
+  }
+
+  async getLoginResponsibilityState(memberId: string): Promise<DdsResponsibilityState> {
+    return this.buildResponsibilityState(memberId, true)
+  }
+
+  private async buildResponsibilityState(
+    memberId: string,
+    assumeMemberPresent: boolean
+  ): Promise<DdsResponsibilityState> {
     const [
       member,
       currentDds,
@@ -750,8 +761,11 @@ export class DdsService {
       this.lockupService.canMemberExerciseLockupAuthority(memberId),
     ])
 
-    const isPresent = presentMembers.some((presentMember) => presentMember.id === memberId)
-    const isFirstMemberCheckin = presentMembers.length === 1 && isPresent
+    const isActuallyPresent = presentMembers.some((presentMember) => presentMember.id === memberId)
+    const isPresent = isActuallyPresent || assumeMemberPresent
+    const effectivePresentMemberCount =
+      presentMembers.length + (!isActuallyPresent && assumeMemberPresent ? 1 : 0)
+    const isFirstMemberCheckin = effectivePresentMemberCount === 1 && isPresent
     const needsDds = currentDds?.status !== 'active'
     const needsBuildingOpen = lockupStatus.buildingStatus === 'secured'
     const canAcceptDds =

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/app/login/page.tsx
+++ b/apps/frontend-admin/src/app/login/page.tsx
@@ -5,11 +5,19 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import {
   DISALLOWED_MEMBER_PINS,
   type AuthMember,
+  type KioskResponsibilityStateResponse,
   type LoginPinSetupReason,
+  type LoginStartOfDayAction,
 } from '@sentinel/contracts'
 import { BadgeScanInput } from '@/components/auth/badge-scan-input'
 import type { PinInputInitialSelection, PinInputSubmission } from '@/components/auth/pin-input'
 import { PinInput } from '@/components/auth/pin-input'
+import {
+  getKioskResponsibilityPromptPresentation,
+  getResponsibilityPrimaryLabel,
+  getResponsibilitySummary,
+  type ResponsibilityActionChoice,
+} from '@/components/kiosk/kiosk-responsibility-prompt.logic'
 import { AppBadge } from '@/components/ui/AppBadge'
 import {
   AppCard,
@@ -26,11 +34,22 @@ import { useAuthStore } from '@/store/auth-store'
 
 const LAST_REMOTE_SYSTEM_STORAGE_KEY = 'sentinel.last-remote-system'
 
-type LoginStep = 'badge' | 'setup' | 'pin'
+type LoginStep = 'badge' | 'setup' | 'pin' | 'start_of_day'
 
 interface SetupFlowState {
   member: AuthMember
   reason: LoginPinSetupReason
+}
+
+interface StartOfDayState {
+  pinSubmission: PinInputSubmission
+  responsibilityState: KioskResponsibilityStateResponse
+}
+
+function mapResponsibilityActionToLoginAction(
+  action: ResponsibilityActionChoice
+): LoginStartOfDayAction {
+  return action === 'accept_dds' ? 'open_and_accept_dds' : 'open_only'
 }
 
 function readInitialSelection(): PinInputInitialSelection | null {
@@ -138,6 +157,9 @@ function LoginPageContent() {
   const [setupState, setSetupState] = useState<SetupFlowState | null>(null)
   const [newPin, setNewPin] = useState('')
   const [confirmPin, setConfirmPin] = useState('')
+  const [startOfDayState, setStartOfDayState] = useState<StartOfDayState | null>(null)
+  const [selectedStartOfDayAction, setSelectedStartOfDayAction] =
+    useState<LoginStartOfDayAction | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [statusMessage, setStatusMessage] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
@@ -165,10 +187,16 @@ function LoginPageContent() {
     setConfirmPin('')
   }
 
+  const resetStartOfDayState = () => {
+    setStartOfDayState(null)
+    setSelectedStartOfDayAction(null)
+  }
+
   const returnToBadgeScan = () => {
     setStep('badge')
     setBadgeSerial('')
     setSetupState(null)
+    resetStartOfDayState()
     setError(null)
     setStatusMessage(null)
     resetPinSetupForm()
@@ -230,7 +258,8 @@ function LoginPageContent() {
     pin,
     remoteSystemId,
     useKioskRemoteSystem,
-  }: PinInputSubmission) => {
+    startOfDayAction,
+  }: PinInputSubmission & { startOfDayAction?: LoginStartOfDayAction }) => {
     setLoading(true)
     setError(null)
     setStatusMessage(null)
@@ -243,8 +272,8 @@ function LoginPageContent() {
 
       const response = await apiClient.auth.login({
         body: useKioskRemoteSystem
-          ? { serialNumber: badgeSerial, pin, useKioskRemoteSystem: true }
-          : { serialNumber: badgeSerial, pin, remoteSystemId },
+          ? { serialNumber: badgeSerial, pin, useKioskRemoteSystem: true, startOfDayAction }
+          : { serialNumber: badgeSerial, pin, remoteSystemId, startOfDayAction },
       })
 
       if (response.status === 403 && getErrorCode(response.body) === 'PIN_SETUP_REQUIRED') {
@@ -252,6 +281,22 @@ function LoginPageContent() {
         if (!recovered) {
           setError(getErrorMessage(response.body, 'PIN setup is required before signing in'))
         }
+        return
+      }
+
+      if (response.status === 409 && response.body.error === 'START_OF_DAY_ACTION_REQUIRED') {
+        const promptState = response.body.responsibilityState
+        const presentation = getKioskResponsibilityPromptPresentation(promptState)
+        const defaultAction = presentation.defaultAction
+          ? mapResponsibilityActionToLoginAction(presentation.defaultAction)
+          : null
+
+        setStartOfDayState({
+          pinSubmission: { pin, remoteSystemId, useKioskRemoteSystem },
+          responsibilityState: promptState,
+        })
+        setSelectedStartOfDayAction(defaultAction)
+        setStep('start_of_day')
         return
       }
 
@@ -265,6 +310,7 @@ function LoginPageContent() {
         persistSelection({ id: data.remoteSystemId })
       }
 
+      resetStartOfDayState()
       setAuth(data.member, data.token)
       const nextDestination = postLoginDestination
       if (data.member.mustChangePin) {
@@ -277,6 +323,18 @@ function LoginPageContent() {
     } finally {
       setLoading(false)
     }
+  }
+
+  const handleStartOfDaySubmit = async () => {
+    if (!startOfDayState || !selectedStartOfDayAction) {
+      setError('Choose how you are opening the unit before signing in')
+      return
+    }
+
+    await handlePinSubmit({
+      ...startOfDayState.pinSubmission,
+      startOfDayAction: selectedStartOfDayAction,
+    })
   }
 
   const handleSetupSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -510,6 +568,129 @@ function LoginPageContent() {
                   forceKioskRemoteSystem={isKioskDestination(postLoginDestination)}
                 />
               )}
+
+              {step === 'start_of_day' &&
+                startOfDayState &&
+                (() => {
+                  const presentation = getKioskResponsibilityPromptPresentation(
+                    startOfDayState.responsibilityState
+                  )
+
+                  return (
+                    <div className="space-y-(--space-4)" data-testid={TID.auth.startOfDayPrompt}>
+                      <div
+                        role="alert"
+                        className={`alert ${presentation.bannerTone === 'info' ? 'alert-info' : 'alert-warning'} alert-soft`}
+                      >
+                        <div className="space-y-(--space-1)">
+                          <div className="font-semibold">{presentation.bannerTitle}</div>
+                          <div>{presentation.bannerDescription}</div>
+                        </div>
+                      </div>
+
+                      <div className="rounded-box border border-base-300 bg-base-200/40 p-(--space-3)">
+                        <div className="flex flex-wrap items-center gap-(--space-2)">
+                          <AppBadge status="warning" size="sm">
+                            First member today
+                          </AppBadge>
+                          <AppBadge status="neutral" size="sm">
+                            {badgeSerial}
+                          </AppBadge>
+                        </div>
+                        <p className="mt-(--space-3) text-sm font-medium text-base-content">
+                          {startOfDayState.responsibilityState.member.rank}{' '}
+                          {startOfDayState.responsibilityState.member.lastName},{' '}
+                          {startOfDayState.responsibilityState.member.firstName}
+                        </p>
+                        <p className="mt-(--space-1) text-sm text-base-content/70">
+                          {presentation.headline}
+                        </p>
+                        <p className="mt-(--space-1) text-sm text-base-content/70">
+                          {presentation.helperText}
+                        </p>
+                      </div>
+
+                      <fieldset className="fieldset rounded-box border border-base-300 bg-base-200/70 p-(--space-4)">
+                        <legend className="fieldset-legend px-(--space-2)">
+                          Choose how you are opening the unit
+                        </legend>
+                        <div className="space-y-(--space-3)">
+                          {presentation.actionOptions.map((option) => {
+                            const loginAction = mapResponsibilityActionToLoginAction(option.value)
+                            const checked = selectedStartOfDayAction === loginAction
+
+                            return (
+                              <label
+                                key={option.value}
+                                className={`flex cursor-pointer items-start gap-(--space-3) rounded-box border p-(--space-3) transition-colors ${
+                                  checked
+                                    ? 'border-primary bg-primary-fadded text-primary-fadded-content'
+                                    : 'border-base-300 bg-base-100'
+                                }`}
+                                data-testid={TID.auth.startOfDayOption(option.value)}
+                              >
+                                <input
+                                  type="radio"
+                                  name="start-of-day-action"
+                                  className="radio radio-primary mt-[2px]"
+                                  checked={checked}
+                                  onChange={() => setSelectedStartOfDayAction(loginAction)}
+                                  disabled={loading}
+                                />
+                                <div className="space-y-(--space-1)">
+                                  <div className="font-semibold">{option.title}</div>
+                                  <div className="text-sm opacity-80">{option.description}</div>
+                                  <div className="text-xs opacity-70">
+                                    {getResponsibilitySummary(
+                                      startOfDayState.responsibilityState,
+                                      option.value
+                                    )}
+                                  </div>
+                                </div>
+                              </label>
+                            )
+                          })}
+                        </div>
+                        {presentation.blockedMessage && (
+                          <p className="label text-error">{presentation.blockedMessage}</p>
+                        )}
+                      </fieldset>
+
+                      <div className="grid grid-cols-2 gap-(--space-2)">
+                        <button
+                          type="button"
+                          className="btn btn-ghost"
+                          onClick={() => {
+                            resetStartOfDayState()
+                            setStep('pin')
+                          }}
+                          disabled={loading}
+                          data-testid={TID.auth.startOfDayBack}
+                        >
+                          Back
+                        </button>
+                        <button
+                          type="button"
+                          className="btn btn-primary"
+                          onClick={handleStartOfDaySubmit}
+                          disabled={loading || !selectedStartOfDayAction}
+                          data-testid={TID.auth.startOfDaySubmit}
+                        >
+                          {loading ? (
+                            <span className="loading loading-spinner loading-sm" />
+                          ) : (
+                            getResponsibilityPrimaryLabel(
+                              startOfDayState.responsibilityState,
+                              selectedStartOfDayAction === 'open_and_accept_dds'
+                                ? 'accept_dds'
+                                : 'open_building'
+                            )
+                          )}
+                        </button>
+                      </div>
+                    </div>
+                  )
+                })()}
             </div>
           </AppCardContent>
         </AppCard>

--- a/apps/frontend-admin/src/lib/test-ids.ts
+++ b/apps/frontend-admin/src/lib/test-ids.ts
@@ -12,6 +12,10 @@ export const TID = {
     setupPinInput: 'auth-setup-pin-input',
     setupPinConfirmInput: 'auth-setup-pin-confirm-input',
     setupPinSubmit: 'auth-setup-pin-submit',
+    startOfDayPrompt: 'auth-start-of-day-prompt',
+    startOfDayOption: (value: string) => `auth-start-of-day-option-${value}`,
+    startOfDaySubmit: 'auth-start-of-day-submit',
+    startOfDayBack: 'auth-start-of-day-back',
   },
   nav: {
     logo: 'nav-logo',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/contracts/src/contracts/auth.contract.ts
+++ b/packages/contracts/src/contracts/auth.contract.ts
@@ -11,6 +11,7 @@ import {
   AuthMessageSchema,
   AuthErrorSchema,
   HeartbeatResponseSchema,
+  LoginStartOfDayRequiredSchema,
 } from '../schemas/auth.schema.js'
 
 const c = initContract()
@@ -44,6 +45,7 @@ export const authContract = c.router({
       400: AuthErrorSchema,
       401: AuthErrorSchema,
       403: AuthErrorSchema,
+      409: LoginStartOfDayRequiredSchema,
       429: AuthErrorSchema,
       500: AuthErrorSchema,
     },

--- a/packages/contracts/src/schemas/auth.schema.ts
+++ b/packages/contracts/src/schemas/auth.schema.ts
@@ -1,9 +1,11 @@
 import * as v from 'valibot'
+import { KioskResponsibilityStateResponseSchema } from './dds.schema.js'
 
 export const DISALLOWED_MEMBER_PINS = ['0000', '1111', '1234', '4321'] as const
 
 export const LoginPinStateValues = ['configured', 'setup_required'] as const
 export const LoginPinSetupReasonValues = ['missing', 'default'] as const
+export const LoginStartOfDayActionValues = ['open_only', 'open_and_accept_dds'] as const
 
 function isAllowedMemberPin(value: string): boolean {
   return !DISALLOWED_MEMBER_PINS.includes(value as (typeof DISALLOWED_MEMBER_PINS)[number])
@@ -40,6 +42,9 @@ export const LoginRequestSchema = v.object({
     v.pipe(v.string('Remote system is required'), v.uuid('Invalid remote system ID'))
   ),
   useKioskRemoteSystem: v.optional(v.boolean('Kiosk mode flag must be a boolean')),
+  startOfDayAction: v.optional(
+    v.picklist(LoginStartOfDayActionValues, 'Choose a valid start-of-day action')
+  ),
 })
 
 export const LoginRequestWithRemoteSystemSchema = v.pipe(
@@ -52,6 +57,8 @@ export const LoginRequestWithRemoteSystemSchema = v.pipe(
 )
 
 export type LoginRequest = v.InferOutput<typeof LoginRequestWithRemoteSystemSchema>
+export const LoginStartOfDayActionSchema = v.picklist(LoginStartOfDayActionValues)
+export type LoginStartOfDayAction = v.InferOutput<typeof LoginStartOfDayActionSchema>
 
 /**
  * Authenticated member info returned in login and session responses
@@ -177,3 +184,11 @@ export const AuthErrorSchema = v.object({
   error: v.string(),
   message: v.string(),
 })
+
+export const LoginStartOfDayRequiredSchema = v.object({
+  error: v.literal('START_OF_DAY_ACTION_REQUIRED'),
+  message: v.string(),
+  responsibilityState: KioskResponsibilityStateResponseSchema,
+})
+
+export type LoginStartOfDayRequired = v.InferOutput<typeof LoginStartOfDayRequiredSchema>

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary
- require the first member opening Sentinel for the day to choose how the unit is being opened before login completes
- support two explicit paths: open the unit only, or open the unit and accept DDS
- reuse the existing lockup and DDS flows after login check-in succeeds
- bump workspace versions to 2.4.4 for release tagging

## Testing
- pnpm version:check
- pnpm --filter @sentinel/contracts build
- pnpm --filter @sentinel/backend typecheck
- pnpm --filter frontend-admin typecheck
- playwright-cli visual check of the new login prompt at 1920x1080 (mocked first-member auth response)

## Notes
- backend auth service tests were updated for the new gate, but could not be executed directly in this workspace because vitest is not installed in the backend package and frontend-scoped vitest would not discover backend files