### PR TITLE
fix(ci): unblock build/test on network-settings route typing

### DIFF
--- a/apps/backend/src/routes/network-settings.ts
+++ b/apps/backend/src/routes/network-settings.ts
@@ -43,6 +43,20 @@ function requireAdmin(req: Request) {
   return null
 }
 
+function getRequestedRemoteSystemName(req: Request): string | null {
+  const sessionValue = (req as Request & { session?: unknown }).session
+  if (!sessionValue || typeof sessionValue !== 'object') {
+    return null
+  }
+
+  const remoteSystemName = (sessionValue as { remoteSystemName?: unknown }).remoteSystemName
+  if (typeof remoteSystemName !== 'string' || remoteSystemName.trim().length === 0) {
+    return null
+  }
+
+  return remoteSystemName.trim()
+}
+
 export const networkSettingsRouter = s.router(networkSettingContract, {
   getNetworkSettings: async ({ req }) => {
     const auth = requireMember(req)
@@ -107,7 +121,7 @@ export const networkSettingsRouter = s.router(networkSettingContract, {
           req.member !== undefined
             ? `${req.member.rank} ${req.member.firstName} ${req.member.lastName}`
             : 'Unknown member',
-        requestedByRemoteSystemName: req.session?.remoteSystemName ?? null,
+        requestedByRemoteSystemName: getRequestedRemoteSystemName(req),
         requestedFromIp: getRequestClientIp(req),
         requestedFromUserAgent: Array.isArray(userAgentHeader)
           ? (userAgentHeader[0] ?? null)


### PR DESCRIPTION
## Why
Build #212 and Test #212 failed with TS2339 because req.session is not part of the ts-rest request type in network-settings route handlers.

## What
- add a narrow helper to read optional session metadata safely from Request
- replace direct req.session?.remoteSystemName access with helper usage

## Result
- keeps queued host-hotspot recovery payload behavior
- removes the compile-time type error that blocked CI
