### PR TITLE
release: prepare v2.6.0 with auth, manual in/out, and logs restore

### DIFF
--- a/.codex/skills/playwright-cli/SKILL.md
+++ b/.codex/skills/playwright-cli/SKILL.md
@@ -1,0 +1,352 @@
+---
+name: playwright-cli
+description: Automate browser interactions, test web pages and work with Playwright tests.
+allowed-tools: Bash(playwright-cli:*) Bash(npx:*) Bash(npm:*)
+---
+
+# Browser Automation with playwright-cli
+
+## Quick start
+
+```bash
+# open new browser
+playwright-cli open
+# navigate to a page
+playwright-cli goto https://playwright.dev
+# interact with the page using refs from the snapshot
+playwright-cli click e15
+playwright-cli type "page.click"
+playwright-cli press Enter
+# take a screenshot (rarely used, as snapshot is more common)
+playwright-cli screenshot
+# close the browser
+playwright-cli close
+```
+
+## Commands
+
+### Core
+
+```bash
+playwright-cli open
+# open and navigate right away
+playwright-cli open https://example.com/
+playwright-cli goto https://playwright.dev
+playwright-cli type "search query"
+playwright-cli click e3
+playwright-cli dblclick e7
+# --submit presses Enter after filling the element
+playwright-cli fill e5 "user@example.com"  --submit
+playwright-cli drag e2 e8
+playwright-cli hover e4
+playwright-cli select e9 "option-value"
+playwright-cli upload ./document.pdf
+playwright-cli check e12
+playwright-cli uncheck e12
+playwright-cli snapshot
+playwright-cli eval "document.title"
+playwright-cli eval "el => el.textContent" e5
+# get element id, class, or any attribute not visible in the snapshot
+playwright-cli eval "el => el.id" e5
+playwright-cli eval "el => el.getAttribute('data-testid')" e5
+playwright-cli dialog-accept
+playwright-cli dialog-accept "confirmation text"
+playwright-cli dialog-dismiss
+playwright-cli resize 1920 1080
+playwright-cli close
+```
+
+### Navigation
+
+```bash
+playwright-cli go-back
+playwright-cli go-forward
+playwright-cli reload
+```
+
+### Keyboard
+
+```bash
+playwright-cli press Enter
+playwright-cli press ArrowDown
+playwright-cli keydown Shift
+playwright-cli keyup Shift
+```
+
+### Mouse
+
+```bash
+playwright-cli mousemove 150 300
+playwright-cli mousedown
+playwright-cli mousedown right
+playwright-cli mouseup
+playwright-cli mouseup right
+playwright-cli mousewheel 0 100
+```
+
+### Save as
+
+```bash
+playwright-cli screenshot
+playwright-cli screenshot e5
+playwright-cli screenshot --filename=page.png
+playwright-cli pdf --filename=page.pdf
+```
+
+### Tabs
+
+```bash
+playwright-cli tab-list
+playwright-cli tab-new
+playwright-cli tab-new https://example.com/page
+playwright-cli tab-close
+playwright-cli tab-close 2
+playwright-cli tab-select 0
+```
+
+### Storage
+
+```bash
+playwright-cli state-save
+playwright-cli state-save auth.json
+playwright-cli state-load auth.json
+
+# Cookies
+playwright-cli cookie-list
+playwright-cli cookie-list --domain=example.com
+playwright-cli cookie-get session_id
+playwright-cli cookie-set session_id abc123
+playwright-cli cookie-set session_id abc123 --domain=example.com --httpOnly --secure
+playwright-cli cookie-delete session_id
+playwright-cli cookie-clear
+
+# LocalStorage
+playwright-cli localstorage-list
+playwright-cli localstorage-get theme
+playwright-cli localstorage-set theme dark
+playwright-cli localstorage-delete theme
+playwright-cli localstorage-clear
+
+# SessionStorage
+playwright-cli sessionstorage-list
+playwright-cli sessionstorage-get step
+playwright-cli sessionstorage-set step 3
+playwright-cli sessionstorage-delete step
+playwright-cli sessionstorage-clear
+```
+
+### Network
+
+```bash
+playwright-cli route "**/*.jpg" --status=404
+playwright-cli route "https://api.example.com/**" --body='{"mock": true}'
+playwright-cli route-list
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+### DevTools
+
+```bash
+playwright-cli console
+playwright-cli console warning
+playwright-cli network
+playwright-cli run-code "async page => await page.context().grantPermissions(['geolocation'])"
+playwright-cli run-code --filename=script.js
+playwright-cli tracing-start
+playwright-cli tracing-stop
+playwright-cli video-start video.webm
+playwright-cli video-chapter "Chapter Title" --description="Details" --duration=2000
+playwright-cli video-stop
+```
+
+## Raw output
+
+The global `--raw` option strips page status, generated code, and snapshot sections from the output, returning only the result value. Use it to pipe command output into other tools. Commands that don't produce output return nothing.
+
+```bash
+playwright-cli --raw eval "JSON.stringify(performance.timing)" | jq '.loadEventEnd - .navigationStart'
+playwright-cli --raw eval "JSON.stringify([...document.querySelectorAll('a')].map(a => a.href))" > links.json
+playwright-cli --raw snapshot > before.yml
+playwright-cli click e5
+playwright-cli --raw snapshot > after.yml
+diff before.yml after.yml
+TOKEN=$(playwright-cli --raw cookie-get session_id)
+playwright-cli --raw localstorage-get theme
+```
+
+## Open parameters
+
+```bash
+# Use specific browser when creating session
+playwright-cli open --browser=chrome
+playwright-cli open --browser=firefox
+playwright-cli open --browser=webkit
+playwright-cli open --browser=msedge
+
+# Use persistent profile (by default profile is in-memory)
+playwright-cli open --persistent
+# Use persistent profile with custom directory
+playwright-cli open --profile=/path/to/profile
+
+# Connect to browser via extension
+playwright-cli attach --extension
+
+# Connect to a running Chrome or Edge by channel name
+playwright-cli attach --cdp=chrome
+playwright-cli attach --cdp=msedge
+
+# Connect to a running browser via CDP endpoint
+playwright-cli attach --cdp=http://localhost:9222
+
+# Start with config file
+playwright-cli open --config=my-config.json
+
+# Close the browser
+playwright-cli close
+# Delete user data for the default session
+playwright-cli delete-data
+```
+
+## Snapshots
+
+After each command, playwright-cli provides a snapshot of the current browser state.
+
+```bash
+> playwright-cli goto https://example.com
+### Page
+- Page URL: https://example.com/
+- Page Title: Example Domain
+### Snapshot
+[Snapshot](.playwright-cli/page-2026-02-14T19-22-42-679Z.yml)
+```
+
+You can also take a snapshot on demand using `playwright-cli snapshot` command. All the options below can be combined as needed.
+
+```bash
+# default - save to a file with timestamp-based name
+playwright-cli snapshot
+
+# save to file, use when snapshot is a part of the workflow result
+playwright-cli snapshot --filename=after-click.yaml
+
+# snapshot an element instead of the whole page
+playwright-cli snapshot "#main"
+
+# limit snapshot depth for efficiency, take a partial snapshot afterwards
+playwright-cli snapshot --depth=4
+playwright-cli snapshot e34
+```
+
+## Targeting elements
+
+By default, use refs from the snapshot to interact with page elements.
+
+```bash
+# get snapshot with refs
+playwright-cli snapshot
+
+# interact using a ref
+playwright-cli click e15
+```
+
+You can also use css selectors or Playwright locators.
+
+```bash
+# css selector
+playwright-cli click "#main > button.submit"
+
+# role locator
+playwright-cli click "getByRole('button', { name: 'Submit' })"
+
+# test id
+playwright-cli click "getByTestId('submit-button')"
+```
+
+## Browser Sessions
+
+```bash
+# create new browser session named "mysession" with persistent profile
+playwright-cli -s=mysession open example.com --persistent
+# same with manually specified profile directory (use when requested explicitly)
+playwright-cli -s=mysession open example.com --profile=/path/to/profile
+playwright-cli -s=mysession click e6
+playwright-cli -s=mysession close  # stop a named browser
+playwright-cli -s=mysession delete-data  # delete user data for persistent session
+
+playwright-cli list
+# Close all browsers
+playwright-cli close-all
+# Forcefully kill all browser processes
+playwright-cli kill-all
+```
+
+## Installation
+
+If global `playwright-cli` command is not available, try a local version via `npx playwright-cli`:
+
+```bash
+npx --no-install playwright-cli --version
+```
+
+When local version is available, use `npx playwright-cli` in all commands. Otherwise, install `playwright-cli` as a global command:
+
+```bash
+npm install -g @playwright/cli@latest
+```
+
+## Example: Form submission
+
+```bash
+playwright-cli open https://example.com/form
+playwright-cli snapshot
+
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Example: Multi-tab workflow
+
+```bash
+playwright-cli open https://example.com
+playwright-cli tab-new https://example.com/other
+playwright-cli tab-list
+playwright-cli tab-select 0
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Example: Debugging with DevTools
+
+```bash
+playwright-cli open https://example.com
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli console
+playwright-cli network
+playwright-cli close
+```
+
+```bash
+playwright-cli open https://example.com
+playwright-cli tracing-start
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli tracing-stop
+playwright-cli close
+```
+
+## Specific tasks
+
+- **Running and Debugging Playwright tests** [references/playwright-tests.md](references/playwright-tests.md)
+- **Request mocking** [references/request-mocking.md](references/request-mocking.md)
+- **Running Playwright code** [references/running-code.md](references/running-code.md)
+- **Browser session management** [references/session-management.md](references/session-management.md)
+- **Storage state (cookies, localStorage)** [references/storage-state.md](references/storage-state.md)
+- **Test generation** [references/test-generation.md](references/test-generation.md)
+- **Tracing** [references/tracing.md](references/tracing.md)
+- **Video recording** [references/video-recording.md](references/video-recording.md)
+- **Inspecting element attributes** [references/element-attributes.md](references/element-attributes.md)

--- a/.codex/skills/playwright-cli/references/element-attributes.md
+++ b/.codex/skills/playwright-cli/references/element-attributes.md
@@ -1,0 +1,23 @@
+# Inspecting Element Attributes
+
+When the snapshot doesn't show an element's `id`, `class`, `data-*` attributes, or other DOM properties, use `eval` to inspect them.
+
+## Examples
+
+```bash
+playwright-cli snapshot
+# snapshot shows a button as e7 but doesn't reveal its id or data attributes
+
+# get the element's id
+playwright-cli eval "el => el.id" e7
+
+# get all CSS classes
+playwright-cli eval "el => el.className" e7
+
+# get a specific attribute
+playwright-cli eval "el => el.getAttribute('data-testid')" e7
+playwright-cli eval "el => el.getAttribute('aria-label')" e7
+
+# get a computed style property
+playwright-cli eval "el => getComputedStyle(el).display" e7
+```

--- a/.codex/skills/playwright-cli/references/playwright-tests.md
+++ b/.codex/skills/playwright-cli/references/playwright-tests.md
@@ -1,0 +1,39 @@
+# Running Playwright Tests
+
+To run Playwright tests, use the `npx playwright test` command, or a package manager script. To avoid opening the interactive html report, use `PLAYWRIGHT_HTML_OPEN=never` environment variable.
+
+```bash
+# Run all tests
+PLAYWRIGHT_HTML_OPEN=never npx playwright test
+
+# Run all tests through a custom npm script
+PLAYWRIGHT_HTML_OPEN=never npm run special-test-command
+```
+
+# Debugging Playwright Tests
+
+To debug a failing Playwright test, run it with `--debug=cli` option. This command will pause the test at the start and print the debugging instructions.
+
+**IMPORTANT**: run the command in the background and check the output until "Debugging Instructions" is printed.
+
+Once instructions containing a session name are printed, use `playwright-cli` to attach the session and explore the page.
+
+```bash
+# Run the test
+PLAYWRIGHT_HTML_OPEN=never npx playwright test --debug=cli
+# ...
+# ... debugging instructions for "tw-abcdef" session ...
+# ...
+
+# Attach to the test
+playwright-cli attach tw-abcdef
+```
+
+Keep the test running in the background while you explore and look for a fix.
+The test is paused at the start, so you should step over or pause at a particular location
+where the problem is most likely to be.
+
+Every action you perform with `playwright-cli` generates corresponding Playwright TypeScript code.
+This code appears in the output and can be copied directly into the test. Most of the time, a specific locator or an expectation should be updated, but it could also be a bug in the app. Use your judgement.
+
+After fixing the test, stop the background test run. Rerun to check that test passes.

--- a/.codex/skills/playwright-cli/references/request-mocking.md
+++ b/.codex/skills/playwright-cli/references/request-mocking.md
@@ -1,0 +1,87 @@
+# Request Mocking
+
+Intercept, mock, modify, and block network requests.
+
+## CLI Route Commands
+
+```bash
+# Mock with custom status
+playwright-cli route "**/*.jpg" --status=404
+
+# Mock with JSON body
+playwright-cli route "**/api/users" --body='[{"id":1,"name":"Alice"}]' --content-type=application/json
+
+# Mock with custom headers
+playwright-cli route "**/api/data" --body='{"ok":true}' --header="X-Custom: value"
+
+# Remove headers from requests
+playwright-cli route "**/*" --remove-header=cookie,authorization
+
+# List active routes
+playwright-cli route-list
+
+# Remove a route or all routes
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+## URL Patterns
+
+```
+**/api/users           - Exact path match
+**/api/*/details       - Wildcard in path
+**/*.{png,jpg,jpeg}    - Match file extensions
+**/search?q=*          - Match query parameters
+```
+
+## Advanced Mocking with run-code
+
+For conditional responses, request body inspection, response modification, or delays:
+
+### Conditional Response Based on Request
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/login', route => {
+    const body = route.request().postDataJSON();
+    if (body.username === 'admin') {
+      route.fulfill({ body: JSON.stringify({ token: 'mock-token' }) });
+    } else {
+      route.fulfill({ status: 401, body: JSON.stringify({ error: 'Invalid' }) });
+    }
+  });
+}"
+```
+
+### Modify Real Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/user', async route => {
+    const response = await route.fetch();
+    const json = await response.json();
+    json.isPremium = true;
+    await route.fulfill({ response, json });
+  });
+}"
+```
+
+### Simulate Network Failures
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/offline', route => route.abort('internetdisconnected'));
+}"
+# Options: connectionrefused, timedout, connectionreset, internetdisconnected
+```
+
+### Delayed Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/slow', async route => {
+    await new Promise(r => setTimeout(r, 3000));
+    route.fulfill({ body: JSON.stringify({ data: 'loaded' }) });
+  });
+}"
+```

--- a/.codex/skills/playwright-cli/references/running-code.md
+++ b/.codex/skills/playwright-cli/references/running-code.md
@@ -1,0 +1,231 @@
+# Running Custom Playwright Code
+
+Use `run-code` to execute arbitrary Playwright code for advanced scenarios not covered by CLI commands.
+
+## Syntax
+
+```bash
+playwright-cli run-code "async page => {
+  // Your Playwright code here
+  // Access page.context() for browser context operations
+}"
+```
+
+## Geolocation
+
+```bash
+# Grant geolocation permission and set location
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 37.7749, longitude: -122.4194 });
+}"
+
+# Set location to London
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 51.5074, longitude: -0.1278 });
+}"
+
+# Clear geolocation override
+playwright-cli run-code "async page => {
+  await page.context().clearPermissions();
+}"
+```
+
+## Permissions
+
+```bash
+# Grant multiple permissions
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions([
+    'geolocation',
+    'notifications',
+    'camera',
+    'microphone'
+  ]);
+}"
+
+# Grant permissions for specific origin
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read'], {
+    origin: 'https://example.com'
+  });
+}"
+```
+
+## Media Emulation
+
+```bash
+# Emulate dark color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'dark' });
+}"
+
+# Emulate light color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'light' });
+}"
+
+# Emulate reduced motion
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+}"
+
+# Emulate print media
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ media: 'print' });
+}"
+```
+
+## Wait Strategies
+
+```bash
+# Wait for network idle
+playwright-cli run-code "async page => {
+  await page.waitForLoadState('networkidle');
+}"
+
+# Wait for specific element
+playwright-cli run-code "async page => {
+  await page.locator('.loading').waitFor({ state: 'hidden' });
+}"
+
+# Wait for function to return true
+playwright-cli run-code "async page => {
+  await page.waitForFunction(() => window.appReady === true);
+}"
+
+# Wait with timeout
+playwright-cli run-code "async page => {
+  await page.locator('.result').waitFor({ timeout: 10000 });
+}"
+```
+
+## Frames and Iframes
+
+```bash
+# Work with iframe
+playwright-cli run-code "async page => {
+  const frame = page.locator('iframe#my-iframe').contentFrame();
+  await frame.locator('button').click();
+}"
+
+# Get all frames
+playwright-cli run-code "async page => {
+  const frames = page.frames();
+  return frames.map(f => f.url());
+}"
+```
+
+## File Downloads
+
+```bash
+# Handle file download
+playwright-cli run-code "async page => {
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('link', { name: 'Download' }).click();
+  const download = await downloadPromise;
+  await download.saveAs('./downloaded-file.pdf');
+  return download.suggestedFilename();
+}"
+```
+
+## Clipboard
+
+```bash
+# Read clipboard (requires permission)
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read']);
+  return await page.evaluate(() => navigator.clipboard.readText());
+}"
+
+# Write to clipboard
+playwright-cli run-code "async page => {
+  await page.evaluate(text => navigator.clipboard.writeText(text), 'Hello clipboard!');
+}"
+```
+
+## Page Information
+
+```bash
+# Get page title
+playwright-cli run-code "async page => {
+  return await page.title();
+}"
+
+# Get current URL
+playwright-cli run-code "async page => {
+  return page.url();
+}"
+
+# Get page content
+playwright-cli run-code "async page => {
+  return await page.content();
+}"
+
+# Get viewport size
+playwright-cli run-code "async page => {
+  return page.viewportSize();
+}"
+```
+
+## JavaScript Execution
+
+```bash
+# Execute JavaScript and return result
+playwright-cli run-code "async page => {
+  return await page.evaluate(() => {
+    return {
+      userAgent: navigator.userAgent,
+      language: navigator.language,
+      cookiesEnabled: navigator.cookieEnabled
+    };
+  });
+}"
+
+# Pass arguments to evaluate
+playwright-cli run-code "async page => {
+  const multiplier = 5;
+  return await page.evaluate(m => document.querySelectorAll('li').length * m, multiplier);
+}"
+```
+
+## Error Handling
+
+```bash
+# Try-catch in run-code
+playwright-cli run-code "async page => {
+  try {
+    await page.getByRole('button', { name: 'Submit' }).click({ timeout: 1000 });
+    return 'clicked';
+  } catch (e) {
+    return 'element not found';
+  }
+}"
+```
+
+## Complex Workflows
+
+```bash
+# Login and save state
+playwright-cli run-code "async page => {
+  await page.goto('https://example.com/login');
+  await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+  await page.getByRole('textbox', { name: 'Password' }).fill('secret');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('**/dashboard');
+  await page.context().storageState({ path: 'auth.json' });
+  return 'Login successful';
+}"
+
+# Scrape data from multiple pages
+playwright-cli run-code "async page => {
+  const results = [];
+  for (let i = 1; i <= 3; i++) {
+    await page.goto(\`https://example.com/page/\${i}\`);
+    const items = await page.locator('.item').allTextContents();
+    results.push(...items);
+  }
+  return results;
+}"
+```

