### PR TITLE
feat(settings): add event type settings management

### DIFF
--- a/apps/backend/src/repositories/unit-event-repository.ts
+++ b/apps/backend/src/repositories/unit-event-repository.ts
@@ -306,7 +306,11 @@ export class UnitEventRepository {
       category: input.category,
       defaultDurationMinutes: input.defaultDurationMinutes,
       requiresDutyWatch: input.requiresDutyWatch ?? false,
-      defaultMetadata: input.defaultMetadata,
+      defaultMetadata: input.defaultMetadata === null
+        ? Prisma.JsonNull
+        : input.defaultMetadata !== undefined
+          ? (input.defaultMetadata as Prisma.InputJsonValue)
+          : undefined,
       displayOrder: input.displayOrder ?? 0,
     }
 
@@ -326,7 +330,11 @@ export class UnitEventRepository {
       data.defaultDurationMinutes = input.defaultDurationMinutes
     }
     if (input.requiresDutyWatch !== undefined) data.requiresDutyWatch = input.requiresDutyWatch
-    if (input.defaultMetadata !== undefined) data.defaultMetadata = input.defaultMetadata
+    if (input.defaultMetadata !== undefined) {
+      data.defaultMetadata = input.defaultMetadata === null
+        ? Prisma.JsonNull
+        : (input.defaultMetadata as Prisma.InputJsonValue)
+    }
     if (input.displayOrder !== undefined) data.displayOrder = input.displayOrder
 
     const type = await this.prisma.unitEventType.update({

--- a/apps/backend/src/repositories/unit-event-repository.ts
+++ b/apps/backend/src/repositories/unit-event-repository.ts
@@ -132,6 +132,24 @@ export interface UpdateUnitEventInput {
   notes?: string | null
 }
 
+export interface CreateUnitEventTypeInput {
+  name: string
+  category: string
+  defaultDurationMinutes: number
+  requiresDutyWatch?: boolean
+  defaultMetadata?: Record<string, unknown> | null
+  displayOrder?: number
+}
+
+export interface UpdateUnitEventTypeInput {
+  name?: string
+  category?: string
+  defaultDurationMinutes?: number
+  requiresDutyWatch?: boolean
+  defaultMetadata?: Record<string, unknown> | null
+  displayOrder?: number
+}
+
 /**
  * Unit event list filter options
  */
@@ -265,6 +283,77 @@ export class UnitEventRepository {
       where: { id },
     })
     return type
+  }
+
+  /**
+   * Find an event type by exact case-insensitive name
+   */
+  async findEventTypeByName(name: string): Promise<UnitEventTypeEntity | null> {
+    const type = await this.prisma.unitEventType.findFirst({
+      where: {
+        name: { equals: name, mode: 'insensitive' },
+      },
+    })
+    return type
+  }
+
+  /**
+   * Create an event type
+   */
+  async createEventType(input: CreateUnitEventTypeInput): Promise<UnitEventTypeEntity> {
+    const data: Prisma.UnitEventTypeCreateInput = {
+      name: input.name,
+      category: input.category,
+      defaultDurationMinutes: input.defaultDurationMinutes,
+      requiresDutyWatch: input.requiresDutyWatch ?? false,
+      defaultMetadata: input.defaultMetadata,
+      displayOrder: input.displayOrder ?? 0,
+    }
+
+    const type = await this.prisma.unitEventType.create({ data })
+    return type
+  }
+
+  /**
+   * Update an event type
+   */
+  async updateEventType(id: string, input: UpdateUnitEventTypeInput): Promise<UnitEventTypeEntity> {
+    const data: Prisma.UnitEventTypeUpdateInput = {}
+
+    if (input.name !== undefined) data.name = input.name
+    if (input.category !== undefined) data.category = input.category
+    if (input.defaultDurationMinutes !== undefined) {
+      data.defaultDurationMinutes = input.defaultDurationMinutes
+    }
+    if (input.requiresDutyWatch !== undefined) data.requiresDutyWatch = input.requiresDutyWatch
+    if (input.defaultMetadata !== undefined) data.defaultMetadata = input.defaultMetadata
+    if (input.displayOrder !== undefined) data.displayOrder = input.displayOrder
+
+    const type = await this.prisma.unitEventType.update({
+      where: { id },
+      data,
+    })
+
+    return type
+  }
+
+  /**
+   * Delete an event type
+   */
+  async deleteEventType(id: string): Promise<void> {
+    await this.prisma.unitEventType.delete({
+      where: { id },
+    })
+  }
+
+  /**
+   * Count events associated with an event type
+   */
+  async countEventsForEventType(eventTypeId: string): Promise<number> {
+    const count = await this.prisma.unitEvent.count({
+      where: { eventTypeId },
+    })
+    return count
   }
 
   // ==========================================================================

