### PR TITLE
fix(ci): correct host hotspot recovery client call signature

### DIFF
--- a/apps/frontend-admin/src/hooks/use-network-settings.ts
+++ b/apps/frontend-admin/src/hooks/use-network-settings.ts
@@ -60,9 +60,7 @@ export function useHostHotspotRecovery() {
 
   return useMutation({
     mutationFn: async () => {
-      const response = await apiClient.networkSettings.hostHotspotRecovery({
-        body: undefined,
-      })
+      const response = await apiClient.networkSettings.hostHotspotRecovery()
 
       if (response.status !== 202) {
         throw new Error(getErrorMessage(response.body, 'Failed to queue host hotspot recovery'))


### PR DESCRIPTION
## Why
Build/Test still failed after PR #98 due to frontend typecheck: the ts-rest client method for host hotspot recovery does not accept a body field.

## What
- remove the invalid `body: undefined` payload from `hostHotspotRecovery()` call
- keep behavior unchanged (same endpoint, same mutation handling)

## Result
- unblocks Next.js/TypeScript build for apps/frontend-admin