--- a/.codex/skills/playwright-cli/references/session-management.md
+++ b/.codex/skills/playwright-cli/references/session-management.md
@@ -1,0 +1,210 @@
+# Browser Session Management
+
+Run multiple isolated browser sessions concurrently with state persistence.
+
+## Named Browser Sessions
+
+Use `-s` flag to isolate browser contexts:
+
+```bash
+# Browser 1: Authentication flow
+playwright-cli -s=auth open https://app.example.com/login
+
+# Browser 2: Public browsing (separate cookies, storage)
+playwright-cli -s=public open https://example.com
+
+# Commands are isolated by browser session
+playwright-cli -s=auth fill e1 "user@example.com"
+playwright-cli -s=public snapshot
+```
+
+## Browser Session Isolation Properties
+
+Each browser session has independent:
+
+- Cookies
+- LocalStorage / SessionStorage
+- IndexedDB
+- Cache
+- Browsing history
+- Open tabs
+
+## Browser Session Commands
+
+```bash
+# List all browser sessions
+playwright-cli list
+
+# Stop a browser session (close the browser)
+playwright-cli close                # stop the default browser
+playwright-cli -s=mysession close   # stop a named browser
+
+# Stop all browser sessions
+playwright-cli close-all
+
+# Forcefully kill all daemon processes (for stale/zombie processes)
+playwright-cli kill-all
+
+# Delete browser session user data (profile directory)
+playwright-cli delete-data                # delete default browser data
+playwright-cli -s=mysession delete-data   # delete named browser data
+```
+
+## Environment Variable
+
+Set a default browser session name via environment variable:
+
+```bash
+export PLAYWRIGHT_CLI_SESSION="mysession"
+playwright-cli open example.com  # Uses "mysession" automatically
+```
+
+## Common Patterns
+
+### Concurrent Scraping
+
+```bash
+#!/bin/bash
+# Scrape multiple sites concurrently
+
+# Start all browsers
+playwright-cli -s=site1 open https://site1.com &
+playwright-cli -s=site2 open https://site2.com &
+playwright-cli -s=site3 open https://site3.com &
+wait
+
+# Take snapshots from each
+playwright-cli -s=site1 snapshot
+playwright-cli -s=site2 snapshot
+playwright-cli -s=site3 snapshot
+
+# Cleanup
+playwright-cli close-all
+```
+
+### A/B Testing Sessions
+
+```bash
+# Test different user experiences
+playwright-cli -s=variant-a open "https://app.com?variant=a"
+playwright-cli -s=variant-b open "https://app.com?variant=b"
+
+# Compare
+playwright-cli -s=variant-a screenshot
+playwright-cli -s=variant-b screenshot
+```
+
+### Persistent Profile
+
+By default, browser profile is kept in memory only. Use `--persistent` flag on `open` to persist the browser profile to disk:
+
+```bash
+# Use persistent profile (auto-generated location)
+playwright-cli open https://example.com --persistent
+
+# Use persistent profile with custom directory
+playwright-cli open https://example.com --profile=/path/to/profile
+```
+
+## Attaching to a Running Browser
+
+Use `attach` to connect to a browser that is already running, instead of launching a new one.
+
+### Attach by channel name
+
+Connect to a running Chrome or Edge instance by its channel name. The browser must have remote debugging enabled — navigate to `chrome://inspect/#remote-debugging` in the target browser and check "Allow remote debugging for this browser instance".
+
+```bash
+# Attach to Chrome
+playwright-cli attach --cdp=chrome
+
+# Attach to Chrome Canary
+playwright-cli attach --cdp=chrome-canary
+
+# Attach to Microsoft Edge
+playwright-cli attach --cdp=msedge
+
+# Attach to Edge Dev
+playwright-cli attach --cdp=msedge-dev
+```
+
+Supported channels: `chrome`, `chrome-beta`, `chrome-dev`, `chrome-canary`, `msedge`, `msedge-beta`, `msedge-dev`, `msedge-canary`.
+
+### Attach via CDP endpoint
+
+Connect to a browser that exposes a Chrome DevTools Protocol endpoint:
+
+```bash
+playwright-cli attach --cdp=http://localhost:9222
+```
+
+### Attach via browser extension
+
+Connect to a browser with the Playwright extension installed:
+
+```bash
+playwright-cli attach --extension
+```
+
+## Default Browser Session
+
+When `-s` is omitted, commands use the default browser session:
+
+```bash
+# These use the same default browser session
+playwright-cli open https://example.com
+playwright-cli snapshot
+playwright-cli close  # Stops default browser
+```
+
+## Browser Session Configuration
+
+Configure a browser session with specific settings when opening:
+
+```bash
+# Open with config file
+playwright-cli open https://example.com --config=.playwright/my-cli.json
+
+# Open with specific browser
+playwright-cli open https://example.com --browser=firefox
+
+# Open in headed mode
+playwright-cli open https://example.com --headed
+
+# Open with persistent profile
+playwright-cli open https://example.com --persistent
+```
+
+## Best Practices
+
+### 1. Name Browser Sessions Semantically
+
+```bash
+# GOOD: Clear purpose
+playwright-cli -s=github-auth open https://github.com
+playwright-cli -s=docs-scrape open https://docs.example.com
+
+# AVOID: Generic names
+playwright-cli -s=s1 open https://github.com
+```
+
+### 2. Always Clean Up
+
+```bash
+# Stop browsers when done
+playwright-cli -s=auth close
+playwright-cli -s=scrape close
+
+# Or stop all at once
+playwright-cli close-all
+
+# If browsers become unresponsive or zombie processes remain
+playwright-cli kill-all
+```
+
+### 3. Delete Stale Browser Data
+
+```bash
+# Remove old browser data to free disk space
+playwright-cli -s=oldsession delete-data
+```