--- a/apps/backend/src/routes/unit-events.ts
+++ b/apps/backend/src/routes/unit-events.ts
@@ -2,9 +2,12 @@ import { initServer } from '@ts-rest/express'
 import { unitEventContract } from '@sentinel/contracts'
 import type {
   UnitEventListQuery,
+  UnitEventTypeIdParam,
   UnitEventIdParam,
   UnitEventPositionParams,
   UnitEventAssignmentParams,
+  CreateUnitEventTypeInput,
+  UpdateUnitEventTypeInput,
   CreateUnitEventInput,
   UpdateUnitEventInput,
   UpdateUnitEventStatusInput,
@@ -254,6 +257,62 @@ export const unitEventsRouter = s.router(unitEventContract, {
       return {
         status: 200 as const,
         body: { data: types.map(eventTypeToApiFormat) },
+      }
+    } catch (error) {
+      return handleError(error)
+    }
+  },
+
+  createEventType: async ({ body }: { body: CreateUnitEventTypeInput }) => {
+    try {
+      const created = await unitEventService.createEventType({
+        name: body.name,
+        category: body.category,
+        defaultDurationMinutes: body.defaultDurationMinutes,
+        requiresDutyWatch: body.requiresDutyWatch,
+        defaultMetadata: body.defaultMetadata ?? null,
+        displayOrder: body.displayOrder,
+      })
+      return {
+        status: 201 as const,
+        body: eventTypeToApiFormat(created),
+      }
+    } catch (error) {
+      return handleError(error)
+    }
+  },
+
+  updateEventType: async ({
+    params,
+    body,
+  }: {
+    params: UnitEventTypeIdParam
+    body: UpdateUnitEventTypeInput
+  }) => {
+    try {
+      const updated = await unitEventService.updateEventType(params.id, {
+        name: body.name,
+        category: body.category,
+        defaultDurationMinutes: body.defaultDurationMinutes,
+        requiresDutyWatch: body.requiresDutyWatch,
+        defaultMetadata: body.defaultMetadata,
+        displayOrder: body.displayOrder,
+      })
+      return {
+        status: 200 as const,
+        body: eventTypeToApiFormat(updated),
+      }
+    } catch (error) {
+      return handleError(error)
+    }
+  },
+
+  deleteEventType: async ({ params }: { params: UnitEventTypeIdParam }) => {
+    try {
+      await unitEventService.deleteEventType(params.id)
+      return {
+        status: 200 as const,
+        body: { success: true, message: 'Event type deleted successfully' },
       }
     } catch (error) {
       return handleError(error)

--- a/apps/backend/src/services/unit-event-service.ts
+++ b/apps/backend/src/services/unit-event-service.ts
@@ -8,6 +8,8 @@ import {
   type UnitEventDutyPositionEntity,
   type UnitEventDutyAssignmentEntity,
   type UnitEventListFilter,
+  type CreateUnitEventTypeInput,
+  type UpdateUnitEventTypeInput,
   type CreateUnitEventInput,
   type UpdateUnitEventInput,
 } from '../repositories/unit-event-repository.js'
@@ -52,6 +54,52 @@ export class UnitEventService {
 
   async getAllEventTypes(): Promise<UnitEventTypeEntity[]> {
     return this.repository.findAllEventTypes()
+  }
+
+  async createEventType(input: CreateUnitEventTypeInput): Promise<UnitEventTypeEntity> {
+    const name = input.name.trim()
+    const existing = await this.repository.findEventTypeByName(name)
+    if (existing) {
+      throw new ConflictError(`Event type '${name}' already exists`)
+    }
+
+    return this.repository.createEventType({
+      ...input,
+      name,
+    })
+  }
+
+  async updateEventType(id: string, input: UpdateUnitEventTypeInput): Promise<UnitEventTypeEntity> {
+    const existing = await this.repository.findEventTypeById(id)
+    if (!existing) {
+      throw new NotFoundError('Unit Event Type', id)
+    }
+
+    let normalizedInput = input
+    if (input.name !== undefined) {
+      const normalizedName = input.name.trim()
+      const duplicate = await this.repository.findEventTypeByName(normalizedName)
+      if (duplicate && duplicate.id !== id) {
+        throw new ConflictError(`Event type '${normalizedName}' already exists`)
+      }
+      normalizedInput = { ...input, name: normalizedName }
+    }
+
+    return this.repository.updateEventType(id, normalizedInput)
+  }
+
+  async deleteEventType(id: string): Promise<void> {
+    const existing = await this.repository.findEventTypeById(id)
+    if (!existing) {
+      throw new NotFoundError('Unit Event Type', id)
+    }
+
+    const usageCount = await this.repository.countEventsForEventType(id)
+    if (usageCount > 0) {
+      throw new ConflictError('Cannot delete event type that is already used by one or more events')
+    }
+
+    await this.repository.deleteEventType(id)
   }
 
   // ==========================================================================

--- a/apps/frontend-admin/src/app/settings/page.tsx
+++ b/apps/frontend-admin/src/app/settings/page.tsx
@@ -4,6 +4,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { AccountLevelSettingsPanel } from '@/components/settings/account-level-settings-panel'
 import { DashboardPersonCardSortSettingsPanel } from '@/components/settings/dashboard-person-card-sort-settings-panel'
 import { EnumTable } from '@/components/settings/enum-table'
+import { EventTypeTable } from '@/components/settings/event-type-table'
 import { QualificationTypeTable } from '@/components/settings/qualification-type-table'
 import { NetworkSettingsPanel } from '@/components/settings/network-settings-panel'
 import { StatHolidayTable } from '@/components/settings/stat-holiday-table'
@@ -19,6 +20,7 @@ import {
   Award,
   ArrowUpDown,
   Calendar,
+  CalendarClock,
   Clock3,
   Wifi,
 } from 'lucide-react'
@@ -43,6 +45,14 @@ export default function SettingsPage() {
           <TabsTrigger value="visit-types" className="flex items-center gap-2">
             <Building className="h-4 w-4" />
             <span className="hidden sm:inline">Visit Types</span>
+          </TabsTrigger>
+          <TabsTrigger
+            value="event-types"
+            className="flex items-center gap-2"
+            data-testid={TID.settings.eventTypes.tab}
+          >
+            <CalendarClock className="h-4 w-4" />
+            <span className="hidden sm:inline">Event Types</span>
           </TabsTrigger>
           <TabsTrigger value="qualifications" className="flex items-center gap-2">
             <Award className="h-4 w-4" />
@@ -111,6 +121,13 @@ export default function SettingsPage() {
             enumType="visit-types"
             title="Visit Types"
             description="Categories for visitor classification"
+          />
+        </TabsContent>
+
+        <TabsContent value="event-types">
+          <EventTypeTable
+            title="Event Types"
+            description="Templates for event category, default duration, and duty-watch defaults"
           />
         </TabsContent>
 

--- a/apps/frontend-admin/src/components/settings/event-type-form-modal.tsx
+++ b/apps/frontend-admin/src/components/settings/event-type-form-modal.tsx
@@ -1,0 +1,297 @@
+'use client'
+
+import { useEffect, useMemo } from 'react'
+import { useForm } from 'react-hook-form'
+import { ButtonSpinner } from '@/components/ui/loading-spinner'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  useCreateEventType,
+  useUpdateEventType,
+  type EventTypeInput,
+} from '@/hooks/use-events'
+import type { UnitEventCategory, UnitEventTypeResponse } from '@sentinel/contracts'
+
+interface EventTypeFormModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  mode: 'create' | 'edit'
+  item?: UnitEventTypeResponse | null
+}
+
+interface FormValues {
+  name: string
+  category: UnitEventCategory
+  defaultDurationMinutes: number
+  requiresDutyWatch: boolean
+  displayOrder: number
+  defaultMetadata: string
+}
+
+const CATEGORY_OPTIONS: Array<{ value: UnitEventCategory; label: string }> = [
+  { value: 'mess_dinner', label: 'Mess Dinner' },
+  { value: 'ceremonial', label: 'Ceremonial' },
+  { value: 'training', label: 'Training' },
+  { value: 'social', label: 'Social' },
+  { value: 'exercise', label: 'Exercise' },
+  { value: 'vip_visit', label: 'VIP Visit' },
+  { value: 'remembrance', label: 'Remembrance' },
+  { value: 'administrative', label: 'Administrative' },
+  { value: 'other', label: 'Other' },
+]
+
+function parseMetadata(raw: string): { value: Record<string, unknown> | null; error?: string } {
+  if (!raw.trim()) {
+    return { value: null }
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return {
+        value: null,
+        error: 'Metadata must be a JSON object.',
+      }
+    }
+    return { value: parsed as Record<string, unknown> }
+  } catch (_error) {
+    return {
+      value: null,
+      error: 'Metadata must be valid JSON.',
+    }
+  }
+}
+
+export function EventTypeFormModal({ open, onOpenChange, mode, item }: EventTypeFormModalProps) {
+  const createMutation = useCreateEventType()
+  const updateMutation = useUpdateEventType()
+
+  const form = useForm<FormValues>({
+    defaultValues: {
+      name: '',
+      category: 'training',
+      defaultDurationMinutes: 120,
+      requiresDutyWatch: false,
+      displayOrder: 0,
+      defaultMetadata: '',
+    },
+  })
+
+  useEffect(() => {
+    if (open && mode === 'edit' && item) {
+      form.reset({
+        name: item.name,
+        category: item.category,
+        defaultDurationMinutes: item.defaultDurationMinutes,
+        requiresDutyWatch: item.requiresDutyWatch,
+        displayOrder: item.displayOrder,
+        defaultMetadata: item.defaultMetadata ? JSON.stringify(item.defaultMetadata, null, 2) : '',
+      })
+      return
+    }
+
+    if (open && mode === 'create') {
+      form.reset({
+        name: '',
+        category: 'training',
+        defaultDurationMinutes: 120,
+        requiresDutyWatch: false,
+        displayOrder: 0,
+        defaultMetadata: '',
+      })
+    }
+  }, [open, mode, item, form])
+
+  const onSubmit = async (values: FormValues) => {
+    const metadataResult = parseMetadata(values.defaultMetadata)
+    if (metadataResult.error) {
+      form.setError('defaultMetadata', {
+        type: 'validate',
+        message: metadataResult.error,
+      })
+      return
+    }
+
+    const payload: EventTypeInput = {
+      name: values.name.trim(),
+      category: values.category,
+      defaultDurationMinutes: values.defaultDurationMinutes,
+      requiresDutyWatch: values.requiresDutyWatch,
+      displayOrder: values.displayOrder,
+      defaultMetadata: metadataResult.value,
+    }
+
+    try {
+      if (mode === 'edit' && item) {
+        await updateMutation.mutateAsync({ id: item.id, data: payload })
+      } else {
+        await createMutation.mutateAsync(payload)
+      }
+      onOpenChange(false)
+    } catch {
+      // Mutation state shows message
+    }
+  }
+
+  const isPending = createMutation.isPending || updateMutation.isPending
+  const mutationError = createMutation.error || updateMutation.error
+
+  const title = useMemo(() => {
+    return mode === 'edit' ? 'Edit Event Type' : 'Create Event Type'
+  }, [mode])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[560px]">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>
+            {mode === 'edit'
+              ? 'Update this event type template.'
+              : 'Add a new event type template for event creation.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          {mutationError && (
+            <div className="alert alert-error" role="alert">
+              <span>{mutationError.message}</span>
+            </div>
+          )}
+
+          <label className="form-control w-full">
+            <div className="label">
+              <span className="label-text">Name</span>
+            </div>
+            <input
+              className="input input-bordered w-full"
+              {...form.register('name', {
+                required: 'Name is required',
+                minLength: { value: 1, message: 'Name is required' },
+                maxLength: { value: 100, message: 'Name must be at most 100 characters' },
+              })}
+              disabled={isPending}
+            />
+            {form.formState.errors.name && (
+              <p className="mt-1 text-sm text-error">{form.formState.errors.name.message}</p>
+            )}
+          </label>
+
+          <label className="form-control w-full">
+            <div className="label">
+              <span className="label-text">Category</span>
+            </div>
+            <select
+              className="select select-bordered w-full"
+              {...form.register('category')}
+              disabled={isPending}
+            >
+              {CATEGORY_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <label className="form-control w-full">
+              <div className="label">
+                <span className="label-text">Default Duration (minutes)</span>
+              </div>
+              <input
+                type="number"
+                min={15}
+                max={1440}
+                className="input input-bordered w-full"
+                {...form.register('defaultDurationMinutes', {
+                  valueAsNumber: true,
+                  min: { value: 15, message: 'Minimum 15 minutes' },
+                  max: { value: 1440, message: 'Maximum 1440 minutes' },
+                })}
+                disabled={isPending}
+              />
+              {form.formState.errors.defaultDurationMinutes && (
+                <p className="mt-1 text-sm text-error">
+                  {form.formState.errors.defaultDurationMinutes.message}
+                </p>
+              )}
+            </label>
+
+            <label className="form-control w-full">
+              <div className="label">
+                <span className="label-text">Display Order</span>
+              </div>
+              <input
+                type="number"
+                min={0}
+                className="input input-bordered w-full"
+                {...form.register('displayOrder', {
+                  valueAsNumber: true,
+                  min: { value: 0, message: 'Display order must be 0 or greater' },
+                })}
+                disabled={isPending}
+              />
+              {form.formState.errors.displayOrder && (
+                <p className="mt-1 text-sm text-error">{form.formState.errors.displayOrder.message}</p>
+              )}
+            </label>
+          </div>
+
+          <label className="flex items-start gap-3 rounded-md border border-base-300 bg-base-200 p-3">
+            <Checkbox
+              checked={form.watch('requiresDutyWatch')}
+              onCheckedChange={(checked) => form.setValue('requiresDutyWatch', checked === true)}
+              disabled={isPending}
+            />
+            <span className="space-y-1">
+              <span className="block text-sm font-medium">Requires duty watch by default</span>
+              <span className="block text-xs text-base-content/60">
+                New events of this type will default to duty-watch enabled.
+              </span>
+            </span>
+          </label>
+
+          <label className="form-control w-full">
+            <div className="label">
+              <span className="label-text">Default Metadata (JSON)</span>
+            </div>
+            <textarea
+              className="textarea textarea-bordered h-32 w-full font-mono text-xs"
+              placeholder='{"positions": [{"code": "SWK", "name": "Senior Watchkeeper"}]}'
+              {...form.register('defaultMetadata')}
+              disabled={isPending}
+            />
+            <div className="label">
+              <span className="label-text-alt text-base-content/60">
+                Optional JSON object applied as defaults for this event type.
+              </span>
+            </div>
+            {form.formState.errors.defaultMetadata && (
+              <p className="mt-1 text-sm text-error">
+                {form.formState.errors.defaultMetadata.message}
+              </p>
+            )}
+          </label>
+
+          <DialogFooter>
+            <button type="button" className="btn btn-ghost" onClick={() => onOpenChange(false)} disabled={isPending}>
+              Cancel
+            </button>
+            <button type="submit" className="btn btn-primary" disabled={isPending}>
+              {isPending && <ButtonSpinner />}
+              {mode === 'edit' ? 'Save Changes' : 'Create Event Type'}
+            </button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/frontend-admin/src/components/settings/event-type-table.tsx
+++ b/apps/frontend-admin/src/components/settings/event-type-table.tsx
@@ -1,0 +1,194 @@
+'use client'
+
+import { useState } from 'react'
+import { Pencil, Plus, Trash2 } from 'lucide-react'
+import { LoadingSpinner, ButtonSpinner } from '@/components/ui/loading-spinner'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { AppBadge } from '@/components/ui/AppBadge'
+import { useDeleteEventType, useEventTypes } from '@/hooks/use-events'
+import { EventTypeFormModal } from './event-type-form-modal'
+import { TID } from '@/lib/test-ids'
+import type { UnitEventTypeResponse } from '@sentinel/contracts'
+
+interface EventTypeTableProps {
+  title: string
+  description: string
+}
+
+function formatCategory(category: UnitEventTypeResponse['category']): string {
+  return category
+    .split('_')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+export function EventTypeTable({ title, description }: EventTypeTableProps) {
+  const { data: eventTypes, isLoading, error } = useEventTypes()
+  const deleteMutation = useDeleteEventType()
+
+  const [isCreateOpen, setIsCreateOpen] = useState(false)
+  const [editingType, setEditingType] = useState<UnitEventTypeResponse | null>(null)
+  const [deletingType, setDeletingType] = useState<UnitEventTypeResponse | null>(null)
+
+  const handleDelete = async () => {
+    if (!deletingType) return
+
+    try {
+      await deleteMutation.mutateAsync(deletingType.id)
+      setDeletingType(null)
+    } catch {
+      // mutation state handled in dialog
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <LoadingSpinner size="md" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return <div className="py-8 text-center text-error">Failed to load event types</div>
+  }
+
+  const rows = eventTypes ?? []
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-lg font-semibold">{title}</h3>
+          <p className="text-sm text-base-content/60">{description}</p>
+        </div>
+        <button
+          className="btn btn-primary btn-md"
+          onClick={() => setIsCreateOpen(true)}
+          data-testid={TID.settings.eventTypes.addBtn}
+        >
+          <Plus className="mr-2 h-4 w-4" />
+          Add New
+        </button>
+      </div>
+
+      <div className="border">
+        <div className="relative w-full overflow-x-auto">
+          <table className="table">
+            <thead>
+              <tr className="hover">
+                <th className="whitespace-nowrap font-medium text-base-content">Name</th>
+                <th className="whitespace-nowrap font-medium text-base-content">Category</th>
+                <th className="whitespace-nowrap font-medium text-base-content text-right">Duration</th>
+                <th className="whitespace-nowrap font-medium text-base-content text-center">Duty Watch</th>
+                <th className="whitespace-nowrap font-medium text-base-content text-right">Order</th>
+                <th className="w-[100px] whitespace-nowrap font-medium text-base-content">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.length > 0 ? (
+                rows.map((item) => (
+                  <tr key={item.id} className="hover">
+                    <td className="whitespace-nowrap font-medium">{item.name}</td>
+                    <td className="whitespace-nowrap">{formatCategory(item.category)}</td>
+                    <td className="whitespace-nowrap text-right">{item.defaultDurationMinutes} min</td>
+                    <td className="whitespace-nowrap text-center">
+                      {item.requiresDutyWatch ? (
+                        <AppBadge status="warning" size="sm">
+                          Required
+                        </AppBadge>
+                      ) : (
+                        <span className="text-base-content/40">-</span>
+                      )}
+                    </td>
+                    <td className="whitespace-nowrap text-right">{item.displayOrder}</td>
+                    <td className="whitespace-nowrap">
+                      <div className="flex items-center gap-1">
+                        <button
+                          className="btn btn-ghost btn-square btn-md"
+                          onClick={() => setEditingType(item)}
+                          data-testid={TID.settings.eventTypes.editBtn(item.id)}
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </button>
+                        <button
+                          className="btn btn-ghost btn-square btn-md"
+                          onClick={() => setDeletingType(item)}
+                          data-testid={TID.settings.eventTypes.deleteBtn(item.id)}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr className="hover">
+                  <td colSpan={6} className="whitespace-nowrap py-8 text-center text-base-content/60">
+                    No event types found. Click "Add New" to create one.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <EventTypeFormModal
+        open={isCreateOpen || !!editingType}
+        onOpenChange={(open) => {
+          if (!open) {
+            setIsCreateOpen(false)
+            setEditingType(null)
+          }
+        }}
+        mode={editingType ? 'edit' : 'create'}
+        item={editingType}
+      />
+
+      <AlertDialog open={!!deletingType} onOpenChange={(open) => !open && setDeletingType(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete {deletingType?.name}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone. Existing events will lose this type reference.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          {deleteMutation.error && (
+            <div className="alert alert-error" role="alert">
+              <span>{deleteMutation.error.message}</span>
+            </div>
+          )}
+
+          <AlertDialogFooter>
+            <AlertDialogCancel data-testid={TID.settings.eventTypes.deleteCancel}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={deleteMutation.isPending}
+              className="bg-error text-error-content hover:bg-error/90"
+              data-testid={TID.settings.eventTypes.deleteConfirm}
+            >
+              {deleteMutation.isPending ? (
+                <>
+                  <ButtonSpinner /> Deleting...
+                </>
+              ) : (
+                'Delete'
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/apps/frontend-admin/src/hooks/use-events.ts
+++ b/apps/frontend-admin/src/hooks/use-events.ts
@@ -82,7 +82,6 @@ export function useDeleteEventType() {
     mutationFn: async (id: string) => {
       const response = await apiClient.unitEvents.deleteEventType({
         params: { id },
-        body: undefined,
       })
       if (response.status !== 200) {
         const errorBody = response.body as { error?: string; message?: string }

--- a/apps/frontend-admin/src/hooks/use-events.ts
+++ b/apps/frontend-admin/src/hooks/use-events.ts
@@ -3,6 +3,8 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { apiClient } from '@/lib/api-client'
 import type {
+  CreateUnitEventTypeInput,
+  UpdateUnitEventTypeInput,
   CreateUnitEventInput,
   UpdateUnitEventInput,
   CreateUnitEventPositionInput,
@@ -11,6 +13,8 @@ import type {
   UnitEventStatus,
   UnitEventCategory,
 } from '@sentinel/contracts'
+
+export type EventTypeInput = CreateUnitEventTypeInput
 
 // ============================================================================
 // Event Types
@@ -27,6 +31,68 @@ export function useEventTypes() {
       return response.body.data
     },
     staleTime: 10 * 60 * 1000, // 10 minutes - event types rarely change
+  })
+}
+
+export function useCreateEventType() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (data: CreateUnitEventTypeInput) => {
+      const response = await apiClient.unitEvents.createEventType({
+        body: data,
+      })
+      if (response.status !== 201) {
+        const errorBody = response.body as { error?: string; message?: string }
+        throw new Error(errorBody?.message || 'Failed to create event type')
+      }
+      return response.body
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['event-types'] })
+    },
+  })
+}
+
+export function useUpdateEventType() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ id, data }: { id: string; data: UpdateUnitEventTypeInput }) => {
+      const response = await apiClient.unitEvents.updateEventType({
+        params: { id },
+        body: data,
+      })
+      if (response.status !== 200) {
+        const errorBody = response.body as { error?: string; message?: string }
+        throw new Error(errorBody?.message || 'Failed to update event type')
+      }
+      return response.body
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['event-types'] })
+    },
+  })
+}
+
+export function useDeleteEventType() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const response = await apiClient.unitEvents.deleteEventType({
+        params: { id },
+        body: undefined,
+      })
+      if (response.status !== 200) {
+        const errorBody = response.body as { error?: string; message?: string }
+        throw new Error(errorBody?.message || 'Failed to delete event type')
+      }
+      return response.body
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['event-types'] })
+    },
   })
 }
 