--- a/.codex/skills/playwright-cli/references/storage-state.md
+++ b/.codex/skills/playwright-cli/references/storage-state.md
@@ -1,0 +1,275 @@
+# Storage Management
+
+Manage cookies, localStorage, sessionStorage, and browser storage state.
+
+## Storage State
+
+Save and restore complete browser state including cookies and storage.
+
+### Save Storage State
+
+```bash
+# Save to auto-generated filename (storage-state-{timestamp}.json)
+playwright-cli state-save
+
+# Save to specific filename
+playwright-cli state-save my-auth-state.json
+```
+
+### Restore Storage State
+
+```bash
+# Load storage state from file
+playwright-cli state-load my-auth-state.json
+
+# Reload page to apply cookies
+playwright-cli open https://example.com
+```
+
+### Storage State File Format
+
+The saved file contains:
+
+```json
+{
+  "cookies": [
+    {
+      "name": "session_id",
+      "value": "abc123",
+      "domain": "example.com",
+      "path": "/",
+      "expires": 1735689600,
+      "httpOnly": true,
+      "secure": true,
+      "sameSite": "Lax"
+    }
+  ],
+  "origins": [
+    {
+      "origin": "https://example.com",
+      "localStorage": [
+        { "name": "theme", "value": "dark" },
+        { "name": "user_id", "value": "12345" }
+      ]
+    }
+  ]
+}
+```
+
+## Cookies
+
+### List All Cookies
+
+```bash
+playwright-cli cookie-list
+```
+
+### Filter Cookies by Domain
+
+```bash
+playwright-cli cookie-list --domain=example.com
+```
+
+### Filter Cookies by Path
+
+```bash
+playwright-cli cookie-list --path=/api
+```
+
+### Get Specific Cookie
+
+```bash
+playwright-cli cookie-get session_id
+```
+
+### Set a Cookie
+
+```bash
+# Basic cookie
+playwright-cli cookie-set session abc123
+
+# Cookie with options
+playwright-cli cookie-set session abc123 --domain=example.com --path=/ --httpOnly --secure --sameSite=Lax
+
+# Cookie with expiration (Unix timestamp)
+playwright-cli cookie-set remember_me token123 --expires=1735689600
+```
+
+### Delete a Cookie
+
+```bash
+playwright-cli cookie-delete session_id
+```
+
+### Clear All Cookies
+
+```bash
+playwright-cli cookie-clear
+```
+
+### Advanced: Multiple Cookies or Custom Options
+
+For complex scenarios like adding multiple cookies at once, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.context().addCookies([
+    { name: 'session_id', value: 'sess_abc123', domain: 'example.com', path: '/', httpOnly: true },
+    { name: 'preferences', value: JSON.stringify({ theme: 'dark' }), domain: 'example.com', path: '/' }
+  ]);
+}"
+```
+
+## Local Storage
+
+### List All localStorage Items
+
+```bash
+playwright-cli localstorage-list
+```
+
+### Get Single Value
+
+```bash
+playwright-cli localstorage-get token
+```
+
+### Set Value
+
+```bash
+playwright-cli localstorage-set theme dark
+```
+
+### Set JSON Value
+
+```bash
+playwright-cli localstorage-set user_settings '{"theme":"dark","language":"en"}'
+```
+
+### Delete Single Item
+
+```bash
+playwright-cli localstorage-delete token
+```
+
+### Clear All localStorage
+
+```bash
+playwright-cli localstorage-clear
+```
+
+### Advanced: Multiple Operations
+
+For complex scenarios like setting multiple values at once, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    localStorage.setItem('token', 'jwt_abc123');
+    localStorage.setItem('user_id', '12345');
+    localStorage.setItem('expires_at', Date.now() + 3600000);
+  });
+}"
+```
+
+## Session Storage
+
+### List All sessionStorage Items
+
+```bash
+playwright-cli sessionstorage-list
+```
+
+### Get Single Value
+
+```bash
+playwright-cli sessionstorage-get form_data
+```
+
+### Set Value
+
+```bash
+playwright-cli sessionstorage-set step 3
+```
+
+### Delete Single Item
+
+```bash
+playwright-cli sessionstorage-delete step
+```
+
+### Clear sessionStorage
+
+```bash
+playwright-cli sessionstorage-clear
+```
+
+## IndexedDB
+
+### List Databases
+
+```bash
+playwright-cli run-code "async page => {
+  return await page.evaluate(async () => {
+    const databases = await indexedDB.databases();
+    return databases;
+  });
+}"
+```
+
+### Delete Database
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    indexedDB.deleteDatabase('myDatabase');
+  });
+}"
+```
+
+## Common Patterns
+
+### Authentication State Reuse
+
+```bash
+# Step 1: Login and save state
+playwright-cli open https://app.example.com/login
+playwright-cli snapshot
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+
+# Save the authenticated state
+playwright-cli state-save auth.json
+
+# Step 2: Later, restore state and skip login
+playwright-cli state-load auth.json
+playwright-cli open https://app.example.com/dashboard
+# Already logged in!
+```
+
+### Save and Restore Roundtrip
+
+```bash
+# Set up authentication state
+playwright-cli open https://example.com
+playwright-cli eval "() => { document.cookie = 'session=abc123'; localStorage.setItem('user', 'john'); }"
+
+# Save state to file
+playwright-cli state-save my-session.json
+
+# ... later, in a new session ...
+
+# Restore state
+playwright-cli state-load my-session.json
+playwright-cli open https://example.com
+# Cookies and localStorage are restored!
+```
+
+## Security Notes
+
+- Never commit storage state files containing auth tokens
+- Add `*.auth-state.json` to `.gitignore`
+- Delete state files after automation completes
+- Use environment variables for sensitive data
+- By default, sessions run in-memory mode which is safer for sensitive operations

--- a/.codex/skills/playwright-cli/references/test-generation.md
+++ b/.codex/skills/playwright-cli/references/test-generation.md
@@ -1,0 +1,88 @@
+# Test Generation
+
+Generate Playwright test code automatically as you interact with the browser.
+
+## How It Works
+
+Every action you perform with `playwright-cli` generates corresponding Playwright TypeScript code.
+This code appears in the output and can be copied directly into your test files.
+
+## Example Workflow
+
+```bash
+# Start a session
+playwright-cli open https://example.com/login
+
+# Take a snapshot to see elements
+playwright-cli snapshot
+# Output shows: e1 [textbox "Email"], e2 [textbox "Password"], e3 [button "Sign In"]
+
+# Fill form fields - generates code automatically
+playwright-cli fill e1 "user@example.com"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+
+playwright-cli fill e2 "password123"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+
+playwright-cli click e3
+# Ran Playwright code:
+# await page.getByRole('button', { name: 'Sign In' }).click();
+```
+
+## Building a Test File
+
+Collect the generated code into a Playwright test:
+
+```typescript
+import { test, expect } from '@playwright/test'
+
+test('login flow', async ({ page }) => {
+  // Generated code from playwright-cli session:
+  await page.goto('https://example.com/login')
+  await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com')
+  await page.getByRole('textbox', { name: 'Password' }).fill('password123')
+  await page.getByRole('button', { name: 'Sign In' }).click()
+
+  // Add assertions
+  await expect(page).toHaveURL(/.*dashboard/)
+})
+```
+
+## Best Practices
+
+### 1. Use Semantic Locators
+
+The generated code uses role-based locators when possible, which are more resilient:
+
+```typescript
+// Generated (good - semantic)
+await page.getByRole('button', { name: 'Submit' }).click()
+
+// Avoid (fragile - CSS selectors)
+await page.locator('#submit-btn').click()
+```
+
+### 2. Explore Before Recording
+
+Take snapshots to understand the page structure before recording actions:
+
+```bash
+playwright-cli open https://example.com
+playwright-cli snapshot
+# Review the element structure
+playwright-cli click e5
+```
+
+### 3. Add Assertions Manually
+
+Generated code captures actions but not assertions. Add expectations in your test:
+
+```typescript
+// Generated action
+await page.getByRole('button', { name: 'Submit' }).click()
+
+// Manual assertion
+await expect(page.getByText('Success')).toBeVisible()
+```

--- a/.codex/skills/playwright-cli/references/tracing.md
+++ b/.codex/skills/playwright-cli/references/tracing.md
@@ -1,0 +1,142 @@
+# Tracing
+
+Capture detailed execution traces for debugging and analysis. Traces include DOM snapshots, screenshots, network activity, and console logs.
+
+## Basic Usage
+
+```bash
+# Start trace recording
+playwright-cli tracing-start
+
+# Perform actions
+playwright-cli open https://example.com
+playwright-cli click e1
+playwright-cli fill e2 "test"
+
+# Stop trace recording
+playwright-cli tracing-stop
+```
+
+## Trace Output Files
+
+When you start tracing, Playwright creates a `traces/` directory with several files:
+
+### `trace-{timestamp}.trace`
+
+**Action log** - The main trace file containing:
+
+- Every action performed (clicks, fills, navigations)
+- DOM snapshots before and after each action
+- Screenshots at each step
+- Timing information
+- Console messages
+- Source locations
+
+### `trace-{timestamp}.network`
+
+**Network log** - Complete network activity:
+
+- All HTTP requests and responses
+- Request headers and bodies
+- Response headers and bodies
+- Timing (DNS, connect, TLS, TTFB, download)
+- Resource sizes
+- Failed requests and errors
+
+### `resources/`
+
+**Resources directory** - Cached resources:
+
+- Images, fonts, stylesheets, scripts
+- Response bodies for replay
+- Assets needed to reconstruct page state
+
+## What Traces Capture
+
+| Category        | Details                                            |
+| --------------- | -------------------------------------------------- |
+| **Actions**     | Clicks, fills, hovers, keyboard input, navigations |
+| **DOM**         | Full DOM snapshot before/after each action         |
+| **Screenshots** | Visual state at each step                          |
+| **Network**     | All requests, responses, headers, bodies, timing   |
+| **Console**     | All console.log, warn, error messages              |
+| **Timing**      | Precise timing for each operation                  |
+
+## Use Cases
+
+### Debugging Failed Actions
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://app.example.com
+
+# This click fails - why?
+playwright-cli click e5
+
+playwright-cli tracing-stop
+# Open trace to see DOM state when click was attempted
+```
+
+### Analyzing Performance
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://slow-site.com
+playwright-cli tracing-stop
+
+# View network waterfall to identify slow resources
+```
+
+### Capturing Evidence
+
+```bash
+# Record a complete user flow for documentation
+playwright-cli tracing-start
+
+playwright-cli open https://app.example.com/checkout
+playwright-cli fill e1 "4111111111111111"
+playwright-cli fill e2 "12/25"
+playwright-cli fill e3 "123"
+playwright-cli click e4
+
+playwright-cli tracing-stop
+# Trace shows exact sequence of events
+```
+
+## Trace vs Video vs Screenshot
+
+| Feature                 | Trace       | Video       | Screenshot       |
+| ----------------------- | ----------- | ----------- | ---------------- |
+| **Format**              | .trace file | .webm video | .png/.jpeg image |
+| **DOM inspection**      | Yes         | No          | No               |
+| **Network details**     | Yes         | No          | No               |
+| **Step-by-step replay** | Yes         | Continuous  | Single frame     |
+| **File size**           | Medium      | Large       | Small            |
+| **Best for**            | Debugging   | Demos       | Quick capture    |
+
+## Best Practices
+
+### 1. Start Tracing Before the Problem
+
+```bash
+# Trace the entire flow, not just the failing step
+playwright-cli tracing-start
+playwright-cli open https://example.com
+# ... all steps leading to the issue ...
+playwright-cli tracing-stop
+```
+
+### 2. Clean Up Old Traces
+
+Traces can consume significant disk space:
+
+```bash
+# Remove traces older than 7 days
+find .playwright-cli/traces -mtime +7 -delete
+```
+
+## Limitations
+
+- Traces add overhead to automation
+- Large traces can consume significant disk space
+- Some dynamic content may not replay perfectly

--- a/.codex/skills/playwright-cli/references/video-recording.md
+++ b/.codex/skills/playwright-cli/references/video-recording.md
@@ -1,0 +1,150 @@
+# Video Recording
+
+Capture browser automation sessions as video for debugging, documentation, or verification. Produces WebM (VP8/VP9 codec).
+
+## Basic Recording
+
+```bash
+# Open browser first
+playwright-cli open
+
+# Start recording
+playwright-cli video-start demo.webm
+
+# Add a chapter marker for section transitions
+playwright-cli video-chapter "Getting Started" --description="Opening the homepage" --duration=2000
+
+# Navigate and perform actions
+playwright-cli goto https://example.com
+playwright-cli snapshot
+playwright-cli click e1
+
+# Add another chapter
+playwright-cli video-chapter "Filling Form" --description="Entering test data" --duration=2000
+playwright-cli fill e2 "test input"
+
+# Stop and save
+playwright-cli video-stop
+```
+
+## Best Practices
+
+### 1. Use Descriptive Filenames
+
+```bash
+# Include context in filename
+playwright-cli video-start recordings/login-flow-2024-01-15.webm
+playwright-cli video-start recordings/checkout-test-run-42.webm
+```
+
+### 2. Record entire hero scripts.
+
+When recording a video for the user or as a proof of work, it is best to create a code snippet and execute it with run-code.
+It allows pulling appropriate pauses between the actions and annotating the video. There are new Playwright APIs for that.
+
+1. Perform scenario using CLI and take note of all locators and actions. You'll need those locators to request their bounding boxes for highlight.
+2. Create a file with the intended script for video (below). Use pressSequentially w/ delay for nice typing, make reasonable pauses.
+3. Use playwright-cli run-code --filename your-script.js
+
+**Important**: Overlays are `pointer-events: none` — they do not interfere with page interactions. You can safely keep sticky overlays visible while clicking, filling, or performing any actions on the page.
+
+```js
+;async (page) => {
+  await page.screencast.start({ path: 'video.webm', size: { width: 1280, height: 800 } })
+  await page.goto('https://demo.playwright.dev/todomvc')
+
+  // Show a chapter card — blurs the page and shows a dialog.
+  // Blocks until duration expires, then auto-removes.
+  // Use this for simple use cases, but always feel free to hand-craft your own beautiful
+  // overlay via await page.screencast.showOverlay().
+  await page.screencast.showChapter('Adding Todo Items', {
+    description: 'We will add several items to the todo list.',
+    duration: 2000,
+  })
+
+  // Perform action
+  await page
+    .getByRole('textbox', { name: 'What needs to be done?' })
+    .pressSequentially('Walk the dog', { delay: 60 })
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).press('Enter')
+  await page.waitForTimeout(1000)
+
+  // Show next chapter
+  await page.screencast.showChapter('Verifying Results', {
+    description: 'Checking the item appeared in the list.',
+    duration: 2000,
+  })
+
+  // Add a sticky annotation that stays while you perform actions.
+  // Overlays are pointer-events: none, so they won't block clicks.
+  const annotation = await page.screencast.showOverlay(`
+    <div style="position: absolute; top: 8px; right: 8px;
+      padding: 6px 12px; background: rgba(0,0,0,0.7);
+      border-radius: 8px; font-size: 13px; color: white;">
+      ✓ Item added successfully
+    </div>
+  `)
+
+  // Perform more actions while the annotation is visible
+  await page
+    .getByRole('textbox', { name: 'What needs to be done?' })
+    .pressSequentially('Buy groceries', { delay: 60 })
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).press('Enter')
+  await page.waitForTimeout(1500)
+
+  // Remove the annotation when done
+  await annotation.dispose()
+
+  // You can also highlight relevant locators and provide contextual annotations.
+  const bounds = await page.getByText('Walk the dog').boundingBox()
+  await page.screencast.showOverlay(
+    `
+    <div style="position: absolute;
+      top: ${bounds.y}px;
+      left: ${bounds.x}px;
+      width: ${bounds.width}px;
+      height: ${bounds.height}px;
+      border: 1px solid red;">
+    </div>
+    <div style="position: absolute;
+      top: ${bounds.y + bounds.height + 5}px;
+      left: ${bounds.x + bounds.width / 2}px;
+      transform: translateX(-50%);
+      padding: 6px;
+      background: #808080;
+      border-radius: 10px;
+      font-size: 14px;
+      color: white;">Check it out, it is right above this text
+    </div>
+  `,
+    { duration: 2000 }
+  )
+
+  await page.screencast.stop()
+}
+```
+
+Embrace creativity, overlays are powerful.
+
+### Overlay API Summary
+
+| Method                                                                         | Use Case                                                                       |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| `page.screencast.showChapter(title, { description?, duration?, styleSheet? })` | Full-screen chapter card with blurred backdrop — ideal for section transitions |
+| `page.screencast.showOverlay(html, { duration? })`                             | Custom HTML overlay — use for callouts, labels, highlights                     |
+| `disposable.dispose()`                                                         | Remove a sticky overlay added without duration                                 |
+| `page.screencast.hideOverlays()` / `page.screencast.showOverlays()`            | Temporarily hide/show all overlays                                             |
+
+## Tracing vs Video
+
+| Feature  | Video                | Tracing                                  |
+| -------- | -------------------- | ---------------------------------------- |
+| Output   | WebM file            | Trace file (viewable in Trace Viewer)    |
+| Shows    | Visual recording     | DOM snapshots, network, console, actions |
+| Use case | Demos, documentation | Debugging, analysis                      |
+| Size     | Larger               | Smaller                                  |
+
+## Limitations
+
+- Recording adds slight overhead to automation
+- Large recordings can consume significant disk space

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,10 @@ apps/backend/*.png
 
 # Logs
 logs/
+!apps/frontend-admin/src/app/logs/
+!apps/frontend-admin/src/app/logs/**
+!apps/frontend-admin/src/components/logs/
+!apps/frontend-admin/src/components/logs/**
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/app/change-pin-required/page.tsx
+++ b/apps/frontend-admin/src/app/change-pin-required/page.tsx
@@ -4,6 +4,7 @@
 import { FormEvent, Suspense, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { DISALLOWED_MEMBER_PINS } from '@sentinel/contracts'
+import { PinField } from '@/components/auth/pin-field'
 import { resolvePostLoginDestination } from '@/lib/post-login-destination'
 import { useAuthStore } from '@/store/auth-store'
 
@@ -109,33 +110,21 @@ function ChangePinRequiredContent() {
           )}
 
           <form className="space-y-(--space-3)" onSubmit={handleSubmit}>
-            <label className="input w-full">
-              <span className="label">New PIN</span>
-              <input
-                type="password"
-                inputMode="numeric"
-                maxLength={4}
-                className="grow font-mono text-center tracking-[0.5em]"
-                value={newPin}
-                onChange={(e) => setNewPin(e.target.value.replace(/\D/g, '').slice(0, 4))}
-                disabled={loading}
-                required
-              />
-            </label>
+            <PinField
+              label="New PIN"
+              value={newPin}
+              onValueChange={setNewPin}
+              disabled={loading}
+              required
+            />
 
-            <label className="input w-full">
-              <span className="label">Confirm New PIN</span>
-              <input
-                type="password"
-                inputMode="numeric"
-                maxLength={4}
-                className="grow font-mono text-center tracking-[0.5em]"
-                value={confirmPin}
-                onChange={(e) => setConfirmPin(e.target.value.replace(/\D/g, '').slice(0, 4))}
-                disabled={loading}
-                required
-              />
-            </label>
+            <PinField
+              label="Confirm New PIN"
+              value={confirmPin}
+              onValueChange={setConfirmPin}
+              disabled={loading}
+              required
+            />
 
             <div className="flex items-center justify-end gap-(--space-2) pt-(--space-2)">
               <button

--- a/apps/frontend-admin/src/app/checkins/page.tsx
+++ b/apps/frontend-admin/src/app/checkins/page.tsx
@@ -78,6 +78,7 @@ export default function CheckinsPage() {
               className="btn btn-primary btn-md"
               onClick={() => setIsManualCheckinModalOpen(true)}
               aria-label="Create manual check-in"
+              data-testid={TID.checkins.manualCheckinBtn}
             >
               <Plus className="h-4 w-4 mr-2" aria-hidden="true" />
               Manual Check-in

--- a/apps/frontend-admin/src/app/login/page.tsx
+++ b/apps/frontend-admin/src/app/login/page.tsx
@@ -11,6 +11,7 @@ import {
   type LoginStartOfDayAction,
 } from '@sentinel/contracts'
 import { BadgeScanInput } from '@/components/auth/badge-scan-input'
+import { PinField } from '@/components/auth/pin-field'
 import type { PinInputInitialSelection, PinInputSubmission } from '@/components/auth/pin-input'
 import { PinInput } from '@/components/auth/pin-input'
 import { getSetupDescription } from './login-flow'
@@ -608,46 +609,32 @@ function LoginPageContent() {
                   </div>
 
                   <form className="space-y-(--space-3)" onSubmit={handleSetupSubmit}>
-                    <label className="input input-lg w-full">
-                      <span className="label">New PIN</span>
-                      <input
-                        type="password"
-                        inputMode="numeric"
-                        maxLength={4}
-                        className="grow text-center font-mono text-2xl tracking-[0.45em]"
-                        value={newPin}
-                        onChange={(changeEvent) =>
-                          setNewPin(changeEvent.target.value.replace(/\D/g, '').slice(0, 4))
-                        }
-                        disabled={loading}
-                        autoComplete="off"
-                        aria-label="New PIN"
-                        data-testid={TID.auth.setupPinInput}
-                        required
-                      />
-                    </label>
+                    <PinField
+                      label="New PIN"
+                      value={newPin}
+                      onValueChange={setNewPin}
+                      size="large"
+                      disabled={loading}
+                      ariaLabel="New PIN"
+                      className="input-lg"
+                      data-testid={TID.auth.setupPinInput}
+                      required
+                    />
                     <p className="label text-base-content/60">
                       Choose a secure 4-digit PIN that is not easy to guess.
                     </p>
 
-                    <label className="input input-lg w-full">
-                      <span className="label">Confirm New PIN</span>
-                      <input
-                        type="password"
-                        inputMode="numeric"
-                        maxLength={4}
-                        className="grow text-center font-mono text-2xl tracking-[0.45em]"
-                        value={confirmPin}
-                        onChange={(changeEvent) =>
-                          setConfirmPin(changeEvent.target.value.replace(/\D/g, '').slice(0, 4))
-                        }
-                        disabled={loading}
-                        autoComplete="off"
-                        aria-label="Confirm new PIN"
-                        data-testid={TID.auth.setupPinConfirmInput}
-                        required
-                      />
-                    </label>
+                    <PinField
+                      label="Confirm New PIN"
+                      value={confirmPin}
+                      onValueChange={setConfirmPin}
+                      size="large"
+                      disabled={loading}
+                      ariaLabel="Confirm new PIN"
+                      className="input-lg"
+                      data-testid={TID.auth.setupPinConfirmInput}
+                      required
+                    />
 
                     <div className="grid grid-cols-2 gap-(--space-2)">
                       <button

--- a/apps/frontend-admin/src/app/logs/page.tsx
+++ b/apps/frontend-admin/src/app/logs/page.tsx
@@ -1,0 +1,1 @@
+export { LogsPage as default } from '@/components/logs/logs-page'

--- a/apps/frontend-admin/src/components/auth/change-pin-modal.tsx
+++ b/apps/frontend-admin/src/components/auth/change-pin-modal.tsx
@@ -12,6 +12,7 @@ import {
   DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog'
+import { PinField } from './pin-field'
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || ''
 
@@ -104,53 +105,32 @@ export function ChangePinModal({ open, onOpenChange }: ChangePinModalProps) {
             </div>
           )}
 
-          <label className="input w-full">
-            <span className="label">Current PIN</span>
-            <input
-              id="current-pin"
-              type="password"
-              inputMode="numeric"
-              maxLength={4}
-              className="grow font-mono text-center tracking-[0.5em]"
-              value={currentPin}
-              onChange={(e) => setCurrentPin(e.target.value.replace(/\D/g, '').slice(0, 4))}
-              disabled={loading}
-              autoComplete="off"
-              required
-            />
-          </label>
+          <PinField
+            id="current-pin"
+            label="Current PIN"
+            value={currentPin}
+            onValueChange={setCurrentPin}
+            disabled={loading}
+            required
+          />
 
-          <label className="input w-full">
-            <span className="label">New PIN</span>
-            <input
-              id="new-pin"
-              type="password"
-              inputMode="numeric"
-              maxLength={4}
-              className="grow font-mono text-center tracking-[0.5em]"
-              value={newPin}
-              onChange={(e) => setNewPin(e.target.value.replace(/\D/g, '').slice(0, 4))}
-              disabled={loading}
-              autoComplete="off"
-              required
-            />
-          </label>
+          <PinField
+            id="new-pin"
+            label="New PIN"
+            value={newPin}
+            onValueChange={setNewPin}
+            disabled={loading}
+            required
+          />
 
-          <label className="input w-full">
-            <span className="label">Confirm New PIN</span>
-            <input
-              id="confirm-pin"
-              type="password"
-              inputMode="numeric"
-              maxLength={4}
-              className="grow font-mono text-center tracking-[0.5em]"
-              value={confirmPin}
-              onChange={(e) => setConfirmPin(e.target.value.replace(/\D/g, '').slice(0, 4))}
-              disabled={loading}
-              autoComplete="off"
-              required
-            />
-          </label>
+          <PinField
+            id="confirm-pin"
+            label="Confirm New PIN"
+            value={confirmPin}
+            onValueChange={setConfirmPin}
+            disabled={loading}
+            required
+          />
 
           <DialogFooter>
             <button

--- a/apps/frontend-admin/src/components/auth/pin-field.logic.test.ts
+++ b/apps/frontend-admin/src/components/auth/pin-field.logic.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { getMaskedPinDisplay, sanitizePinValue } from './pin-field.logic'
+
+describe('pin-field logic', () => {
+  it('strips non-digits and caps PIN values at four characters', () => {
+    expect(sanitizePinValue('12a34b56')).toBe('1234')
+  })
+
+  it('renders standard bullet masking without exposing digits', () => {
+    expect(getMaskedPinDisplay('12')).toBe('••')
+  })
+
+  it('renders slot placeholders for login-style PIN entry', () => {
+    expect(getMaskedPinDisplay('12', 'slots')).toBe('• • - -')
+  })
+
+  it('ignores invalid characters when building the masked display', () => {
+    expect(getMaskedPinDisplay('1a2b3c4d5', 'slots')).toBe('• • • •')
+  })
+})

--- a/apps/frontend-admin/src/components/auth/pin-field.logic.ts
+++ b/apps/frontend-admin/src/components/auth/pin-field.logic.ts
@@ -1,0 +1,24 @@
+export type PinFieldPlaceholderStyle = 'bullets' | 'slots'
+
+const PIN_MAX_LENGTH = 4
+const MASK_CHAR = '\u2022'
+const EMPTY_SLOT_CHAR = '-'
+
+export function sanitizePinValue(value: string): string {
+  return value.replace(/\D/g, '').slice(0, PIN_MAX_LENGTH)
+}
+
+export function getMaskedPinDisplay(
+  value: string,
+  placeholderStyle: PinFieldPlaceholderStyle = 'bullets'
+): string {
+  const sanitizedValue = sanitizePinValue(value)
+
+  if (placeholderStyle === 'slots') {
+    return Array.from({ length: PIN_MAX_LENGTH }, (_, index) =>
+      index < sanitizedValue.length ? MASK_CHAR : EMPTY_SLOT_CHAR
+    ).join(' ')
+  }
+
+  return MASK_CHAR.repeat(sanitizedValue.length)
+}

--- a/apps/frontend-admin/src/components/auth/pin-field.tsx
+++ b/apps/frontend-admin/src/components/auth/pin-field.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+/* global HTMLInputElement */
+
+import { forwardRef, type InputHTMLAttributes } from 'react'
+import { cn } from '@/lib/utils'
+import {
+  getMaskedPinDisplay,
+  sanitizePinValue,
+  type PinFieldPlaceholderStyle,
+} from './pin-field.logic'
+
+interface PinFieldProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'type' | 'inputMode' | 'autoComplete' | 'maxLength' | 'size' | 'value' | 'onChange'
+> {
+  value: string
+  onValueChange: (value: string) => void
+  label?: string
+  ariaLabel?: string
+  size?: 'default' | 'large'
+  placeholderStyle?: PinFieldPlaceholderStyle
+  containerClassName?: string
+  inputClassName?: string
+  maskClassName?: string
+}
+
+const sizeClasses = {
+  default: 'font-mono text-center tracking-[0.5em]',
+  large: 'font-mono text-center text-2xl tracking-[0.45em]',
+} as const
+
+export const PinField = forwardRef<HTMLInputElement, PinFieldProps>(function PinField(
+  {
+    value,
+    onValueChange,
+    label,
+    ariaLabel,
+    size = 'default',
+    placeholderStyle = 'bullets',
+    className,
+    containerClassName,
+    inputClassName,
+    maskClassName,
+    disabled,
+    ...props
+  },
+  ref
+) {
+  const sanitizedValue = sanitizePinValue(value)
+  const maskedValue = getMaskedPinDisplay(sanitizedValue, placeholderStyle)
+
+  return (
+    <label className={cn('input w-full', className)}>
+      {label ? <span className="label">{label}</span> : null}
+      <div className={cn('relative grow', containerClassName)}>
+        <input
+          {...props}
+          ref={ref}
+          type="text"
+          inputMode="numeric"
+          autoComplete="off"
+          maxLength={4}
+          value={sanitizedValue}
+          onChange={(event) => onValueChange(sanitizePinValue(event.target.value))}
+          disabled={disabled}
+          aria-label={ariaLabel}
+          className={cn(
+            'relative z-10 w-full grow bg-transparent text-transparent caret-base-content outline-none selection:bg-primary-fadded selection:text-transparent',
+            sizeClasses[size],
+            inputClassName
+          )}
+        />
+        <span
+          aria-hidden="true"
+          className={cn(
+            'pointer-events-none absolute inset-y-0 left-0 flex w-full items-center whitespace-pre text-base-content',
+            sizeClasses[size],
+            disabled ? 'text-base-content/50' : 'text-base-content',
+            maskClassName
+          )}
+        >
+          {maskedValue}
+        </span>
+      </div>
+    </label>
+  )
+})

--- a/apps/frontend-admin/src/components/auth/pin-input.tsx
+++ b/apps/frontend-admin/src/components/auth/pin-input.tsx
@@ -2,7 +2,7 @@
 
 /* global HTMLInputElement */
 
-import { useRef, useEffect, useMemo, useState, type ChangeEvent, type KeyboardEvent } from 'react'
+import { useRef, useEffect, useMemo, useState, type KeyboardEvent } from 'react'
 import type { RemoteSystemLoginContext, RemoteSystemOption } from '@sentinel/contracts'
 import { KeyRound, ArrowLeft, LoaderCircle, LogIn } from 'lucide-react'
 import { TID } from '@/lib/test-ids'
@@ -13,6 +13,7 @@ import {
   resolveForcedRemoteSystem,
   type PinInputInitialSelection,
 } from './pin-input.logic'
+import { PinField } from './pin-field'
 
 export type { PinInputInitialSelection } from './pin-input.logic'
 
@@ -104,11 +105,6 @@ export function PinInput({
       pin,
       remoteSystemId: effectiveSelectedRemoteSystem,
     })
-  }
-
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value.replace(/\D/g, '').slice(0, 4)
-    setPin(value)
   }
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
@@ -217,7 +213,9 @@ export function PinInput({
             Required so Sentinel can track which managed station is connected.
           </p>
           {!remoteSystemsLoading && remoteSystems.some((system) => system.isOccupied) && (
-            <p className="label text-base-content/60">In-use systems stay visible but cannot be selected.</p>
+            <p className="label text-base-content/60">
+              In-use systems stay visible but cannot be selected.
+            </p>
           )}
           {remoteSystemsLoading && (
             <p className="label text-base-content/60">Loading managed remote systems...</p>
@@ -235,24 +233,19 @@ export function PinInput({
         </fieldset>
       )}
 
-      <label className="input input-lg w-full">
-        <span className="label">PIN</span>
-        <input
-          ref={inputRef}
-          type="password"
-          inputMode="numeric"
-          className="grow text-center font-mono text-2xl tracking-[0.45em]"
-          placeholder="- - - -"
-          value={pin}
-          onChange={handleChange}
-          onKeyDown={handleKeyDown}
-          maxLength={4}
-          disabled={loading}
-          aria-label="PIN"
-          autoComplete="off"
-          data-testid={TID.auth.pinInput}
-        />
-      </label>
+      <PinField
+        ref={inputRef}
+        label="PIN"
+        value={pin}
+        onValueChange={setPin}
+        size="large"
+        placeholderStyle="slots"
+        onKeyDown={handleKeyDown}
+        disabled={loading}
+        ariaLabel="PIN"
+        className="input-lg"
+        data-testid={TID.auth.pinInput}
+      />
 
       <div className="grid grid-cols-2 gap-(--space-2)">
         <button

--- a/apps/frontend-admin/src/components/checkins/manual-checkin-modal.logic.test.ts
+++ b/apps/frontend-admin/src/components/checkins/manual-checkin-modal.logic.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import {
+  evaluateManualCheckinEligibility,
+  formatManualCheckinMemberLabel,
+  type ManualCheckinMemberOption,
+} from './manual-checkin-modal.logic'
+
+function createMember(
+  id: string,
+  overrides: Partial<ManualCheckinMemberOption> = {}
+): ManualCheckinMemberOption {
+  return {
+    id,
+    rank: 'PO2',
+    firstName: 'Jordan',
+    lastName: `Member${id}`,
+    displayName: null,
+    serviceNumber: `10000000${id}`,
+    ...overrides,
+  }
+}
+
+describe('evaluateManualCheckinEligibility', () => {
+  it('filters to absent members for check-in', () => {
+    const members = [createMember('1'), createMember('2')]
+
+    const result = evaluateManualCheckinEligibility({
+      members,
+      presentMemberIds: new Set(['1']),
+      direction: 'in',
+      selectedMemberId: null,
+    })
+
+    expect(result.eligibleMembers.map((member) => member.id)).toEqual(['2'])
+    expect(result.selectedMemberReason).toBeNull()
+  })
+
+  it('filters to present members for check-out', () => {
+    const members = [createMember('1'), createMember('2')]
+
+    const result = evaluateManualCheckinEligibility({
+      members,
+      presentMemberIds: new Set(['2']),
+      direction: 'out',
+      selectedMemberId: null,
+    })
+
+    expect(result.eligibleMembers.map((member) => member.id)).toEqual(['2'])
+  })
+
+  it('reports when the selected member is already checked in for check-in', () => {
+    const members = [createMember('1')]
+
+    const result = evaluateManualCheckinEligibility({
+      members,
+      presentMemberIds: new Set(['1']),
+      direction: 'in',
+      selectedMemberId: '1',
+    })
+
+    expect(result.selectedMemberEligible).toBe(false)
+    expect(result.selectedMemberReason).toContain('already checked in')
+  })
+
+  it('reports when the selected member is not checked in for check-out', () => {
+    const members = [createMember('1')]
+
+    const result = evaluateManualCheckinEligibility({
+      members,
+      presentMemberIds: new Set(),
+      direction: 'out',
+      selectedMemberId: '1',
+    })
+
+    expect(result.selectedMemberEligible).toBe(false)
+    expect(result.selectedMemberReason).toContain('not currently checked in')
+  })
+})
+
+describe('formatManualCheckinMemberLabel', () => {
+  it('prefers display name and appends short service number', () => {
+    expect(
+      formatManualCheckinMemberLabel(
+        createMember('321', {
+          displayName: 'PO2 Taylor Hunt',
+          serviceNumber: '1234567890',
+        })
+      )
+    ).toBe('PO2 Taylor Hunt (890)')
+  })
+})

--- a/apps/frontend-admin/src/components/checkins/manual-checkin-modal.logic.ts
+++ b/apps/frontend-admin/src/components/checkins/manual-checkin-modal.logic.ts
@@ -1,0 +1,85 @@
+export type ManualCheckinDirection = 'in' | 'out'
+
+export interface ManualCheckinMemberOption {
+  id: string
+  rank: string
+  displayName?: string | null
+  firstName: string
+  lastName: string
+  serviceNumber: string
+}
+
+export interface ManualCheckinEligibilityResult {
+  eligibleMembers: ManualCheckinMemberOption[]
+  selectedMemberEligible: boolean
+  selectedMemberReason: string | null
+}
+
+function getFormattedName(member: ManualCheckinMemberOption): string {
+  return (
+    member.displayName?.trim() || `${member.rank} ${member.lastName}, ${member.firstName}`.trim()
+  )
+}
+
+export function formatManualCheckinMemberLabel(member: ManualCheckinMemberOption): string {
+  return `${getFormattedName(member)} (${member.serviceNumber.slice(-3)})`
+}
+
+export function evaluateManualCheckinEligibility({
+  members,
+  presentMemberIds,
+  direction,
+  selectedMemberId,
+}: {
+  members: ManualCheckinMemberOption[]
+  presentMemberIds: Set<string>
+  direction: ManualCheckinDirection
+  selectedMemberId: string | null
+}): ManualCheckinEligibilityResult {
+  const eligibleMembers = members.filter((member) => {
+    const isPresent = presentMemberIds.has(member.id)
+    return direction === 'in' ? !isPresent : isPresent
+  })
+
+  if (!selectedMemberId) {
+    return {
+      eligibleMembers,
+      selectedMemberEligible: false,
+      selectedMemberReason: null,
+    }
+  }
+
+  const selectedMember = members.find((member) => member.id === selectedMemberId)
+
+  if (!selectedMember) {
+    return {
+      eligibleMembers,
+      selectedMemberEligible: false,
+      selectedMemberReason: 'Selected member is no longer available.',
+    }
+  }
+
+  const isPresent = presentMemberIds.has(selectedMember.id)
+
+  if (direction === 'in' && isPresent) {
+    return {
+      eligibleMembers,
+      selectedMemberEligible: false,
+      selectedMemberReason: `${getFormattedName(selectedMember)} is already checked in.`,
+    }
+  }
+
+  if (direction === 'out' && !isPresent) {
+    return {
+      eligibleMembers,
+      selectedMemberEligible: false,
+      selectedMemberReason: `${getFormattedName(selectedMember)} is not currently checked in.`,
+    }
+  }
+
+  return {
+    eligibleMembers,
+    selectedMemberEligible: true,
+    selectedMemberReason: null,
+  }
+}

--- a/apps/frontend-admin/src/components/checkins/manual-checkin-modal.tsx
+++ b/apps/frontend-admin/src/components/checkins/manual-checkin-modal.tsx
@@ -1,31 +1,41 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
-import { useForm } from 'react-hook-form'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { AlertTriangle, ArrowRightLeft, Search, UserCheck, UserX, X } from 'lucide-react'
 import { useCreateCheckin } from '@/hooks/use-checkins'
 import { useMembers } from '@/hooks/use-members'
+import { usePresentPeople } from '@/hooks/use-present-people'
 import { useCheckoutOptions } from '@/hooks/use-lockup'
-import { AlertTriangle, Search, X } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { AppCard, AppCardContent } from '@/components/ui/AppCard'
+import { AppBadge } from '@/components/ui/AppBadge'
 import { LockupOptionsModal } from '@/components/lockup/lockup-options-modal'
-import type { CreateCheckinInput } from '@sentinel/contracts'
+import type { CreateCheckinInput, PresentPerson } from '@sentinel/contracts'
 import { TID } from '@/lib/test-ids'
+import {
+  evaluateManualCheckinEligibility,
+  formatManualCheckinMemberLabel,
+  type ManualCheckinDirection,
+  type ManualCheckinMemberOption,
+} from './manual-checkin-modal.logic'
 
 interface ManualCheckinModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
 }
 
-interface FormData {
-  memberId: string
-  direction: 'in' | 'out'
-}
-
 export function ManualCheckinModal({ open, onOpenChange }: ManualCheckinModalProps) {
-  // eslint-disable-next-line no-undef -- DOM type available in browser build
-  const dialogRef = useRef<HTMLDialogElement>(null)
   // eslint-disable-next-line no-undef -- DOM type available in browser build
   const searchInputRef = useRef<HTMLInputElement>(null)
   const [memberSearch, setMemberSearch] = useState('')
+  const [direction, setDirection] = useState<ManualCheckinDirection>('in')
   const [selectedMemberInfo, setSelectedMemberInfo] = useState<{
     id: string
     rank: string
@@ -34,33 +44,32 @@ export function ManualCheckinModal({ open, onOpenChange }: ManualCheckinModalPro
     lastName: string
     serviceNumber: string
   } | null>(null)
+  const [submitError, setSubmitError] = useState<string | null>(null)
   const showMemberList = !selectedMemberInfo
-  const { data: membersData } = useMembers({
+  const {
+    data: membersData,
+    isLoading: isMembersLoading,
+    isError: isMembersError,
+  } = useMembers({
     limit: 100,
     search: showMemberList && memberSearch ? memberSearch : undefined,
   })
+  const {
+    data: presentPeopleData,
+    isLoading: isPresenceLoading,
+    isError: isPresenceError,
+  } = usePresentPeople()
   const createCheckin = useCreateCheckin()
   const [showLockupOptions, setShowLockupOptions] = useState(false)
-  const [pendingCheckout, setPendingCheckout] = useState<FormData | null>(null)
+  const [pendingCheckout, setPendingCheckout] = useState<{
+    memberId: string
+    direction: ManualCheckinDirection
+  } | null>(null)
 
-  const {
-    handleSubmit,
-    reset,
-    setValue,
-    watch,
-    formState: { errors, isSubmitting },
-  } = useForm<FormData>({
-    defaultValues: {
-      memberId: '',
-      direction: 'in',
-    },
-  })
-
-  const selectedMemberId = watch('memberId')
-  const selectedDirection = watch('direction')
+  const selectedMemberId = selectedMemberInfo?.id ?? ''
 
   const { data: checkoutOptions, isLoading: loadingCheckoutOptions } = useCheckoutOptions(
-    selectedDirection === 'out' && selectedMemberId ? selectedMemberId : ''
+    direction === 'out' && selectedMemberId ? selectedMemberId : ''
   )
 
   const memberName = selectedMemberInfo
@@ -70,55 +79,92 @@ export function ManualCheckinModal({ open, onOpenChange }: ManualCheckinModalPro
 
   const holdsLockup = checkoutOptions?.holdsLockup ?? false
   const canCheckoutNormally = checkoutOptions?.canCheckout ?? true
-  const isFormBusy = isSubmitting || loadingCheckoutOptions
+  const isFormBusy = createCheckin.isPending || loadingCheckoutOptions
 
-  // Sync open prop with dialog element
-  useEffect(() => {
-    const dialog = dialogRef.current
-    if (!dialog) return
-    if (open && !dialog.open) dialog.showModal()
-    if (!open && dialog.open) dialog.close()
-  }, [open])
+  const members = useMemo<ManualCheckinMemberOption[]>(
+    () =>
+      membersData?.members.map((member) => ({
+        id: member.id,
+        rank: member.rank,
+        displayName: member.displayName ?? null,
+        firstName: member.firstName,
+        lastName: member.lastName,
+        serviceNumber: member.serviceNumber,
+      })) ?? [],
+    [membersData?.members]
+  )
 
-  // Notify parent when dialog closes (ESC key, backdrop click)
-  useEffect(() => {
-    const dialog = dialogRef.current
-    if (!dialog) return
-    const handleClose = () => onOpenChange(false)
-    dialog.addEventListener('close', handleClose)
-    return () => dialog.removeEventListener('close', handleClose)
-  }, [onOpenChange])
+  const presentMemberIds = useMemo(
+    () =>
+      new Set(
+        (presentPeopleData?.people ?? [])
+          .filter(
+            (person): person is PresentPerson & { type: 'member' } => person.type === 'member'
+          )
+          .map((person) => person.id)
+      ),
+    [presentPeopleData?.people]
+  )
+
+  const eligibility = useMemo(
+    () =>
+      evaluateManualCheckinEligibility({
+        members,
+        presentMemberIds,
+        direction,
+        selectedMemberId: selectedMemberInfo?.id ?? null,
+      }),
+    [direction, members, presentMemberIds, selectedMemberInfo?.id]
+  )
 
   // Reset state when modal closes
   useEffect(() => {
     if (!open) {
       setPendingCheckout(null)
       setMemberSearch('')
+      setDirection('in')
       setSelectedMemberInfo(null)
+      setSubmitError(null)
     }
   }, [open])
 
-  const onSubmit = async (data: FormData) => {
-    if (data.direction === 'out' && holdsLockup && !canCheckoutNormally) {
-      setPendingCheckout(data)
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    const timer = window.setTimeout(() => {
+      searchInputRef.current?.focus()
+    }, 0)
+
+    return () => window.clearTimeout(timer)
+  }, [open, direction, selectedMemberInfo])
+
+  const onSubmit = async () => {
+    if (!selectedMemberInfo || !eligibility.selectedMemberEligible) {
+      return
+    }
+
+    setSubmitError(null)
+
+    if (direction === 'out' && holdsLockup && !canCheckoutNormally) {
+      setPendingCheckout({ memberId: selectedMemberInfo.id, direction })
       setShowLockupOptions(true)
       return
     }
 
     try {
       const checkinData: CreateCheckinInput = {
-        memberId: data.memberId,
-        direction: data.direction,
+        memberId: selectedMemberInfo.id,
+        direction,
         kioskId: 'ADMIN_MANUAL',
         method: 'manual',
       }
       await createCheckin.mutateAsync(checkinData)
-      reset()
-      setMemberSearch('')
-      setSelectedMemberInfo(null)
       onOpenChange(false)
     } catch (error) {
       console.error('Failed to create manual check-in:', error)
+      setSubmitError(error instanceof Error ? error.message : 'Failed to record manual presence')
     }
   }
 
@@ -135,205 +181,300 @@ export function ManualCheckinModal({ open, onOpenChange }: ManualCheckinModalPro
         await createCheckin.mutateAsync(checkinData)
       } catch (error) {
         console.error('Failed to complete checkout after lockup:', error)
+        setSubmitError(
+          error instanceof Error ? error.message : 'Failed to complete checkout after lockup'
+        )
+        return
       }
     }
-    // After execute, member was already checked out by bulk checkout — no action needed
+
     setPendingCheckout(null)
-    reset()
-    setMemberSearch('')
-    setSelectedMemberInfo(null)
     onOpenChange(false)
   }
 
+  const handleMemberClear = () => {
+    setSelectedMemberInfo(null)
+    setMemberSearch('')
+    setSubmitError(null)
+    window.setTimeout(() => {
+      searchInputRef.current?.focus()
+    }, 0)
+  }
+
+  const submitLabel =
+    direction === 'out' && holdsLockup && !canCheckoutNormally
+      ? 'Handle lockup and check out'
+      : direction === 'out'
+        ? 'Record check-out'
+        : 'Record check-in'
+
+  const hasSelectedMember = Boolean(selectedMemberInfo)
+  const canSubmit =
+    hasSelectedMember &&
+    eligibility.selectedMemberEligible &&
+    !isFormBusy &&
+    !(direction === 'out' && selectedMemberId && loadingCheckoutOptions)
+
   return (
     <>
-      <dialog ref={dialogRef} className="modal">
-        <div className="modal-box max-w-md">
-          {/* Header */}
-          <form method="dialog">
-            <button className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
-          </form>
-          <h3 className="text-lg font-bold">Manual Check-in</h3>
-          <p className="text-base-content/60 text-sm mt-1">
-            Record a manual check-in for a member who cannot use their badge.
-          </p>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent
+          size="lg"
+          className="max-h-[85vh] overflow-hidden"
+          testId={TID.checkins.manualModal.dialog}
+        >
+          <DialogHeader className="mb-0">
+            <div className="flex items-start justify-between gap-(--space-3) pr-10">
+              <div className="min-w-0">
+                <DialogTitle className="flex items-center gap-(--space-2) font-display">
+                  <ArrowRightLeft className="size-5 text-primary" />
+                  Manual in/out
+                </DialogTitle>
+                <DialogDescription>
+                  Pick a direction, then choose the member to record.
+                </DialogDescription>
+              </div>
+              <AppBadge status="info" size="sm">
+                DDS/Admin
+              </AppBadge>
+            </div>
+          </DialogHeader>
 
-          {/* Form */}
-          <form onSubmit={handleSubmit(onSubmit)} className="mt-4 space-y-4">
-            {/* Member Selection */}
-            <fieldset className="fieldset">
-              <legend className="fieldset-legend">
-                Member <span className="text-error">*</span>
-              </legend>
-              <div>
-                {selectedMemberInfo ? (
-                  <div className="input input-neutral flex items-center gap-2">
-                    <span className="label">Selected</span>
-                    <span className="flex-1 truncate">
-                      {selectedMemberInfo.displayName ??
-                        `${selectedMemberInfo.rank} ${selectedMemberInfo.lastName}, ${selectedMemberInfo.firstName}`}{' '}
-                      ({selectedMemberInfo.serviceNumber.slice(-3)})
-                    </span>
-                    <button
-                      type="button"
-                      className="btn btn-ghost btn-xs btn-circle"
-                      onClick={() => {
-                        setValue('memberId', '', { shouldValidate: true })
-                        setSelectedMemberInfo(null)
-                        setMemberSearch('')
-                        setTimeout(() => searchInputRef.current?.focus(), 0)
-                      }}
-                      disabled={isFormBusy}
-                      data-testid={TID.checkins.manualModal.clearMember}
-                    >
-                      <X className="h-3.5 w-3.5" />
-                    </button>
+          <div className="grid gap-(--space-4)">
+            <fieldset className="grid gap-(--space-2)">
+              <legend className="text-sm font-medium text-base-content">Direction</legend>
+              <div
+                className="grid grid-cols-2 gap-(--space-2)"
+                role="radiogroup"
+                aria-label="Manual direction"
+              >
+                <button
+                  type="button"
+                  className={`btn h-auto justify-start px-(--space-3) py-(--space-3) normal-case ${direction === 'in' ? 'btn-success' : 'btn-outline border-base-300 bg-base-100 text-base-content'}`}
+                  onClick={() => {
+                    setDirection('in')
+                    setSubmitError(null)
+                  }}
+                  disabled={isFormBusy}
+                  aria-pressed={direction === 'in'}
+                  data-testid={TID.checkins.manualModal.directionIn}
+                >
+                  <UserCheck className="size-4 shrink-0" />
+                  <span className="text-left">
+                    <span className="block text-sm font-semibold">Check in</span>
+                    <span className="block text-xs opacity-80">Show absent members first</span>
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  className={`btn h-auto justify-start px-(--space-3) py-(--space-3) normal-case ${direction === 'out' ? 'btn-error' : 'btn-outline border-base-300 bg-base-100 text-base-content'}`}
+                  onClick={() => {
+                    setDirection('out')
+                    setSubmitError(null)
+                  }}
+                  disabled={isFormBusy}
+                  aria-pressed={direction === 'out'}
+                  data-testid={TID.checkins.manualModal.directionOut}
+                >
+                  <UserX className="size-4 shrink-0" />
+                  <span className="text-left">
+                    <span className="block text-sm font-semibold">Check out</span>
+                    <span className="block text-xs opacity-80">Show present members first</span>
+                  </span>
+                </button>
+              </div>
+            </fieldset>
+
+            <div className="grid gap-(--space-2)">
+              <label className="input input-bordered input-sm w-full">
+                <span className="label">Search</span>
+                <Search className="h-4 w-4 text-base-content/50 pointer-events-none" />
+                <input
+                  ref={searchInputRef}
+                  type="text"
+                  className="grow"
+                  placeholder="Search by name or service number..."
+                  value={memberSearch}
+                  onChange={(event) => {
+                    setMemberSearch(event.target.value)
+                    setSubmitError(null)
+                  }}
+                  disabled={isFormBusy || !!selectedMemberInfo}
+                  data-testid={TID.checkins.manualModal.memberSearch}
+                />
+              </label>
+              <p className="text-xs text-base-content/55">
+                Only eligible members stay selectable for the chosen direction.
+              </p>
+            </div>
+
+            {selectedMemberInfo ? (
+              <AppCard className="border border-base-300 bg-base-200/50">
+                <AppCardContent className="flex items-center gap-(--space-3) p-(--space-3)">
+                  <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-primary-fadded text-primary-fadded-content">
+                    <ArrowRightLeft className="size-4" />
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-xs uppercase tracking-wide text-base-content/55">
+                      Selected member
+                    </p>
+                    <p className="truncate text-sm font-semibold text-base-content">
+                      {formatManualCheckinMemberLabel(selectedMemberInfo)}
+                    </p>
                   </div>
-                ) : (
-                  <>
-                    <label className="input input-neutral w-full">
-                      <span className="label">Search</span>
-                      <Search className="h-4 w-4 text-base-content/60 pointer-events-none" />
-                      <input
-                        ref={searchInputRef}
-                        type="text"
-                        className="grow"
-                        placeholder="Search by name or service number..."
-                        value={memberSearch}
-                        onChange={(e) => setMemberSearch(e.target.value)}
-                        disabled={isFormBusy}
-                        data-testid={TID.checkins.manualModal.memberSearch}
-                      />
-                    </label>
-                    <ul className="menu bg-base-200 rounded-box mt-2 w-full max-h-48 overflow-y-auto">
-                      {membersData?.members.length === 0 ? (
-                        <li className="disabled">
-                          <span className="text-base-content/60">No members found</span>
-                        </li>
-                      ) : (
-                        membersData?.members.map((member) => (
-                          <li key={member.id}>
-                            <button
-                              type="button"
-                              data-testid={TID.checkins.manualModal.memberOption(member.id)}
-                              onClick={() => {
-                                setValue('memberId', member.id, { shouldValidate: true })
-                                setSelectedMemberInfo({
-                                  id: member.id,
-                                  rank: member.rank,
-                                  displayName: member.displayName ?? undefined,
-                                  firstName: member.firstName,
-                                  lastName: member.lastName,
-                                  serviceNumber: member.serviceNumber,
-                                })
-                                setMemberSearch('')
-                              }}
-                            >
-                              <span className="font-medium">
-                                {member.displayName ??
-                                  `${member.rank} ${member.lastName}, ${member.firstName}`}
-                              </span>
-                              <span className="text-xs opacity-60">
-                                {member.serviceNumber.slice(-3)}
-                              </span>
-                            </button>
-                          </li>
-                        ))
-                      )}
-                    </ul>
-                  </>
-                )}
-              </div>
-              {errors.memberId && (
-                <span className="label text-error">{errors.memberId.message}</span>
-              )}
-            </fieldset>
-
-            {/* Direction Selection */}
-            <fieldset className="fieldset">
-              <legend className="fieldset-legend">
-                Direction <span className="text-error">*</span>
-              </legend>
-              <div className="flex gap-4">
-                <label className="flex items-center gap-2 cursor-pointer">
-                  <input
-                    type="radio"
-                    name="direction"
-                    className="radio radio-primary"
-                    checked={selectedDirection === 'in'}
-                    onChange={() => setValue('direction', 'in', { shouldValidate: true })}
+                  <button
+                    type="button"
+                    className="btn btn-ghost btn-xs btn-circle"
+                    onClick={handleMemberClear}
                     disabled={isFormBusy}
-                    data-testid={TID.checkins.manualModal.directionIn}
-                  />
-                  <span className="flex items-center gap-1.5">
-                    <span className="badge badge-success badge-sm">IN</span>
-                    Check In
-                  </span>
-                </label>
-                <label className="flex items-center gap-2 cursor-pointer">
-                  <input
-                    type="radio"
-                    name="direction"
-                    className="radio radio-primary"
-                    checked={selectedDirection === 'out'}
-                    onChange={() => setValue('direction', 'out', { shouldValidate: true })}
-                    disabled={isFormBusy}
-                    data-testid={TID.checkins.manualModal.directionOut}
-                  />
-                  <span className="flex items-center gap-1.5">
-                    <span className="badge badge-error badge-sm">OUT</span>
-                    Check Out
-                  </span>
-                </label>
-              </div>
-              {errors.direction && (
-                <span className="label text-error">{errors.direction.message}</span>
-              )}
-            </fieldset>
+                    data-testid={TID.checkins.manualModal.clearMember}
+                  >
+                    <X className="size-3.5" />
+                    <span className="sr-only">Clear selected member</span>
+                  </button>
+                </AppCardContent>
+              </AppCard>
+            ) : null}
 
-            {/* Lockup Warning */}
-            {selectedDirection === 'out' && selectedMemberId && holdsLockup && (
-              <div role="alert" className="alert alert-warning text-base-content">
-                <AlertTriangle className="h-5 w-5 shrink-0" />
-                <div>
-                  <h4 className="font-bold">Lockup Holder</h4>
-                  <p className="text-xs">
-                    This member holds lockup responsibility. They must transfer lockup or lock up
-                    the building before checking out.
+            <div className="min-h-64 overflow-hidden rounded-box border border-base-300 bg-base-100">
+              {isPresenceError || isMembersError ? (
+                <div className="grid gap-(--space-3) p-(--space-4)">
+                  <AppCard status="error" className="border border-base-300">
+                    <AppCardContent className="flex items-start gap-(--space-3) p-(--space-4)">
+                      <AlertTriangle className="mt-0.5 size-4.5 shrink-0 text-error" />
+                      <div>
+                        <p className="text-sm font-semibold text-base-content">
+                          Manual presence is unavailable
+                        </p>
+                        <p className="text-sm text-base-content/65">
+                          Close the modal and retry once member and presence data have loaded again.
+                        </p>
+                      </div>
+                    </AppCardContent>
+                  </AppCard>
+                </div>
+              ) : isMembersLoading || membersData === undefined || isPresenceLoading ? (
+                <div className="flex h-64 items-center justify-center">
+                  <span className="loading loading-spinner loading-md text-base-content/60" />
+                </div>
+              ) : eligibility.eligibleMembers.length === 0 ? (
+                <div className="flex h-64 flex-col items-center justify-center gap-(--space-2) px-(--space-4) text-center">
+                  <Search className="size-5 text-base-content/35" />
+                  <p className="text-sm font-medium text-base-content">No eligible members found</p>
+                  <p className="max-w-sm text-sm text-base-content/60">
+                    {direction === 'in'
+                      ? 'Try a different search or switch to check out to see members who are already present.'
+                      : 'Try a different search or switch to check in to see members who are currently absent.'}
                   </p>
                 </div>
-              </div>
-            )}
-
-            {/* Actions */}
-            <div className="modal-action">
-              <button
-                type="button"
-                className="btn btn-outline"
-                onClick={() => onOpenChange(false)}
-                disabled={isFormBusy}
-                data-testid={TID.checkins.manualModal.cancel}
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                className="btn btn-primary"
-                disabled={isFormBusy || !selectedMemberId}
-                data-testid={TID.checkins.manualModal.submit}
-              >
-                {isFormBusy && <span className="loading loading-spinner loading-sm" />}
-                {selectedDirection === 'out' && holdsLockup
-                  ? 'Handle Lockup & Check Out'
-                  : 'Create Check-in'}
-              </button>
+              ) : (
+                <ul className="menu max-h-64 overflow-y-auto p-(--space-2)">
+                  {eligibility.eligibleMembers.map((member) => (
+                    <li key={member.id}>
+                      <button
+                        type="button"
+                        className="flex items-center justify-between gap-(--space-3)"
+                        data-testid={TID.checkins.manualModal.memberOption(member.id)}
+                        onClick={() => {
+                          setSelectedMemberInfo({
+                            id: member.id,
+                            rank: member.rank,
+                            displayName: member.displayName ?? undefined,
+                            firstName: member.firstName,
+                            lastName: member.lastName,
+                            serviceNumber: member.serviceNumber,
+                          })
+                          setMemberSearch('')
+                          setSubmitError(null)
+                        }}
+                      >
+                        <span className="min-w-0 text-left">
+                          <span className="block truncate text-sm font-medium text-base-content">
+                            {member.displayName ??
+                              `${member.rank} ${member.lastName}, ${member.firstName}`}
+                          </span>
+                          <span className="block text-xs text-base-content/55">
+                            {member.serviceNumber.slice(-3)}
+                          </span>
+                        </span>
+                        <AppBadge status={direction === 'in' ? 'success' : 'neutral'} size="sm">
+                          {direction === 'in' ? 'Ready in' : 'Present'}
+                        </AppBadge>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
             </div>
-          </form>
-        </div>
-        <form method="dialog" className="modal-backdrop">
-          <button>close</button>
-        </form>
-      </dialog>
+
+            {eligibility.selectedMemberReason ? (
+              <div
+                role="alert"
+                className="alert alert-warning alert-soft text-sm text-base-content"
+              >
+                <AlertTriangle className="size-4 shrink-0" />
+                <span>{eligibility.selectedMemberReason}</span>
+              </div>
+            ) : null}
+
+            {direction === 'out' && selectedMemberId && loadingCheckoutOptions ? (
+              <div className="alert text-sm text-base-content">
+                <span className="loading loading-spinner loading-xs" />
+                <span>Checking lockup status before checkout.</span>
+              </div>
+            ) : null}
+
+            {direction === 'out' && selectedMemberId && holdsLockup ? (
+              <AppCard status="warning" className="border border-base-300 bg-warning-fadded/60">
+                <AppCardContent className="flex items-start gap-(--space-3) p-(--space-4)">
+                  <AlertTriangle className="mt-0.5 size-4.5 shrink-0 text-warning-fadded-content" />
+                  <div>
+                    <p className="text-sm font-semibold text-warning-fadded-content">
+                      Lockup must be resolved first
+                    </p>
+                    <p className="text-sm text-warning-fadded-content/80">
+                      This member holds lockup responsibility. Continue to transfer lockup or finish
+                      building lockup before checkout completes.
+                    </p>
+                  </div>
+                </AppCardContent>
+              </AppCard>
+            ) : null}
+
+            {submitError ? (
+              <div
+                role="alert"
+                aria-live="polite"
+                className="alert alert-error alert-soft text-sm text-base-content"
+              >
+                <AlertTriangle className="size-4 shrink-0" />
+                <span>{submitError}</span>
+              </div>
+            ) : null}
+          </div>
+
+          <DialogFooter className="mt-(--space-4)">
+            <button
+              type="button"
+              className="btn btn-outline"
+              onClick={() => onOpenChange(false)}
+              data-testid={TID.checkins.manualModal.cancel}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="btn btn-primary"
+              onClick={() => void onSubmit()}
+              disabled={!canSubmit || isPresenceError || isMembersError}
+              data-testid={TID.checkins.manualModal.submit}
+            >
+              {isFormBusy ? <span className="loading loading-spinner loading-sm" /> : null}
+              {submitLabel}
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Lockup Options Modal */}
       {checkoutOptions && (

--- a/apps/frontend-admin/src/components/dashboard/person-card-grid.tsx
+++ b/apps/frontend-admin/src/components/dashboard/person-card-grid.tsx
@@ -10,6 +10,7 @@ import { useDdsStatus } from '@/hooks/use-dds'
 import { useCurrentDds } from '@/hooks/use-schedules'
 import { useAuthStore, AccountLevel } from '@/store/auth-store'
 import { SimulateScanModal } from '@/components/dev/simulate-scan-modal'
+import { ManualCheckinModal } from '@/components/checkins/manual-checkin-modal'
 import {
   MemberActionPanel,
   type MemberActionDrawerSide,
@@ -21,6 +22,7 @@ import { TID } from '@/lib/test-ids'
 import { MotionButton } from '@/components/ui/motion-button'
 import { isSentinelBootstrapServiceNumber } from '@/lib/system-bootstrap'
 import { applyDashboardPersonCardSort } from '@/lib/dashboard-person-card-sort'
+import { canEditHistoryEntries, getCurrentDdsEditorId } from '@/lib/history-permissions'
 import { cn } from '@/lib/utils'
 
 type FilterType = 'all' | 'member' | 'visitor'
@@ -38,11 +40,14 @@ export function PersonCardGrid() {
   const [filter, setFilter] = useState<FilterType>('all')
   const [search, setSearch] = useState('')
   const [isScanModalOpen, setIsScanModalOpen] = useState(false)
+  const [isManualCheckinModalOpen, setIsManualCheckinModalOpen] = useState(false)
   const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null)
   const [selectedMemberActionView, setSelectedMemberActionView] = useState<MemberActionView>('menu')
   const [selectedMemberActionSide, setSelectedMemberActionSide] =
     useState<MemberActionDrawerSide>('right')
   const [isPending, startTransition] = useTransition()
+  const currentDdsMemberId = getCurrentDdsEditorId(scheduledDds)
+  const canCreateManualCheckin = canEditHistoryEntries(member, currentDdsMemberId)
 
   // Current DDS member ID (only when assignment is active/pending)
   const ddsMemberId = ddsStatus?.assignment?.memberId ?? null
@@ -237,6 +242,16 @@ export function PersonCardGrid() {
               Simulate Scan
             </MotionButton>
           )}
+          {canCreateManualCheckin && (
+            <MotionButton
+              className="btn btn-xs btn-outline border-base-300 bg-base-100 text-base-content/80 hover:border-primary/40 hover:bg-primary-fadded hover:text-primary-fadded-content"
+              onClick={() => setIsManualCheckinModalOpen(true)}
+              data-testid={TID.dashboard.quickAction.manualCheckin}
+            >
+              <UsersRound className="size-[1em] shrink-0" />
+              Manual in/out
+            </MotionButton>
+          )}
           <label className="input input-bordered input-sm w-full sm:w-56">
             <span className="label">Search</span>
             <Search size={14} className="text-base-content/40" />
@@ -255,6 +270,12 @@ export function PersonCardGrid() {
 
       {(isDevMode || isSentinelSystem) && (
         <SimulateScanModal open={isScanModalOpen} onOpenChange={setIsScanModalOpen} />
+      )}
+      {canCreateManualCheckin && (
+        <ManualCheckinModal
+          open={isManualCheckinModalOpen}
+          onOpenChange={setIsManualCheckinModalOpen}
+        />
       )}
 
       <div

--- a/apps/frontend-admin/src/components/layout/app-navbar.tsx
+++ b/apps/frontend-admin/src/components/layout/app-navbar.tsx
@@ -11,6 +11,7 @@ import { Menu, PanelLeftOpen } from 'lucide-react'
 import { toast } from 'sonner'
 import { AppBadge, type AppBadgeStatus } from '@/components/ui/AppBadge'
 import { Chip } from '@/components/ui/chip'
+import { ADMIN_NAV_ROUTES, isAdminNavPath } from '@/lib/admin-routes'
 import { cn } from '@/lib/utils'
 import { UserMenu } from '@/components/layout/user-menu'
 import { HelpButton } from '@/components/help/HelpButton'
@@ -26,13 +27,6 @@ const navLinks = [
   { href: '/members', label: 'Members' },
   { href: '/events', label: 'Events' },
   { href: '/schedules', label: 'Schedules' },
-]
-
-const adminLinks = [
-  { href: '/settings', label: 'Settings' },
-  { href: '/badges', label: 'Badges' },
-  { href: '/database', label: 'Database' },
-  { href: '/logs', label: 'Logs' },
 ]
 
 interface AppNavbarProps {
@@ -69,7 +63,7 @@ export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
     isLoading: isStatusLoading,
     isError: systemStatusQuery.isError,
   })
-  const isAdminRoute = adminLinks.some((link) => pathname === link.href)
+  const isAdminRoute = isAdminNavPath(pathname)
   const isClient = useSyncExternalStore(
     () => () => {},
     () => true,
@@ -155,9 +149,7 @@ export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
         }, delayMs)
       })
     } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : 'Failed to queue host hotspot recovery'
-      )
+      toast.error(error instanceof Error ? error.message : 'Failed to queue host hotspot recovery')
     }
   }
 
@@ -166,9 +158,7 @@ export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
       const result = await queueLatestSystemUpdate.mutateAsync()
       toast.success(result.message)
     } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : 'Failed to queue latest system update'
-      )
+      toast.error(error instanceof Error ? error.message : 'Failed to queue latest system update')
     }
   }
 
@@ -271,7 +261,7 @@ export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
                 tabIndex={-1}
                 className="dropdown-content z-20 w-56 rounded-box bg-base-100 p-2 text-base-content shadow-xl"
               >
-                {adminLinks.map((link) => (
+                {ADMIN_NAV_ROUTES.map((link) => (
                   <li key={link.href}>
                     <Link
                       href={link.href}
@@ -426,9 +416,7 @@ export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
                       : 'border-base-300 bg-base-200 text-base-content'
                   )}
                 >
-                  <p className="text-xs font-semibold uppercase tracking-wide">
-                    Wireless Recovery
-                  </p>
+                  <p className="text-xs font-semibold uppercase tracking-wide">Wireless Recovery</p>
                   <p className="mt-1 text-xs leading-relaxed">
                     Reconnect this laptop to the approved hotspot SSID, or ask the host server to
                     requeue a hotspot repair.

--- a/apps/frontend-admin/src/components/logs/logs-page.tsx
+++ b/apps/frontend-admin/src/components/logs/logs-page.tsx
@@ -1,0 +1,637 @@
+'use client'
+
+import { useEffect } from 'react'
+import { Activity, Cable, PauseCircle, PlayCircle, Search, ShieldAlert, Trash2 } from 'lucide-react'
+import {
+  AppCard,
+  AppCardContent,
+  AppCardDescription,
+  AppCardHeader,
+  AppCardTitle,
+} from '@/components/ui/AppCard'
+import { AppBadge, type AppBadgeStatus } from '@/components/ui/AppBadge'
+import { EmptyState } from '@/components/ui/empty-state'
+import { Chip, type ChipColor } from '@/components/ui/chip'
+import {
+  DEFAULT_LOG_FILTERS,
+  LOG_STREAM_LEVELS,
+  type LogStreamLevel,
+  useFilteredLogs,
+  useLogStats,
+  useLogViewer,
+  useLogViewerStore,
+} from '@/hooks/use-log-viewer'
+import { TID } from '@/lib/test-ids'
+import { cn } from '@/lib/utils'
+import { AccountLevel, useAuthStore } from '@/store/auth-store'
+
+function formatTimestamp(timestamp: string): string {
+  const date = new Date(timestamp)
+
+  if (Number.isNaN(date.getTime())) {
+    return timestamp
+  }
+
+  return new Intl.DateTimeFormat('en-CA', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    month: 'short',
+    day: '2-digit',
+  }).format(date)
+}
+
+function formatDateTime(timestamp: string): string {
+  const date = new Date(timestamp)
+
+  if (Number.isNaN(date.getTime())) {
+    return timestamp
+  }
+
+  return new Intl.DateTimeFormat('en-CA', {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  }).format(date)
+}
+
+function getLevelStatus(level: string): AppBadgeStatus {
+  switch (level) {
+    case 'error':
+      return 'error'
+    case 'warn':
+      return 'warning'
+    case 'info':
+    case 'http':
+      return 'info'
+    default:
+      return 'neutral'
+  }
+}
+
+function getLevelChipColor(level: string): ChipColor {
+  switch (level) {
+    case 'error':
+      return 'error'
+    case 'warn':
+      return 'warning'
+    case 'info':
+    case 'http':
+      return 'info'
+    case 'verbose':
+      return 'secondary'
+    case 'debug':
+      return 'accent'
+    case 'silly':
+      return 'neutral'
+    default:
+      return 'default'
+  }
+}
+
+function describeConnection(
+  isConnected: boolean,
+  isPaused: boolean
+): {
+  cardStatus: AppBadgeStatus
+  label: string
+  detail: string
+} {
+  if (!isConnected) {
+    return {
+      cardStatus: 'error',
+      label: 'Disconnected',
+      detail: 'Waiting for a live socket connection to the backend.',
+    }
+  }
+
+  if (isPaused) {
+    return {
+      cardStatus: 'warning',
+      label: 'Paused',
+      detail: 'Incoming entries are buffered locally until you resume.',
+    }
+  }
+
+  return {
+    cardStatus: 'success',
+    label: 'Streaming',
+    detail: 'Live entries are flowing into the viewer.',
+  }
+}
+
+function renderMetadata(metadata: Record<string, unknown> | undefined): string {
+  if (!metadata || Object.keys(metadata).length === 0) {
+    return 'No structured metadata'
+  }
+
+  return JSON.stringify(metadata, null, 2)
+}
+
+function LogsPageContent() {
+  const member = useAuthStore((state) => state.member)
+  const canAccessLogs = (member?.accountLevel ?? 0) >= AccountLevel.ADMIN
+
+  useLogViewer(canAccessLogs)
+
+  const logs = useFilteredLogs()
+  const stats = useLogStats()
+  const allLogs = useLogViewerStore((state) => state.logs)
+  const filters = useLogViewerStore((state) => state.filters)
+  const isConnected = useLogViewerStore((state) => state.isConnected)
+  const isPaused = useLogViewerStore((state) => state.isPaused)
+  const bufferedEntries = useLogViewerStore((state) => state.bufferedEntries)
+  const selectedLogId = useLogViewerStore((state) => state.selectedLogId)
+  const streamLevel = useLogViewerStore((state) => state.streamLevel)
+  const setFilter = useLogViewerStore((state) => state.setFilter)
+  const clearLogs = useLogViewerStore((state) => state.clearLogs)
+  const togglePause = useLogViewerStore((state) => state.togglePause)
+  const setSelectedLogId = useLogViewerStore((state) => state.setSelectedLogId)
+  const setStreamLevel = useLogViewerStore((state) => state.setStreamLevel)
+
+  const modules = [...new Set(allLogs.flatMap((log) => (log.module ? [log.module] : [])))].sort(
+    (left, right) => left.localeCompare(right)
+  )
+  const selectedLog =
+    logs.find((entry) => entry.id === selectedLogId) ??
+    allLogs.find((entry) => entry.id === selectedLogId) ??
+    null
+  const connection = describeConnection(isConnected, isPaused)
+
+  useEffect(() => {
+    if (!canAccessLogs) {
+      if (selectedLogId !== null) {
+        setSelectedLogId(null)
+      }
+      return
+    }
+
+    if (logs.length === 0) {
+      if (selectedLogId !== null) {
+        setSelectedLogId(null)
+      }
+      return
+    }
+
+    if (!selectedLogId || !logs.some((entry) => entry.id === selectedLogId)) {
+      setSelectedLogId(logs[0]?.id ?? null)
+    }
+  }, [canAccessLogs, logs, selectedLogId, setSelectedLogId])
+
+  if (!canAccessLogs) {
+    return (
+      <div className="space-y-(--space-4)">
+        <div>
+          <h1 className="text-3xl font-semibold">Logs</h1>
+          <p className="mt-(--space-1) max-w-3xl text-sm text-base-content/70">
+            Live operational log viewer for short-horizon incident triage and correlation-driven
+            debugging.
+          </p>
+        </div>
+
+        <AppCard status="warning">
+          <AppCardContent className="p-(--space-6)">
+            <EmptyState
+              icon={ShieldAlert}
+              title="Admin access required"
+              description="The live logs viewer is restricted to admin and developer accounts because it can expose operational diagnostics and sensitive context."
+            />
+          </AppCardContent>
+        </AppCard>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-(--space-4)">
+      <div className="flex flex-wrap items-end justify-between gap-(--space-4)">
+        <div>
+          <h1 className="text-3xl font-semibold">Logs</h1>
+          <p className="mt-(--space-1) max-w-3xl text-sm text-base-content/70">
+            Filter by severity, module, search terms, and correlation IDs before broad scans. This
+            viewer uses live socket updates plus a short in-memory history buffer from the backend.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-(--space-2)">
+          <AppBadge status={connection.cardStatus}>{connection.label}</AppBadge>
+          {isPaused && bufferedEntries.length > 0 ? (
+            <AppBadge status="warning">{bufferedEntries.length} buffered</AppBadge>
+          ) : null}
+          <AppBadge status="info">Level {streamLevel}</AppBadge>
+        </div>
+      </div>
+
+      <section className="grid gap-(--space-4) md:grid-cols-2 xl:grid-cols-4">
+        <AppCard status={connection.cardStatus} variant="elevated">
+          <AppCardHeader>
+            <AppCardTitle className="flex items-center gap-(--space-2)">
+              <Cable className="h-4 w-4" />
+              Connection
+            </AppCardTitle>
+            <AppCardDescription>{connection.detail}</AppCardDescription>
+          </AppCardHeader>
+          <AppCardContent className="pt-0">
+            <p className="text-2xl font-semibold">{connection.label}</p>
+          </AppCardContent>
+        </AppCard>
+
+        <AppCard status="info">
+          <AppCardHeader>
+            <AppCardTitle className="flex items-center gap-(--space-2)">
+              <Activity className="h-4 w-4" />
+              Live rate
+            </AppCardTitle>
+            <AppCardDescription>
+              Average events per second across the visible stream.
+            </AppCardDescription>
+          </AppCardHeader>
+          <AppCardContent className="pt-0">
+            <p className="text-2xl font-semibold">{stats.rate.toFixed(1)}/s</p>
+            <p className="mt-(--space-1) text-xs text-base-content/70">
+              {stats.total} retained entries in memory
+            </p>
+          </AppCardContent>
+        </AppCard>
+
+        <AppCard status={stats.errors > 0 ? 'error' : 'neutral'}>
+          <AppCardHeader>
+            <AppCardTitle>Errors</AppCardTitle>
+            <AppCardDescription>
+              Critical entries that usually need immediate triage.
+            </AppCardDescription>
+          </AppCardHeader>
+          <AppCardContent className="pt-0">
+            <p className="text-2xl font-semibold">{stats.errors}</p>
+            <p className="mt-(--space-1) text-xs text-base-content/70">
+              {stats.warnings} warnings currently retained
+            </p>
+          </AppCardContent>
+        </AppCard>
+
+        <AppCard status="neutral">
+          <AppCardHeader>
+            <AppCardTitle>Viewer state</AppCardTitle>
+            <AppCardDescription>
+              Entries that match the active filters in this session.
+            </AppCardDescription>
+          </AppCardHeader>
+          <AppCardContent className="pt-0">
+            <p className="text-2xl font-semibold">{logs.length}</p>
+            <p className="mt-(--space-1) text-xs text-base-content/70">
+              {filters.levels.length} level filters, {filters.modules.length} module filters
+            </p>
+          </AppCardContent>
+        </AppCard>
+      </section>
+
+      <AppCard>
+        <AppCardHeader>
+          <AppCardTitle>Viewer controls</AppCardTitle>
+          <AppCardDescription>
+            Pause the live stream when bursts get noisy, or narrow scope before searching.
+          </AppCardDescription>
+        </AppCardHeader>
+        <AppCardContent className="space-y-(--space-4)">
+          <div className="grid gap-(--space-3) xl:grid-cols-[minmax(0,1.3fr)_minmax(0,1fr)_12rem_auto]">
+            <label className="form-control w-full">
+              <span className="mb-(--space-1) text-xs font-medium uppercase tracking-wide text-base-content/65">
+                Search
+              </span>
+              <div className="input input-bordered input-sm flex items-center gap-(--space-2)">
+                <Search className="h-4 w-4 text-base-content/50" />
+                <input
+                  type="text"
+                  className="grow"
+                  placeholder="Message or metadata"
+                  value={filters.search}
+                  onChange={(event) => setFilter({ search: event.target.value })}
+                  data-testid={TID.logs.search}
+                />
+              </div>
+            </label>
+
+            <label className="form-control w-full">
+              <span className="mb-(--space-1) text-xs font-medium uppercase tracking-wide text-base-content/65">
+                Correlation ID
+              </span>
+              <input
+                type="text"
+                className="input input-bordered input-sm w-full"
+                placeholder="Filter a related incident chain"
+                value={filters.correlationId}
+                onChange={(event) => setFilter({ correlationId: event.target.value })}
+              />
+            </label>
+
+            <label className="form-control w-full">
+              <span className="mb-(--space-1) text-xs font-medium uppercase tracking-wide text-base-content/65">
+                Stream level
+              </span>
+              <select
+                className="select select-bordered select-sm w-full"
+                value={streamLevel}
+                onChange={(event) => setStreamLevel(event.target.value as LogStreamLevel)}
+                data-testid={TID.logs.streamLevel}
+              >
+                {LOG_STREAM_LEVELS.map((level) => (
+                  <option key={level} value={level}>
+                    {level}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <div className="flex flex-wrap items-end gap-(--space-2)">
+              <button
+                type="button"
+                className={cn('btn btn-sm', isPaused ? 'btn-warning' : 'btn-outline')}
+                onClick={() => togglePause()}
+                data-testid={TID.logs.pauseResumeBtn}
+              >
+                {isPaused ? (
+                  <PlayCircle className="h-4 w-4" />
+                ) : (
+                  <PauseCircle className="h-4 w-4" />
+                )}
+                {isPaused ? 'Resume stream' : 'Pause stream'}
+              </button>
+              <button
+                type="button"
+                className="btn btn-sm btn-outline"
+                onClick={() => setFilter({ ...DEFAULT_LOG_FILTERS })}
+                data-testid={TID.logs.clearFiltersBtn}
+              >
+                Clear filters
+              </button>
+              <button
+                type="button"
+                className="btn btn-sm btn-outline"
+                onClick={() => clearLogs()}
+                data-testid={TID.logs.clearLogsBtn}
+              >
+                <Trash2 className="h-4 w-4" />
+                Clear history
+              </button>
+            </div>
+          </div>
+
+          <div className="space-y-(--space-3)">
+            <div className="space-y-(--space-2)">
+              <div className="flex flex-wrap items-center gap-(--space-2)">
+                <p className="text-xs font-medium uppercase tracking-wide text-base-content/65">
+                  Level filters
+                </p>
+                <p className="text-xs text-base-content/55">
+                  Narrow to the severity band you want to investigate.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-(--space-2)">
+                {LOG_STREAM_LEVELS.map((level) => {
+                  const isActive = filters.levels.includes(level)
+
+                  return (
+                    <button
+                      key={level}
+                      type="button"
+                      className="rounded-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                      aria-pressed={isActive}
+                      onClick={() =>
+                        setFilter({
+                          levels: isActive
+                            ? filters.levels.filter((value) => value !== level)
+                            : [...filters.levels, level],
+                        })
+                      }
+                      data-testid={TID.logs.levelToggle(level)}
+                    >
+                      <Chip
+                        color={getLevelChipColor(level)}
+                        variant={isActive ? 'soft' : 'bordered'}
+                        size="sm"
+                        showDot
+                      >
+                        {level}
+                      </Chip>
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+
+            <div className="space-y-(--space-2)">
+              <div className="flex flex-wrap items-center gap-(--space-2)">
+                <p className="text-xs font-medium uppercase tracking-wide text-base-content/65">
+                  Module filters
+                </p>
+                <p className="text-xs text-base-content/55">
+                  Use modules to isolate a subsystem before broad search terms.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-(--space-2)">
+                {modules.length > 0 ? (
+                  modules.map((moduleName) => {
+                    const isActive = filters.modules.includes(moduleName)
+
+                    return (
+                      <button
+                        key={moduleName}
+                        type="button"
+                        className="rounded-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                        aria-pressed={isActive}
+                        onClick={() =>
+                          setFilter({
+                            modules: isActive
+                              ? filters.modules.filter((value) => value !== moduleName)
+                              : [...filters.modules, moduleName],
+                          })
+                        }
+                        data-testid={TID.logs.moduleToggle(moduleName)}
+                      >
+                        <Chip variant={isActive ? 'soft' : 'bordered'} size="sm">
+                          {moduleName}
+                        </Chip>
+                      </button>
+                    )
+                  })
+                ) : (
+                  <p className="text-sm text-base-content/55">
+                    Module chips will appear once the stream includes named subsystems.
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+        </AppCardContent>
+      </AppCard>
+
+      <div className="grid gap-(--space-4) xl:grid-cols-[minmax(0,2fr)_minmax(22rem,1fr)]">
+        <AppCard className="overflow-hidden">
+          <AppCardHeader>
+            <AppCardTitle>Live entries</AppCardTitle>
+            <AppCardDescription>
+              Select a row to inspect stack traces, correlation IDs, and metadata.
+            </AppCardDescription>
+          </AppCardHeader>
+          <AppCardContent className="min-h-0 p-0">
+            {logs.length > 0 ? (
+              <div className="max-h-[65vh] overflow-auto">
+                <table className="table table-pin-rows table-sm" data-testid={TID.logs.table}>
+                  <thead className="bg-base-200 text-xs uppercase tracking-wide text-base-content/65">
+                    <tr>
+                      <th>Time</th>
+                      <th>Level</th>
+                      <th>Module</th>
+                      <th>Message</th>
+                      <th>Correlation</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {logs.map((entry) => {
+                      const isSelected = entry.id === selectedLog?.id
+
+                      return (
+                        <tr
+                          key={entry.id}
+                          className={cn(
+                            'cursor-pointer align-top transition-colors',
+                            isSelected
+                              ? 'bg-primary-fadded text-primary-fadded-content'
+                              : 'hover:bg-base-200/70'
+                          )}
+                          onClick={() => setSelectedLogId(entry.id)}
+                          data-testid={TID.logs.row}
+                        >
+                          <td className="font-mono text-xs whitespace-nowrap">
+                            {formatTimestamp(entry.timestamp)}
+                          </td>
+                          <td>
+                            <AppBadge status={getLevelStatus(entry.level)} size="sm">
+                              {entry.level}
+                            </AppBadge>
+                          </td>
+                          <td className="font-mono text-xs text-base-content/70">
+                            {entry.module ?? 'system'}
+                          </td>
+                          <td className="max-w-xl">
+                            <div className="line-clamp-2 text-sm leading-snug">{entry.message}</div>
+                          </td>
+                          <td className="font-mono text-xs text-base-content/70">
+                            {entry.correlationId ? (
+                              <span className="truncate">{entry.correlationId}</span>
+                            ) : (
+                              '—'
+                            )}
+                          </td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <div className="p-(--space-6)">
+                <EmptyState
+                  icon={Activity}
+                  title="No matching logs"
+                  description="Adjust the filters or wait for the live stream to deliver the next entries."
+                />
+              </div>
+            )}
+          </AppCardContent>
+        </AppCard>
+
+        <AppCard className="overflow-hidden">
+          <AppCardHeader>
+            <AppCardTitle>Selected entry</AppCardTitle>
+            <AppCardDescription>
+              Use this panel for full message context, stack traces, and structured metadata.
+            </AppCardDescription>
+          </AppCardHeader>
+          <AppCardContent className="space-y-(--space-4)">
+            {selectedLog ? (
+              <>
+                <div className="flex flex-wrap items-center gap-(--space-2)">
+                  <AppBadge status={getLevelStatus(selectedLog.level)}>
+                    {selectedLog.level}
+                  </AppBadge>
+                  <Chip variant="soft" size="sm">
+                    {selectedLog.module ?? 'system'}
+                  </Chip>
+                  {selectedLog.correlationId ? (
+                    <Chip variant="bordered" size="sm">
+                      {selectedLog.correlationId}
+                    </Chip>
+                  ) : null}
+                </div>
+
+                <div className="space-y-(--space-2)">
+                  <div className="rounded-box border border-base-300 bg-base-200 p-(--space-3)">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-base-content/65">
+                      Message
+                    </p>
+                    <p className="mt-(--space-2) text-sm leading-relaxed">{selectedLog.message}</p>
+                  </div>
+
+                  <dl className="grid gap-(--space-2) sm:grid-cols-2">
+                    <div className="rounded-box border border-base-300 bg-base-100 p-(--space-3)">
+                      <dt className="text-xs font-semibold uppercase tracking-wide text-base-content/65">
+                        Timestamp
+                      </dt>
+                      <dd className="mt-(--space-1) font-mono text-xs">
+                        {formatDateTime(selectedLog.timestamp)}
+                      </dd>
+                    </div>
+                    <div className="rounded-box border border-base-300 bg-base-100 p-(--space-3)">
+                      <dt className="text-xs font-semibold uppercase tracking-wide text-base-content/65">
+                        User ID
+                      </dt>
+                      <dd className="mt-(--space-1) font-mono text-xs">
+                        {selectedLog.userId ?? 'Unavailable'}
+                      </dd>
+                    </div>
+                  </dl>
+                </div>
+
+                <div className="space-y-(--space-2)">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-base-content/65">
+                      Metadata
+                    </p>
+                    <pre className="mt-(--space-2) overflow-auto rounded-box border border-base-300 bg-base-100 p-(--space-3) text-xs leading-relaxed text-base-content/80">
+                      {renderMetadata(selectedLog.metadata)}
+                    </pre>
+                  </div>
+
+                  {selectedLog.stack ? (
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-wide text-base-content/65">
+                        Stack trace
+                      </p>
+                      <pre className="mt-(--space-2) overflow-auto rounded-box border border-base-300 bg-base-100 p-(--space-3) text-xs leading-relaxed text-base-content/80">
+                        {selectedLog.stack}
+                      </pre>
+                    </div>
+                  ) : null}
+                </div>
+              </>
+            ) : (
+              <EmptyState
+                icon={Cable}
+                title="Select a log entry"
+                description="Click an entry in the table to inspect its complete details."
+                className="py-(--space-10)"
+              />
+            )}
+          </AppCardContent>
+        </AppCard>
+      </div>
+    </div>
+  )
+}
+
+export function LogsPage() {
+  return <LogsPageContent />
+}

--- a/apps/frontend-admin/src/components/members/set-pin-modal.tsx
+++ b/apps/frontend-admin/src/components/members/set-pin-modal.tsx
@@ -12,6 +12,7 @@ import {
   DialogDescription,
   DialogFooter,
 } from '@/components/ui/dialog'
+import { PinField } from '@/components/auth/pin-field'
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || ''
 
@@ -108,37 +109,25 @@ export function SetPinModal({
             </div>
           )}
 
-          <label className="input input-bordered w-full" htmlFor="set-new-pin">
-            <span className="label">New PIN</span>
-            <input
-              id="set-new-pin"
-              type="password"
-              inputMode="numeric"
-              maxLength={4}
-              className="grow font-mono text-center tracking-[0.5em]"
-              value={newPin}
-              onChange={(e) => setNewPin(e.target.value.replace(/\D/g, '').slice(0, 4))}
-              disabled={loading}
-              autoComplete="off"
-              required
-            />
-          </label>
+          <PinField
+            id="set-new-pin"
+            label="New PIN"
+            value={newPin}
+            onValueChange={setNewPin}
+            className="input-bordered"
+            disabled={loading}
+            required
+          />
 
-          <label className="input input-bordered w-full" htmlFor="set-confirm-pin">
-            <span className="label">Confirm PIN</span>
-            <input
-              id="set-confirm-pin"
-              type="password"
-              inputMode="numeric"
-              maxLength={4}
-              className="grow font-mono text-center tracking-[0.5em]"
-              value={confirmPin}
-              onChange={(e) => setConfirmPin(e.target.value.replace(/\D/g, '').slice(0, 4))}
-              disabled={loading}
-              autoComplete="off"
-              required
-            />
-          </label>
+          <PinField
+            id="set-confirm-pin"
+            label="Confirm PIN"
+            value={confirmPin}
+            onValueChange={setConfirmPin}
+            className="input-bordered"
+            disabled={loading}
+            required
+          />
 
           <DialogFooter>
             <button

--- a/apps/frontend-admin/src/hooks/use-log-viewer.test.ts
+++ b/apps/frontend-admin/src/hooks/use-log-viewer.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const websocketManagerMock = vi.hoisted(() => ({
+  connect: vi.fn(),
+  subscribe: vi.fn(),
+  unsubscribe: vi.fn(),
+  on: vi.fn(),
+  emit: vi.fn(),
+  off: vi.fn(),
+  hasSocket: true,
+  isSocketConnected: true,
+}))
+
+vi.mock('@/lib/websocket', () => ({
+  websocketManager: websocketManagerMock,
+}))
+
+import {
+  DEFAULT_LOG_FILTERS,
+  DEFAULT_LOG_STREAM_LEVEL,
+  useLogViewerStore,
+  type LogEntry,
+} from './use-log-viewer'
+
+function createEntry(overrides: Partial<LogEntry>): LogEntry {
+  return {
+    id: overrides.id ?? 'entry-1',
+    timestamp: overrides.timestamp ?? '2026-04-21T12:00:00.000Z',
+    level: overrides.level ?? 'info',
+    message: overrides.message ?? 'hello world',
+    module: overrides.module,
+    correlationId: overrides.correlationId,
+    userId: overrides.userId,
+    metadata: overrides.metadata,
+    stack: overrides.stack,
+  }
+}
+
+describe('useLogViewerStore', () => {
+  beforeEach(() => {
+    websocketManagerMock.connect.mockReset()
+    websocketManagerMock.subscribe.mockReset()
+    websocketManagerMock.unsubscribe.mockReset()
+    websocketManagerMock.on.mockReset()
+    websocketManagerMock.emit.mockReset()
+    websocketManagerMock.off.mockReset()
+    websocketManagerMock.hasSocket = true
+    websocketManagerMock.isSocketConnected = true
+
+    useLogViewerStore.setState({
+      logs: [],
+      filters: { ...DEFAULT_LOG_FILTERS },
+      isConnected: false,
+      isPaused: false,
+      selectedLogId: null,
+      bufferedEntries: [],
+      streamLevel: DEFAULT_LOG_STREAM_LEVEL,
+    })
+  })
+
+  it('buffers paused entries without mutating visible logs', () => {
+    useLogViewerStore.getState().togglePause()
+    useLogViewerStore.getState().addLog(
+      createEntry({
+        id: 'paused-1',
+        message: 'buffer me',
+      })
+    )
+
+    expect(useLogViewerStore.getState().logs).toEqual([])
+    expect(useLogViewerStore.getState().bufferedEntries).toEqual([
+      expect.objectContaining({ id: 'paused-1', message: 'buffer me' }),
+    ])
+  })
+
+  it('flushes buffered entries newest-first when resuming', () => {
+    useLogViewerStore.setState({
+      logs: [
+        createEntry({ id: 'existing-1', timestamp: '2026-04-21T11:59:00.000Z' }),
+        createEntry({ id: 'existing-2', timestamp: '2026-04-21T11:58:00.000Z' }),
+      ],
+    })
+
+    useLogViewerStore.getState().togglePause()
+    useLogViewerStore
+      .getState()
+      .addLog(createEntry({ id: 'paused-1', timestamp: '2026-04-21T12:01:00.000Z' }))
+    useLogViewerStore
+      .getState()
+      .addLog(createEntry({ id: 'paused-2', timestamp: '2026-04-21T12:02:00.000Z' }))
+    useLogViewerStore.getState().togglePause()
+
+    expect(useLogViewerStore.getState().isPaused).toBe(false)
+    expect(useLogViewerStore.getState().bufferedEntries).toEqual([])
+    expect(useLogViewerStore.getState().logs.map((entry) => entry.id)).toEqual([
+      'paused-2',
+      'paused-1',
+      'existing-1',
+      'existing-2',
+    ])
+  })
+
+  it('requests a history refresh after changing stream level', () => {
+    useLogViewerStore.getState().setStreamLevel('debug')
+
+    expect(useLogViewerStore.getState().streamLevel).toBe('debug')
+    expect(websocketManagerMock.emit).toHaveBeenNthCalledWith(1, 'logs:set-level', 'debug')
+    expect(websocketManagerMock.emit).toHaveBeenNthCalledWith(2, 'logs:subscribe')
+  })
+
+  it('clears local state and backend history when clearing logs', () => {
+    useLogViewerStore.setState({
+      logs: [createEntry({ id: 'visible-1' })],
+      bufferedEntries: [createEntry({ id: 'buffered-1' })],
+      selectedLogId: 'visible-1',
+    })
+
+    useLogViewerStore.getState().clearLogs()
+
+    expect(websocketManagerMock.emit).toHaveBeenCalledWith('logs:clear-history')
+    expect(useLogViewerStore.getState().logs).toEqual([])
+    expect(useLogViewerStore.getState().bufferedEntries).toEqual([])
+    expect(useLogViewerStore.getState().selectedLogId).toBeNull()
+  })
+})

--- a/apps/frontend-admin/src/hooks/use-log-viewer.ts
+++ b/apps/frontend-admin/src/hooks/use-log-viewer.ts
@@ -23,6 +23,37 @@ export interface LogFilters {
   correlationId: string
 }
 
+export const LOG_STREAM_LEVELS = [
+  'error',
+  'warn',
+  'info',
+  'http',
+  'verbose',
+  'debug',
+  'silly',
+] as const
+
+export type LogStreamLevel = (typeof LOG_STREAM_LEVELS)[number]
+
+export const DEFAULT_LOG_FILTERS: LogFilters = {
+  levels: [],
+  modules: [],
+  search: '',
+  correlationId: '',
+}
+
+export const DEFAULT_LOG_STREAM_LEVEL: LogStreamLevel = 'info'
+
+const LOG_LEVEL_VALUE: Record<LogStreamLevel, number> = {
+  error: 0,
+  warn: 1,
+  info: 2,
+  http: 3,
+  verbose: 4,
+  debug: 5,
+  silly: 6,
+}
+
 interface LogViewerState {
   logs: LogEntry[]
   filters: LogFilters
@@ -30,6 +61,7 @@ interface LogViewerState {
   isPaused: boolean
   selectedLogId: string | null
   bufferedEntries: LogEntry[]
+  streamLevel: LogStreamLevel
 
   // Actions
   subscribe: () => void
@@ -41,53 +73,47 @@ interface LogViewerState {
   addLog: (entry: LogEntry) => void
   setHistory: (logs: LogEntry[]) => void
   setConnected: (connected: boolean) => void
+  setStreamLevel: (level: LogStreamLevel) => void
 }
 
 const MAX_LOGS = 2000
 
-export const useLogViewerStore = create<LogViewerState>((set, get) => ({
+export const useLogViewerStore = create<LogViewerState>((set) => ({
   logs: [],
-  filters: {
-    levels: [],
-    modules: [],
-    search: '',
-    correlationId: '',
-  },
+  filters: { ...DEFAULT_LOG_FILTERS },
   isConnected: false,
   isPaused: false,
   selectedLogId: null,
   bufferedEntries: [],
+  streamLevel: DEFAULT_LOG_STREAM_LEVEL,
 
   subscribe: () => {
-    set({ isConnected: true })
     websocketManager.connect()
+    set({ isConnected: websocketManager.isSocketConnected })
     websocketManager.subscribe('logs')
-
-    const handleHistory = (data: unknown) => {
-      if (Array.isArray(data)) {
-        get().setHistory(data as LogEntry[])
-      }
-    }
-
-    const handleEntry = (data: unknown) => {
-      if (data && typeof data === 'object' && 'id' in data) {
-        get().addLog(data as LogEntry)
-      }
-    }
-
     websocketManager.on('log:history', handleHistory)
     websocketManager.on('log:entry', handleEntry)
+    websocketManager.on('connect', handleConnect)
+    websocketManager.on('disconnect', handleDisconnect)
   },
 
   unsubscribe: () => {
     set({ isConnected: false })
-    websocketManager.unsubscribe('logs')
-    websocketManager.off('log:history')
-    websocketManager.off('log:entry')
+    if (websocketManager.hasSocket) {
+      websocketManager.unsubscribe('logs')
+      websocketManager.off('log:history', handleHistory)
+      websocketManager.off('log:entry', handleEntry)
+      websocketManager.off('connect', handleConnect)
+      websocketManager.off('disconnect', handleDisconnect)
+    }
   },
 
   clearLogs: () => {
-    set({ logs: [], bufferedEntries: [] })
+    if (websocketManager.hasSocket) {
+      websocketManager.emit('logs:clear-history')
+    }
+
+    set({ logs: [], bufferedEntries: [], selectedLogId: null })
   },
 
   setFilter: (partial: Partial<LogFilters>) => {
@@ -97,7 +123,17 @@ export const useLogViewerStore = create<LogViewerState>((set, get) => ({
   },
 
   togglePause: () => {
-    set((state) => ({ isPaused: !state.isPaused }))
+    set((state) => {
+      if (!state.isPaused) {
+        return { isPaused: true }
+      }
+
+      return {
+        isPaused: false,
+        logs: trimLogs([...state.bufferedEntries, ...state.logs]),
+        bufferedEntries: [],
+      }
+    })
   },
 
   setSelectedLogId: (id: string | null) => {
@@ -106,44 +142,106 @@ export const useLogViewerStore = create<LogViewerState>((set, get) => ({
 
   addLog: (entry: LogEntry) => {
     set((state) => {
-      const newLogs = [entry, ...state.logs]
-      if (newLogs.length > MAX_LOGS) {
-        newLogs.length = MAX_LOGS
-      }
-
       if (state.isPaused) {
         return {
-          logs: newLogs,
-          bufferedEntries: [entry, ...state.bufferedEntries],
+          bufferedEntries: trimLogs([entry, ...state.bufferedEntries]),
         }
       }
 
-      return { logs: newLogs }
+      return { logs: trimLogs([entry, ...state.logs]) }
     })
   },
 
   setHistory: (logs: LogEntry[]) => {
-    const sorted = [...logs].sort(
-      (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
-    )
-    set({ logs: sorted.slice(0, MAX_LOGS) })
+    set((state) => {
+      const sorted = trimLogs(sortLogs(logs))
+
+      return {
+        logs: sorted,
+        streamLevel: inferStreamLevel(sorted, state.streamLevel),
+      }
+    })
   },
 
   setConnected: (connected: boolean) => {
     set({ isConnected: connected })
   },
+
+  setStreamLevel: (level: LogStreamLevel) => {
+    set((state) => ({
+      streamLevel: level,
+      bufferedEntries: filterEntriesByStreamLevel(state.bufferedEntries, level),
+    }))
+
+    if (websocketManager.hasSocket) {
+      websocketManager.emit('logs:set-level', level)
+      websocketManager.emit('logs:subscribe')
+    }
+  },
 }))
 
-export function useLogViewer() {
+function sortLogs(logs: LogEntry[]): LogEntry[] {
+  return [...logs].sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+}
+
+function trimLogs(logs: LogEntry[]): LogEntry[] {
+  return logs.slice(0, MAX_LOGS)
+}
+
+function getLevelValue(level: string): number {
+  return LOG_LEVEL_VALUE[level as LogStreamLevel] ?? LOG_LEVEL_VALUE.info
+}
+
+function filterEntriesByStreamLevel(logs: LogEntry[], level: LogStreamLevel): LogEntry[] {
+  const threshold = LOG_LEVEL_VALUE[level]
+  return trimLogs(logs.filter((entry) => getLevelValue(entry.level) <= threshold))
+}
+
+function inferStreamLevel(logs: LogEntry[], fallback: LogStreamLevel): LogStreamLevel {
+  return logs.reduce<LogStreamLevel>((current, entry) => {
+    const nextLevel = entry.level as LogStreamLevel
+    if (!LOG_STREAM_LEVELS.includes(nextLevel)) {
+      return current
+    }
+
+    return LOG_LEVEL_VALUE[nextLevel] > LOG_LEVEL_VALUE[current] ? nextLevel : current
+  }, fallback)
+}
+
+function handleHistory(data: unknown) {
+  if (Array.isArray(data)) {
+    useLogViewerStore.getState().setHistory(data as LogEntry[])
+  }
+}
+
+function handleEntry(data: unknown) {
+  if (data && typeof data === 'object' && 'id' in data) {
+    useLogViewerStore.getState().addLog(data as LogEntry)
+  }
+}
+
+function handleConnect() {
+  useLogViewerStore.getState().setConnected(true)
+}
+
+function handleDisconnect() {
+  useLogViewerStore.getState().setConnected(false)
+}
+
+export function useLogViewer(enabled = true) {
   const subscribe = useLogViewerStore((s) => s.subscribe)
   const unsubscribe = useLogViewerStore((s) => s.unsubscribe)
 
   useEffect(() => {
+    if (!enabled) {
+      return
+    }
+
     subscribe()
     return () => {
       unsubscribe()
     }
-  }, [subscribe, unsubscribe])
+  }, [enabled, subscribe, unsubscribe])
 }
 
 export function useFilteredLogs(): LogEntry[] {
@@ -165,7 +263,9 @@ export function useFilteredLogs(): LogEntry[] {
       if (filters.search) {
         const searchLower = filters.search.toLowerCase()
         const messageMatch = log.message.toLowerCase().includes(searchLower)
-        const metadataMatch = log.metadata ? JSON.stringify(log.metadata).toLowerCase().includes(searchLower) : false
+        const metadataMatch = log.metadata
+          ? JSON.stringify(log.metadata).toLowerCase().includes(searchLower)
+          : false
         if (!messageMatch && !metadataMatch) {
           return false
         }

--- a/apps/frontend-admin/src/lib/admin-routes.test.ts
+++ b/apps/frontend-admin/src/lib/admin-routes.test.ts
@@ -1,0 +1,25 @@
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { ADMIN_NAV_ROUTES, isAdminNavPath } from './admin-routes'
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url))
+const appDir = path.resolve(currentDir, '../app')
+
+describe('ADMIN_NAV_ROUTES', () => {
+  it('matches known admin paths', () => {
+    expect(isAdminNavPath('/settings')).toBe(true)
+    expect(isAdminNavPath('/logs')).toBe(true)
+    expect(isAdminNavPath('/dashboard')).toBe(false)
+  })
+
+  it('only includes routes that ship a page entrypoint', () => {
+    for (const route of ADMIN_NAV_ROUTES) {
+      const routeSegment = route.href.slice(1)
+      const pagePath = path.join(appDir, routeSegment, 'page.tsx')
+
+      expect(existsSync(pagePath)).toBe(true)
+    }
+  })
+})

--- a/apps/frontend-admin/src/lib/admin-routes.ts
+++ b/apps/frontend-admin/src/lib/admin-routes.ts
@@ -1,0 +1,15 @@
+export interface AdminNavRoute {
+  href: `/${string}`
+  label: string
+}
+
+export const ADMIN_NAV_ROUTES = [
+  { href: '/settings', label: 'Settings' },
+  { href: '/badges', label: 'Badges' },
+  { href: '/database', label: 'Database' },
+  { href: '/logs', label: 'Logs' },
+] as const satisfies readonly AdminNavRoute[]
+
+export function isAdminNavPath(pathname: string): boolean {
+  return ADMIN_NAV_ROUTES.some((route) => route.href === pathname)
+}

--- a/apps/frontend-admin/src/lib/test-ids.ts
+++ b/apps/frontend-admin/src/lib/test-ids.ts
@@ -128,6 +128,7 @@ export const TID = {
       rowsPerPage: 'checkins-rows-per-page',
     },
     manualModal: {
+      dialog: 'manual-checkin-dialog',
       memberSearch: 'manual-checkin-member-search',
       clearMember: 'manual-checkin-clear-member',
       memberOption: (id: string) => `manual-checkin-member-${id}`,

--- a/apps/frontend-admin/src/lib/websocket.ts
+++ b/apps/frontend-admin/src/lib/websocket.ts
@@ -4,6 +4,14 @@ import { io, Socket } from 'socket.io-client'
 class WebSocketManager {
   private socket: Socket | null = null
 
+  get hasSocket(): boolean {
+    return this.socket !== null
+  }
+
+  get isSocketConnected(): boolean {
+    return this.socket?.connected ?? false
+  }
+
   connect() {
     if (this.socket) return
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

Prepare `v2.6.0` by shipping four workstreams together:

- reusable masked PIN inputs across auth and member PIN flows
- redesigned manual in/out operations with clearer eligibility handling
- restored `/logs` admin route with route-parity safeguards and regression tests
- repo-local `playwright-cli` Codex skill reference material

This PR also synchronizes workspace package versions to `2.6.0`.

## What Changed

### Auth and PIN flows

- Added a reusable `PinField` component plus masking/sanitizing logic tests.
- Replaced duplicated numeric PIN inputs in:
  - login PIN setup
  - forced PIN change
  - change PIN modal
  - member set PIN modal
  - main PIN entry surface
- Kept the existing 4-digit constraints while making the visual masking behavior consistent.

### Manual in/out workflow

- Reworked the manual check-in modal into a clearer manual in/out flow.
- Added direction-aware eligibility logic with dedicated tests.
- Added better selected-member state, clearer error handling, and lockup-aware checkout messaging.
- Exposed the manual in/out action from the dashboard quick actions for authorized operators.
- Added stable dialog/test IDs for Playwright and UI automation.

### Logs route restoration

- Restored the shipped `/logs` route that admin nav and help already referenced.
- Added a dense desktop-first live log viewer with:
  - connection state
  - search and correlation filters
  - level/module filters
  - pause/resume controls
  - clear-history action
  - selected entry detail panel
- Corrected log viewer store semantics so pause buffers correctly, resume flushes correctly, and stream-level changes refresh history.
- Added a shared admin route manifest plus parity tests so admin nav cannot point at a missing page again.
- Added a `.gitignore` exception so `apps/frontend-admin/src/app/logs/**` and `apps/frontend-admin/src/components/logs/**` are actually tracked despite the repo-wide `logs/` ignore rule.

### Codex tooling

- Added a repo-local `playwright-cli` skill under `.codex/skills/playwright-cli/` for project-specific agent workflows and references.

### Release prep

- Bumped root and workspace package versions from `2.5.1` to `2.6.0`.

## Why

- The logs route bug reported in Issue `#57` was still reproducible on current `main`: admin nav and help advertised `/logs`, but the Next app did not ship a `/logs` page.
- PIN entry behavior was duplicated across several surfaces, increasing drift and maintenance cost.
- Manual in/out operations needed a clearer direction-first workflow and better operator guidance around eligibility and lockup handoff.
- The workspace package versions had drifted behind the tagged release line and needed to be brought back in sync for the new release.

## User Impact

- Admin users regain a working Logs page instead of hitting a 404 from Admin navigation.
- Operators get a clearer manual in/out workflow from both the Check-ins page and dashboard quick actions.
- PIN entry and PIN setup flows are more consistent across login, forced PIN change, and member management.
- Internal Codex workflows gain a local Playwright skill reference set.

## Validation

- `pnpm --filter frontend-admin exec vitest run src/hooks/use-log-viewer.test.ts src/lib/admin-routes.test.ts src/components/layout/app-navbar.logic.test.ts src/help/help-registry.test.ts src/components/auth/pin-field.logic.test.ts src/components/checkins/manual-checkin-modal.logic.test.ts`
- `pnpm --filter frontend-admin typecheck`
- `pnpm --filter frontend-admin build`
- Desktop `playwright-cli` sanity pass at `1920x1080` for `/logs`:
  - admin route resolves and renders the full surface
  - pause/resume control toggles correctly
  - clear history action is reachable
  - non-admin state shows the intended access-required surface

## Issue

- Closes #57