--- a/apps/frontend-admin/src/lib/test-ids.ts
+++ b/apps/frontend-admin/src/lib/test-ids.ts
@@ -182,6 +182,14 @@ export const TID = {
       remoteSystemSubmit: 'settings-network-remote-system-submit',
       remoteSystemCancel: 'settings-network-remote-system-cancel',
     },
+    eventTypes: {
+      tab: 'settings-event-types-tab',
+      addBtn: 'settings-event-types-add-btn',
+      editBtn: (id: string) => `settings-event-types-edit-${id}`,
+      deleteBtn: (id: string) => `settings-event-types-delete-${id}`,
+      deleteConfirm: 'settings-event-types-delete-confirm',
+      deleteCancel: 'settings-event-types-delete-cancel',
+    },
     timings: {
       tab: 'settings-timings-tab',
       form: 'settings-timings-form',

--- a/deploy/_common.sh
+++ b/deploy/_common.sh
@@ -350,9 +350,17 @@ SNAPSHOT
 upsert_env() {
   local key="${1}" value="${2}" file="${3:-$ENV_FILE}"
   if grep -qE "^${key}=" "${file}"; then
-    sed -i "s#^${key}=.*#${key}=${value}#" "${file}"
+    if [[ -w "${file}" && -w "$(dirname "${file}")" ]]; then
+      sed -i "s#^${key}=.*#${key}=${value}#" "${file}"
+    else
+      run_root sed -i "s#^${key}=.*#${key}=${value}#" "${file}"
+    fi
   else
-    printf '%s=%s\n' "${key}" "${value}" >>"${file}"
+    if [[ -w "${file}" ]]; then
+      printf '%s=%s\n' "${key}" "${value}" >>"${file}"
+    else
+      printf '%s=%s\n' "${key}" "${value}" | run_root tee -a "${file}" >/dev/null
+    fi
   fi
 }
 

--- a/packages/contracts/src/contracts/unit-event.contract.ts
+++ b/packages/contracts/src/contracts/unit-event.contract.ts
@@ -1,10 +1,13 @@
 import { initContract } from '@ts-rest/core'
 import {
   UnitEventTypeListResponseSchema,
+  UnitEventTypeResponseSchema,
   UnitEventWithDetailsResponseSchema,
   UnitEventListResponseSchema,
   UnitEventDutyPositionResponseSchema,
   UnitEventDutyAssignmentResponseSchema,
+  CreateUnitEventTypeInputSchema,
+  UpdateUnitEventTypeInputSchema,
   CreateUnitEventInputSchema,
   UpdateUnitEventInputSchema,
   UpdateUnitEventStatusInputSchema,
@@ -12,6 +15,7 @@ import {
   UpdateUnitEventPositionInputSchema,
   CreateUnitEventAssignmentInputSchema,
   UnitEventListQuerySchema,
+  UnitEventTypeIdParamSchema,
   UnitEventIdParamSchema,
   UnitEventPositionParamsSchema,
   UnitEventAssignmentParamsSchema,
@@ -44,6 +48,63 @@ export const unitEventContract = c.router({
     },
     summary: 'List event types',
     description: 'Get all event type templates (mess dinner, ceremonial, etc.)',
+  },
+
+  /**
+   * Create event type template
+   */
+  createEventType: {
+    method: 'POST',
+    path: '/api/unit-events/types',
+    body: CreateUnitEventTypeInputSchema,
+    responses: {
+      201: UnitEventTypeResponseSchema,
+      400: ErrorResponseSchema,
+      401: ErrorResponseSchema,
+      409: ErrorResponseSchema,
+      500: ErrorResponseSchema,
+    },
+    summary: 'Create event type',
+    description: 'Create a new unit event type template used by event creation workflows',
+  },
+
+  /**
+   * Update event type template
+   */
+  updateEventType: {
+    method: 'PATCH',
+    path: '/api/unit-events/types/:id',
+    pathParams: UnitEventTypeIdParamSchema,
+    body: UpdateUnitEventTypeInputSchema,
+    responses: {
+      200: UnitEventTypeResponseSchema,
+      400: ErrorResponseSchema,
+      401: ErrorResponseSchema,
+      404: ErrorResponseSchema,
+      409: ErrorResponseSchema,
+      500: ErrorResponseSchema,
+    },
+    summary: 'Update event type',
+    description: 'Update a unit event type template',
+  },
+
+  /**
+   * Delete event type template
+   */
+  deleteEventType: {
+    method: 'DELETE',
+    path: '/api/unit-events/types/:id',
+    pathParams: UnitEventTypeIdParamSchema,
+    body: c.type<undefined>(),
+    responses: {
+      200: c.type<{ success: boolean; message: string }>(),
+      401: ErrorResponseSchema,
+      404: ErrorResponseSchema,
+      409: ErrorResponseSchema,
+      500: ErrorResponseSchema,
+    },
+    summary: 'Delete event type',
+    description: 'Delete a unit event type template',
   },
 
   // ==========================================================================

--- a/packages/contracts/src/schemas/unit-event.schema.ts
+++ b/packages/contracts/src/schemas/unit-event.schema.ts
@@ -32,6 +32,48 @@ export const UnitEventTypeListResponseSchema = v.object({
   data: v.array(UnitEventTypeResponseSchema),
 })
 
+export const CreateUnitEventTypeInputSchema = v.object({
+  name: v.pipe(
+    v.string('Event type name is required'),
+    v.minLength(1, 'Event type name cannot be empty'),
+    v.maxLength(100, 'Event type name must be at most 100 characters')
+  ),
+  category: UnitEventCategorySchema,
+  defaultDurationMinutes: v.pipe(
+    v.number('Default duration is required'),
+    v.minValue(15, 'Default duration must be at least 15 minutes'),
+    v.maxValue(1440, 'Default duration must be at most 1440 minutes')
+  ),
+  requiresDutyWatch: v.optional(v.boolean()),
+  defaultMetadata: v.optional(v.nullable(v.record(v.string(), v.unknown()))),
+  displayOrder: v.optional(
+    v.pipe(v.number(), v.minValue(0, 'Display order must be 0 or greater'))
+  ),
+})
+
+export const UpdateUnitEventTypeInputSchema = v.object({
+  name: v.optional(
+    v.pipe(
+      v.string(),
+      v.minLength(1, 'Event type name cannot be empty'),
+      v.maxLength(100, 'Event type name must be at most 100 characters')
+    )
+  ),
+  category: v.optional(UnitEventCategorySchema),
+  defaultDurationMinutes: v.optional(
+    v.pipe(
+      v.number(),
+      v.minValue(15, 'Default duration must be at least 15 minutes'),
+      v.maxValue(1440, 'Default duration must be at most 1440 minutes')
+    )
+  ),
+  requiresDutyWatch: v.optional(v.boolean()),
+  defaultMetadata: v.optional(v.nullable(v.record(v.string(), v.unknown()))),
+  displayOrder: v.optional(
+    v.pipe(v.number(), v.minValue(0, 'Display order must be 0 or greater'))
+  ),
+})
+
 // ============================================================================
 // Unit Event Schemas
 // ============================================================================
@@ -314,6 +356,10 @@ export const UnitEventIdParamSchema = v.object({
   id: v.pipe(v.string('Event ID is required'), v.uuid('Invalid event ID format')),
 })
 
+export const UnitEventTypeIdParamSchema = v.object({
+  id: v.pipe(v.string('Event type ID is required'), v.uuid('Invalid event type ID format')),
+})
+
 export const UnitEventPositionParamsSchema = v.object({
   id: v.pipe(v.string('Event ID is required'), v.uuid('Invalid event ID format')),
   positionId: v.pipe(
@@ -339,6 +385,8 @@ export type UnitEventStatus = v.InferOutput<typeof UnitEventStatusSchema>
 export type UnitEventDutyAssignmentStatus = v.InferOutput<typeof UnitEventDutyAssignmentStatusSchema>
 export type UnitEventTypeResponse = v.InferOutput<typeof UnitEventTypeResponseSchema>
 export type UnitEventTypeListResponse = v.InferOutput<typeof UnitEventTypeListResponseSchema>
+export type CreateUnitEventTypeInput = v.InferOutput<typeof CreateUnitEventTypeInputSchema>
+export type UpdateUnitEventTypeInput = v.InferOutput<typeof UpdateUnitEventTypeInputSchema>
 export type UnitEventDutyPositionResponse = v.InferOutput<typeof UnitEventDutyPositionResponseSchema>
 export type UnitEventDutyAssignmentResponse = v.InferOutput<typeof UnitEventDutyAssignmentResponseSchema>
 export type UnitEventResponse = v.InferOutput<typeof UnitEventResponseSchema>
@@ -352,5 +400,6 @@ export type UpdateUnitEventPositionInput = v.InferOutput<typeof UpdateUnitEventP
 export type CreateUnitEventAssignmentInput = v.InferOutput<typeof CreateUnitEventAssignmentInputSchema>
 export type UnitEventListQuery = v.InferOutput<typeof UnitEventListQuerySchema>
 export type UnitEventIdParam = v.InferOutput<typeof UnitEventIdParamSchema>
+export type UnitEventTypeIdParam = v.InferOutput<typeof UnitEventTypeIdParamSchema>
 export type UnitEventPositionParams = v.InferOutput<typeof UnitEventPositionParamsSchema>
 export type UnitEventAssignmentParams = v.InferOutput<typeof UnitEventAssignmentParamsSchema>


### PR DESCRIPTION
## What\n- Add Event Types tab in Settings modeled after Visit Types\n- Add Event Type table + create/edit modal in frontend-admin\n- Add Event Type CRUD hooks in frontend-admin\n- Add unit-event contract/schema support for Event Type CRUD\n- Add backend repository/service/route support for Event Type create/update/delete\n- Include deploy env upsert permission hardening fix\n\n## Commits\n- fix(deploy): escalate env file updates when deploy dir is root-owned\n- feat(settings): add event type management modeled after visit types\n\n## Notes\n- Local node/pnpm checks were not runnable in this execution environment.\n