### PR TITLE
Release v2.6.1

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -9,6 +9,7 @@ import {
   checkinContract,
   divisionContract,
   badgeContract,
+  auditContract,
   eventContract,
   visitorContract,
   securityAlertContract,
@@ -54,6 +55,7 @@ import { membersRouter } from './routes/members.js'
 import { checkinsRouter } from './routes/checkins.js'
 import { divisionsRouter } from './routes/divisions.js'
 import { badgesRouter } from './routes/badges.js'
+import { auditLogsRouter } from './routes/audit-logs.js'
 import { eventsRouter } from './routes/events.js'
 import { visitorsRouter } from './routes/visitors.js'
 import { securityAlertsRouter } from './routes/security-alerts.js'
@@ -204,6 +206,15 @@ export function createApp(): Express {
     },
   })
   createExpressEndpoints(badgeContract, badgesRouter, app, {
+    requestValidationErrorHandler: (err, _req, res) => {
+      return res.status(400).json({
+        error: 'VALIDATION_ERROR',
+        message: 'Request validation failed',
+        issues: err.body?.issues || err.pathParams?.issues || err.query?.issues || [],
+      })
+    },
+  })
+  createExpressEndpoints(auditContract, auditLogsRouter, app, {
     requestValidationErrorHandler: (err, _req, res) => {
       return res.status(400).json({
         error: 'VALIDATION_ERROR',

--- a/apps/backend/src/lib/audit-log.ts
+++ b/apps/backend/src/lib/audit-log.ts
@@ -1,0 +1,82 @@
+import type { Request } from 'express'
+import type { AuditAction, AuditRepository } from '../repositories/audit-repository.js'
+
+type AuditedMember = {
+  id?: string
+  rank?: string
+  firstName?: string
+  lastName?: string
+  displayName?: string | null
+  serviceNumber?: string
+}
+
+type AuditedRequest = Pick<Request, 'ip' | 'socket'> & {
+  member?: AuditedMember
+}
+
+export function getAuditClientIp(req: AuditedRequest): string {
+  return req.ip || req.socket?.remoteAddress || 'unknown'
+}
+
+export function formatAuditMemberName(member?: AuditedMember | null): string | null {
+  if (!member) {
+    return null
+  }
+
+  if (typeof member.displayName === 'string' && member.displayName.trim().length > 0) {
+    return member.displayName.trim()
+  }
+
+  const nameParts = [member.rank, member.firstName, member.lastName].filter(
+    (value): value is string => typeof value === 'string' && value.trim().length > 0
+  )
+
+  if (nameParts.length === 0) {
+    return null
+  }
+
+  return nameParts.join(' ')
+}
+
+export function getAuditActorDetails(req: AuditedRequest) {
+  const actorName = formatAuditMemberName(req.member)
+
+  if (!req.member) {
+    return {
+      actorMemberId: null,
+      actorName: null,
+      actorServiceNumber: null,
+      actorType: 'system' as const,
+    }
+  }
+
+  return {
+    actorMemberId: req.member.id ?? null,
+    actorName,
+    actorServiceNumber: req.member.serviceNumber ?? null,
+    actorType: 'member' as const,
+  }
+}
+
+export async function logRequestAudit(
+  auditRepo: AuditRepository,
+  req: AuditedRequest,
+  entry: {
+    action: AuditAction
+    entityType: string
+    entityId: string | null
+    details?: Record<string, unknown>
+  }
+): Promise<void> {
+  await auditRepo.log({
+    adminUserId: null,
+    action: entry.action,
+    entityType: entry.entityType,
+    entityId: entry.entityId,
+    details: {
+      ...getAuditActorDetails(req),
+      ...(entry.details ?? {}),
+    },
+    ipAddress: getAuditClientIp(req),
+  })
+}

--- a/apps/backend/src/lib/kiosk-device-auth.test.ts
+++ b/apps/backend/src/lib/kiosk-device-auth.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  KIOSK_DEVICE_COOKIE_NAME,
+  authenticateKioskDeviceApiKey,
+  extractKioskDeviceApiKeyFromCookieHeader,
+  extractKioskDeviceApiKeyFromCookies,
+} from './kiosk-device-auth.js'
+
+const ORIGINAL_KIOSK_DEVICE_API_KEY = process.env.SENTINEL_KIOSK_DEVICE_API_KEY
+const ORIGINAL_KIOSK_DEVICE_NAME = process.env.SENTINEL_KIOSK_DEVICE_NAME
+
+describe('kiosk-device-auth', () => {
+  afterEach(() => {
+    if (ORIGINAL_KIOSK_DEVICE_API_KEY === undefined) {
+      delete process.env.SENTINEL_KIOSK_DEVICE_API_KEY
+    } else {
+      process.env.SENTINEL_KIOSK_DEVICE_API_KEY = ORIGINAL_KIOSK_DEVICE_API_KEY
+    }
+
+    if (ORIGINAL_KIOSK_DEVICE_NAME === undefined) {
+      delete process.env.SENTINEL_KIOSK_DEVICE_NAME
+    } else {
+      process.env.SENTINEL_KIOSK_DEVICE_NAME = ORIGINAL_KIOSK_DEVICE_NAME
+    }
+  })
+
+  it('authenticates the configured kiosk device API key', () => {
+    process.env.SENTINEL_KIOSK_DEVICE_API_KEY = 'sk_kiosk_test_123'
+    process.env.SENTINEL_KIOSK_DEVICE_NAME = 'Front entrance kiosk'
+
+    expect(authenticateKioskDeviceApiKey('sk_kiosk_test_123')).toEqual({
+      id: 'kiosk-device',
+      name: 'Front entrance kiosk',
+      scopes: ['kiosk:access', 'system-status:read'],
+    })
+  })
+
+  it('rejects missing, malformed, or incorrect kiosk device API keys', () => {
+    delete process.env.SENTINEL_KIOSK_DEVICE_API_KEY
+    expect(authenticateKioskDeviceApiKey('sk_kiosk_test_123')).toBeNull()
+
+    process.env.SENTINEL_KIOSK_DEVICE_API_KEY = 'not-prefixed'
+    expect(authenticateKioskDeviceApiKey('not-prefixed')).toBeNull()
+
+    process.env.SENTINEL_KIOSK_DEVICE_API_KEY = 'sk_kiosk_test_123'
+    expect(authenticateKioskDeviceApiKey('sk_kiosk_test_999')).toBeNull()
+    expect(authenticateKioskDeviceApiKey('')).toBeNull()
+  })
+
+  it('extracts the kiosk device API key from parsed cookies', () => {
+    const cookies = {
+      [KIOSK_DEVICE_COOKIE_NAME]: 'sk_kiosk_cookie_value',
+    }
+
+    expect(extractKioskDeviceApiKeyFromCookies(cookies)).toBe('sk_kiosk_cookie_value')
+  })
+
+  it('extracts and decodes the kiosk device API key from the raw cookie header', () => {
+    const cookieHeader = `foo=bar; ${KIOSK_DEVICE_COOKIE_NAME}=sk_kiosk_cookie%5Fvalue`
+
+    expect(extractKioskDeviceApiKeyFromCookieHeader(cookieHeader)).toBe('sk_kiosk_cookie_value')
+  })
+})

--- a/apps/backend/src/lib/kiosk-device-auth.ts
+++ b/apps/backend/src/lib/kiosk-device-auth.ts
@@ -1,0 +1,121 @@
+import { timingSafeEqual } from 'node:crypto'
+
+export const KIOSK_DEVICE_COOKIE_NAME = 'sentinel-kiosk-device'
+const KIOSK_DEVICE_API_KEY_ENV = 'SENTINEL_KIOSK_DEVICE_API_KEY'
+const KIOSK_DEVICE_NAME_ENV = 'SENTINEL_KIOSK_DEVICE_NAME'
+const KIOSK_DEVICE_DEFAULT_NAME = 'Sentinel kiosk'
+const KIOSK_DEVICE_DEFAULT_SCOPES = ['kiosk:access', 'system-status:read'] as const
+
+export interface KioskDeviceAuthRecord {
+  id: string
+  name: string
+  scopes: string[]
+}
+
+interface KioskDeviceConfig {
+  key: string
+  auth: KioskDeviceAuthRecord
+}
+
+function normalizeConfiguredApiKey(): string | null {
+  const configured = process.env[KIOSK_DEVICE_API_KEY_ENV]?.trim()
+  if (!configured) {
+    return null
+  }
+
+  return configured.startsWith('sk_') ? configured : null
+}
+
+function normalizeConfiguredName(): string {
+  const configured = process.env[KIOSK_DEVICE_NAME_ENV]?.trim()
+  return configured && configured.length > 0 ? configured : KIOSK_DEVICE_DEFAULT_NAME
+}
+
+function getConfiguredKioskDevice(): KioskDeviceConfig | null {
+  const key = normalizeConfiguredApiKey()
+  if (!key) {
+    return null
+  }
+
+  return {
+    key,
+    auth: {
+      id: 'kiosk-device',
+      name: normalizeConfiguredName(),
+      scopes: [...KIOSK_DEVICE_DEFAULT_SCOPES],
+    },
+  }
+}
+
+function safelyCompare(candidate: string, expected: string): boolean {
+  const candidateBuffer = Buffer.from(candidate)
+  const expectedBuffer = Buffer.from(expected)
+
+  if (candidateBuffer.length !== expectedBuffer.length) {
+    return false
+  }
+
+  return timingSafeEqual(candidateBuffer, expectedBuffer)
+}
+
+function normalizeCookieValue(value: string): string | null {
+  const trimmed = value.trim()
+  if (trimmed.length === 0) {
+    return null
+  }
+
+  try {
+    return decodeURIComponent(trimmed)
+  } catch {
+    return trimmed
+  }
+}
+
+export function authenticateKioskDeviceApiKey(
+  apiKey: string | null | undefined
+): KioskDeviceAuthRecord | null {
+  if (typeof apiKey !== 'string') {
+    return null
+  }
+
+  const candidate = apiKey.trim()
+  if (candidate.length === 0) {
+    return null
+  }
+
+  const configured = getConfiguredKioskDevice()
+  if (!configured) {
+    return null
+  }
+
+  return safelyCompare(candidate, configured.key) ? configured.auth : null
+}
+
+export function extractKioskDeviceApiKeyFromCookies(
+  cookies: Record<string, unknown> | undefined
+): string | null {
+  const cookie = cookies?.[KIOSK_DEVICE_COOKIE_NAME]
+  return typeof cookie === 'string' ? normalizeCookieValue(cookie) : null
+}
+
+export function extractKioskDeviceApiKeyFromCookieHeader(
+  cookieHeader: string | string[] | undefined
+): string | null {
+  if (!cookieHeader) {
+    return null
+  }
+
+  const rawCookies = Array.isArray(cookieHeader) ? cookieHeader.join(';') : cookieHeader
+  const cookies = rawCookies.split(';')
+
+  for (const cookie of cookies) {
+    const [name, ...valueParts] = cookie.trim().split('=')
+    if (name !== KIOSK_DEVICE_COOKIE_NAME) {
+      continue
+    }
+
+    return normalizeCookieValue(valueParts.join('='))
+  }
+
+  return null
+}

--- a/apps/backend/src/middleware/auth.test.ts
+++ b/apps/backend/src/middleware/auth.test.ts
@@ -1,0 +1,102 @@
+import type { NextFunction, Request, Response } from 'express'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { KIOSK_DEVICE_COOKIE_NAME } from '../lib/kiosk-device-auth.js'
+
+const findByTokenMock = vi.fn()
+
+vi.mock('../lib/database.js', () => ({
+  getPrismaClient: vi.fn(() => ({})),
+}))
+
+vi.mock('../repositories/session-repository.js', () => ({
+  SessionRepository: class {
+    findByToken = findByTokenMock
+  },
+}))
+
+const { requireAuth } = await import('./auth.js')
+
+function createResponse() {
+  const response = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  }
+
+  return response as unknown as Response & {
+    status: ReturnType<typeof vi.fn>
+    json: ReturnType<typeof vi.fn>
+  }
+}
+
+describe('requireAuth', () => {
+  const originalDeviceApiKey = process.env.SENTINEL_KIOSK_DEVICE_API_KEY
+  const originalDeviceName = process.env.SENTINEL_KIOSK_DEVICE_NAME
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    findByTokenMock.mockReset()
+
+    if (originalDeviceApiKey === undefined) {
+      delete process.env.SENTINEL_KIOSK_DEVICE_API_KEY
+    } else {
+      process.env.SENTINEL_KIOSK_DEVICE_API_KEY = originalDeviceApiKey
+    }
+
+    if (originalDeviceName === undefined) {
+      delete process.env.SENTINEL_KIOSK_DEVICE_NAME
+    } else {
+      process.env.SENTINEL_KIOSK_DEVICE_NAME = originalDeviceName
+    }
+  })
+
+  it('authenticates requests with the kiosk device cookie', async () => {
+    process.env.SENTINEL_KIOSK_DEVICE_API_KEY = 'sk_kiosk_cookie_auth'
+    process.env.SENTINEL_KIOSK_DEVICE_NAME = 'Front entrance kiosk'
+
+    const req = {
+      cookies: {
+        [KIOSK_DEVICE_COOKIE_NAME]: 'sk_kiosk_cookie_auth',
+      },
+      headers: {},
+      path: '/system-status',
+      method: 'GET',
+    } as unknown as Request
+    const res = createResponse()
+    const next = vi.fn<NextFunction>()
+
+    await requireAuth(true)(req, res, next)
+
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(req.apiKey).toEqual({
+      id: 'kiosk-device',
+      name: 'Front entrance kiosk',
+      scopes: ['kiosk:access', 'system-status:read'],
+    })
+    expect(req.member).toBeUndefined()
+    expect(findByTokenMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the kiosk device cookie when a session token is invalid', async () => {
+    process.env.SENTINEL_KIOSK_DEVICE_API_KEY = 'sk_kiosk_cookie_auth'
+
+    findByTokenMock.mockResolvedValue(null)
+
+    const req = {
+      cookies: {
+        'sentinel-session': 'expired-session-token',
+        [KIOSK_DEVICE_COOKIE_NAME]: 'sk_kiosk_cookie_auth',
+      },
+      headers: {},
+      path: '/system-status',
+      method: 'GET',
+    } as unknown as Request
+    const res = createResponse()
+    const next = vi.fn<NextFunction>()
+
+    await requireAuth(true)(req, res, next)
+
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(req.apiKey?.id).toBe('kiosk-device')
+    expect(req.member).toBeUndefined()
+  })
+})

--- a/apps/backend/src/middleware/auth.ts
+++ b/apps/backend/src/middleware/auth.ts
@@ -1,6 +1,11 @@
 import { Request, Response, NextFunction } from 'express'
 import { authLogger } from '../lib/logger.js'
 import { requestContext } from '../lib/logger.js'
+import { recordAuthAttempt } from '../lib/metrics.js'
+import {
+  authenticateKioskDeviceApiKey,
+  extractKioskDeviceApiKeyFromCookies,
+} from '../lib/kiosk-device-auth.js'
 import { SessionRepository } from '../repositories/session-repository.js'
 import { getPrismaClient } from '../lib/database.js'
 import { isSentinelBootstrapServiceNumber } from '../lib/system-bootstrap.js'
@@ -76,7 +81,7 @@ function extractApiKey(req: Request): string | null {
     return authHeader.slice(7)
   }
 
-  return null
+  return extractKioskDeviceApiKeyFromCookies(req.cookies)
 }
 
 function isPinChangeExemptPath(req: Request): boolean {
@@ -112,6 +117,7 @@ export function requireAuth(required: boolean = true) {
         const session = await sessionRepo.findByToken(sessionToken)
 
         if (session) {
+          recordAuthAttempt('success', 'session')
           req.member = {
             id: session.member.id,
             firstName: session.member.firstName,
@@ -143,14 +149,34 @@ export function requireAuth(required: boolean = true) {
           return next()
         }
 
+        recordAuthAttempt('failure', 'session')
         authLogger.debug('Session validation failed: invalid or expired token')
       }
 
       // Try API key authentication
       const apiKey = extractApiKey(req)
       if (apiKey) {
-        // TODO: Implement custom API key validation
-        authLogger.debug('API key authentication not yet implemented')
+        const authenticatedApiKey = authenticateKioskDeviceApiKey(apiKey)
+
+        if (authenticatedApiKey) {
+          recordAuthAttempt('success', 'apikey')
+          req.apiKey = authenticatedApiKey
+
+          const store = requestContext.getStore()
+          if (store) {
+            store.apiKeyId = authenticatedApiKey.id
+          }
+
+          authLogger.debug('API key authenticated', {
+            apiKeyId: authenticatedApiKey.id,
+            apiKeyName: authenticatedApiKey.name,
+          })
+
+          return next()
+        }
+
+        recordAuthAttempt('failure', 'apikey')
+        authLogger.debug('API key authentication failed')
       }
 
       // No valid authentication found

--- a/apps/backend/src/repositories/audit-repository.ts
+++ b/apps/backend/src/repositories/audit-repository.ts
@@ -1,11 +1,22 @@
 import type { PrismaClientInstance } from '@sentinel/database'
 import { prisma as defaultPrisma, Prisma } from '@sentinel/database'
-import type { AuditLog as PrismaAuditLog } from '@sentinel/database'
 
 export type AuditAction =
+  | 'create'
+  | 'update'
+  | 'delete'
+  | 'assign'
+  | 'unassign'
+  | 'flag'
+  | 'unflag'
+  | 'export'
+  | 'import'
   | 'login'
   | 'logout'
   | 'login_failed'
+  | 'checkin_scan'
+  | 'checkin_login'
+  | 'checkin_manual_create'
   | 'member_create'
   | 'member_update'
   | 'member_delete'
@@ -17,6 +28,15 @@ export type AuditAction =
   | 'badge_status_change'
   | 'badge_create'
   | 'badge_delete'
+  | 'setting_create'
+  | 'setting_update'
+  | 'setting_delete'
+  | 'network_settings_update'
+  | 'operational_timings_update'
+  | 'remote_system_create'
+  | 'remote_system_update'
+  | 'remote_system_delete'
+  | 'remote_system_reorder'
   | 'admin_create'
   | 'admin_update'
   | 'admin_delete'
@@ -46,6 +66,14 @@ export type AuditAction =
   | 'checkin_update'
   | 'checkin_delete'
   | 'checkin_manual_checkout'
+  | 'dds_accept'
+  | 'dds_assign'
+  | 'dds_transfer'
+  | 'dds_release'
+  | 'lockup_acquire'
+  | 'lockup_open'
+  | 'lockup_transfer'
+  | 'lockup_execute'
   | 'duty_watch_live_assignment_set'
   | 'duty_watch_live_assignment_clear'
   | 'duty_watch_override_create'
@@ -60,12 +88,69 @@ interface AuditLogEntry {
 }
 
 interface AuditLogFilters {
-  action?: AuditAction | AuditAction[]
-  actorId?: string
+  action?: string | string[]
+  adminUserId?: string
+  entityType?: string
   entityId?: string
   startDate?: Date
   endDate?: Date
 }
+
+const adminUserSelect = {
+  id: true,
+  username: true,
+  displayName: true,
+} as const
+
+const AUDIT_REDACTED_VALUE = '[REDACTED]'
+const SENSITIVE_AUDIT_KEY_PATTERN =
+  /authorization|cookie|hash|passphrase|password|pin|secret|token|api[-_]?key/i
+
+function sanitizeAuditValue(value: unknown, key?: string): Prisma.InputJsonValue | null {
+  if (value === undefined) {
+    return null
+  }
+
+  if (key && SENSITIVE_AUDIT_KEY_PATTERN.test(key)) {
+    return AUDIT_REDACTED_VALUE
+  }
+
+  if (value === null) {
+    return null
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString()
+  }
+
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeAuditValue(item))
+  }
+
+  if (typeof value === 'object') {
+    const entries = Object.entries(value)
+      .filter(([, nestedValue]) => nestedValue !== undefined)
+      .map(([nestedKey, nestedValue]) => [nestedKey, sanitizeAuditValue(nestedValue, nestedKey)])
+
+    return Object.fromEntries(entries) as Prisma.InputJsonObject
+  }
+
+  return String(value)
+}
+
+function sanitizeAuditDetails(details: Record<string, unknown>): Prisma.InputJsonObject {
+  return Object.fromEntries(
+    Object.entries(details).map(([key, value]) => [key, sanitizeAuditValue(value, key)])
+  ) as Prisma.InputJsonObject
+}
+
+export type AuditLogWithAdminRecord = Prisma.AuditLogGetPayload<{
+  include: { adminUser: { select: typeof adminUserSelect } }
+}>
 
 export class AuditRepository {
   private prisma: PrismaClientInstance
@@ -77,52 +162,38 @@ export class AuditRepository {
     this.prisma = prismaClient || defaultPrisma
   }
 
-  async log(entry: AuditLogEntry): Promise<void> {
-    await this.prisma.auditLog.create({
+  async log(entry: AuditLogEntry): Promise<AuditLogWithAdminRecord> {
+    return await this.prisma.auditLog.create({
       data: {
         adminUserId: entry.adminUserId,
         action: entry.action,
         entityType: entry.entityType,
         entityId: entry.entityId,
-        details: entry.details as Prisma.JsonObject,
+        details: sanitizeAuditDetails(entry.details),
         ipAddress: entry.ipAddress,
+      },
+      include: {
+        adminUser: {
+          select: adminUserSelect,
+        },
       },
     })
   }
 
   /**
-   * Find audit logs for user management actions with pagination and filtering
+   * Find audit logs with pagination and filtering
    */
-  async findUserAuditLogs(
+  async findAuditLogs(
     filters: AuditLogFilters,
     pagination: { page: number; limit: number }
-  ): Promise<PrismaAuditLog[]> {
-    const where: Prisma.AuditLogWhereInput = {}
-
-    if (filters.action) {
-      where.action = Array.isArray(filters.action) ? { in: filters.action } : filters.action
-    }
-
-    if (filters.actorId) {
-      where.adminUserId = filters.actorId
-    }
-
-    if (filters.entityId) {
-      where.entityId = filters.entityId
-    }
-
-    if (filters.startDate || filters.endDate) {
-      where.createdAt = {}
-      if (filters.startDate) {
-        where.createdAt.gte = filters.startDate
-      }
-      if (filters.endDate) {
-        where.createdAt.lte = filters.endDate
-      }
-    }
-
+  ): Promise<AuditLogWithAdminRecord[]> {
     const logs = await this.prisma.auditLog.findMany({
-      where,
+      where: this.buildWhere(filters),
+      include: {
+        adminUser: {
+          select: adminUserSelect,
+        },
+      },
       orderBy: {
         createdAt: 'desc',
       },
@@ -136,15 +207,121 @@ export class AuditRepository {
   /**
    * Count audit logs matching filters
    */
-  async countUserAuditLogs(filters: AuditLogFilters): Promise<number> {
+  async countAuditLogs(filters: AuditLogFilters): Promise<number> {
+    return await this.prisma.auditLog.count({ where: this.buildWhere(filters) })
+  }
+
+  async findById(id: string): Promise<AuditLogWithAdminRecord | null> {
+    return await this.prisma.auditLog.findUnique({
+      where: { id },
+      include: {
+        adminUser: {
+          select: adminUserSelect,
+        },
+      },
+    })
+  }
+
+  async getStats(filters: AuditLogFilters): Promise<{
+    total: number
+    byAction: Record<string, number>
+    byEntityType: Record<string, number>
+    byAdmin: Array<{
+      adminUserId: string
+      adminUsername: string
+      count: number
+    }>
+    recentActivity: AuditLogWithAdminRecord[]
+  }> {
+    const where = this.buildWhere(filters)
+
+    const [total, byActionRows, byEntityTypeRows, byAdminRows, recentActivity] = await Promise.all([
+      this.prisma.auditLog.count({ where }),
+      this.prisma.auditLog.groupBy({
+        by: ['action'],
+        where,
+        _count: {
+          action: true,
+        },
+      }),
+      this.prisma.auditLog.groupBy({
+        by: ['entityType'],
+        where,
+        _count: {
+          entityType: true,
+        },
+      }),
+      this.prisma.auditLog.groupBy({
+        by: ['adminUserId'],
+        where: {
+          ...where,
+          adminUserId: {
+            not: null,
+          },
+        },
+        _count: {
+          adminUserId: true,
+        },
+      }),
+      this.prisma.auditLog.findMany({
+        where,
+        include: {
+          adminUser: {
+            select: adminUserSelect,
+          },
+        },
+        orderBy: {
+          createdAt: 'desc',
+        },
+        take: 20,
+      }),
+    ])
+
+    const byAdminIds = byAdminRows
+      .map((row) => row.adminUserId)
+      .filter((value): value is string => typeof value === 'string')
+    const adminUsers = byAdminIds.length
+      ? await this.prisma.adminUser.findMany({
+          where: {
+            id: {
+              in: byAdminIds,
+            },
+          },
+          select: adminUserSelect,
+        })
+      : []
+    const adminUserById = new Map(adminUsers.map((user) => [user.id, user]))
+
+    return {
+      total,
+      byAction: Object.fromEntries(byActionRows.map((row) => [row.action, row._count.action])),
+      byEntityType: Object.fromEntries(
+        byEntityTypeRows.map((row) => [row.entityType, row._count.entityType])
+      ),
+      byAdmin: byAdminRows
+        .filter((row) => typeof row.adminUserId === 'string')
+        .map((row) => ({
+          adminUserId: row.adminUserId as string,
+          adminUsername: adminUserById.get(row.adminUserId as string)?.username ?? 'Unknown',
+          count: row._count.adminUserId,
+        })),
+      recentActivity,
+    }
+  }
+
+  private buildWhere(filters: AuditLogFilters): Prisma.AuditLogWhereInput {
     const where: Prisma.AuditLogWhereInput = {}
 
     if (filters.action) {
       where.action = Array.isArray(filters.action) ? { in: filters.action } : filters.action
     }
 
-    if (filters.actorId) {
-      where.adminUserId = filters.actorId
+    if (filters.adminUserId) {
+      where.adminUserId = filters.adminUserId
+    }
+
+    if (filters.entityType) {
+      where.entityType = filters.entityType
     }
 
     if (filters.entityId) {
@@ -161,7 +338,7 @@ export class AuditRepository {
       }
     }
 
-    return await this.prisma.auditLog.count({ where })
+    return where
   }
 }
 

--- a/apps/backend/src/routes/audit-logs.test.ts
+++ b/apps/backend/src/routes/audit-logs.test.ts
@@ -1,0 +1,146 @@
+import { createExpressEndpoints } from '@ts-rest/express'
+import { auditContract } from '@sentinel/contracts'
+import type { PrismaClientInstance } from '@sentinel/database'
+import express from 'express'
+import request from 'supertest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { resetPrismaClient, setPrismaClient } from '../lib/database.js'
+
+const auditLogs = [
+  {
+    id: '11111111-1111-4111-8111-111111111111',
+    adminUserId: null,
+    action: 'member_create',
+    entityType: 'member',
+    entityId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    details: {
+      actorName: 'PO2 Alex Admin',
+      memberName: 'PO2 Casey Example',
+    },
+    ipAddress: '127.0.0.1',
+    createdAt: new Date('2026-04-21T12:00:00.000Z'),
+    adminUser: null,
+  },
+  {
+    id: '22222222-2222-4222-8222-222222222222',
+    adminUserId: '99999999-9999-4999-8999-999999999999',
+    action: 'badge_assign',
+    entityType: 'badge',
+    entityId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+    details: {
+      badgeSerialNumber: 'SENT-0001',
+    },
+    ipAddress: '127.0.0.1',
+    createdAt: new Date('2026-04-21T13:00:00.000Z'),
+    adminUser: {
+      id: '99999999-9999-4999-8999-999999999999',
+      username: 'sentinel-admin',
+      displayName: 'Sentinel Admin',
+    },
+  },
+]
+
+function createPrismaHarness(): PrismaClientInstance {
+  return {
+    auditLog: {
+      findMany: async () =>
+        [...auditLogs].sort((left, right) => right.createdAt.getTime() - left.createdAt.getTime()),
+      count: async () => auditLogs.length,
+      findUnique: async ({ where }: { where: { id: string } }) =>
+        auditLogs.find((log) => log.id === where.id) ?? null,
+      groupBy: async ({ by }: { by: Array<'action' | 'entityType' | 'adminUserId'> }) => {
+        if (by.includes('action')) {
+          return [
+            { action: 'member_create', _count: { action: 1 } },
+            { action: 'badge_assign', _count: { action: 1 } },
+          ]
+        }
+
+        if (by.includes('entityType')) {
+          return [
+            { entityType: 'member', _count: { entityType: 1 } },
+            { entityType: 'badge', _count: { entityType: 1 } },
+          ]
+        }
+
+        return [
+          {
+            adminUserId: '99999999-9999-4999-8999-999999999999',
+            _count: { adminUserId: 1 },
+          },
+        ]
+      },
+      create: async () => auditLogs[0],
+    },
+    adminUser: {
+      findMany: async () => [
+        {
+          id: '99999999-9999-4999-8999-999999999999',
+          username: 'sentinel-admin',
+          displayName: 'Sentinel Admin',
+        },
+      ],
+    },
+  } as unknown as PrismaClientInstance
+}
+
+async function createTestApp(accountLevel: number) {
+  const { auditLogsRouter } = await import('./audit-logs.js')
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => {
+    Object.assign(req, {
+      member: {
+        id: 'member-1',
+        firstName: 'Alex',
+        lastName: 'Admin',
+        rank: 'PO2',
+        serviceNumber: 'M12345678',
+        accountLevel,
+      },
+    })
+    next()
+  })
+  createExpressEndpoints(auditContract, auditLogsRouter, app)
+  return app
+}
+
+describe('auditLogsRouter', () => {
+  afterEach(() => {
+    resetPrismaClient()
+    vi.resetModules()
+  })
+
+  it('serves audit stats from /api/audit-logs/stats', async () => {
+    setPrismaClient(createPrismaHarness())
+
+    const app = await createTestApp(5)
+    const response = await request(app).get('/api/audit-logs/stats')
+
+    expect(response.status).toBe(200)
+    expect(response.body).toMatchObject({
+      total: 2,
+      byAction: {
+        member_create: 1,
+        badge_assign: 1,
+      },
+      byEntityType: {
+        member: 1,
+        badge: 1,
+      },
+    })
+    expect(response.body.recentActivity).toHaveLength(2)
+  })
+
+  it('requires admin access for audit log listing', async () => {
+    setPrismaClient(createPrismaHarness())
+
+    const app = await createTestApp(1)
+    const response = await request(app).get('/api/audit-logs')
+
+    expect(response.status).toBe(403)
+    expect(response.body).toMatchObject({
+      error: 'FORBIDDEN',
+    })
+  })
+})

--- a/apps/backend/src/routes/audit-logs.ts
+++ b/apps/backend/src/routes/audit-logs.ts
@@ -1,0 +1,243 @@
+import { initServer } from '@ts-rest/express'
+import { auditContract, type AuditLogListQuery } from '@sentinel/contracts'
+import { AccountLevel } from '../middleware/roles.js'
+import { getPrismaClient } from '../lib/database.js'
+import { AuditRepository, type AuditLogWithAdminRecord } from '../repositories/audit-repository.js'
+
+const s = initServer()
+const auditRepo = new AuditRepository(getPrismaClient())
+
+function requireAdmin(req: { member?: { accountLevel?: number } }) {
+  if (!req.member) {
+    return {
+      status: 401 as const,
+      body: {
+        error: 'UNAUTHORIZED',
+        message: 'Authentication required',
+      },
+    }
+  }
+
+  if ((req.member.accountLevel ?? 0) < AccountLevel.ADMIN) {
+    return {
+      status: 403 as const,
+      body: {
+        error: 'FORBIDDEN',
+        message: 'Admin access required',
+      },
+    }
+  }
+
+  return null
+}
+
+function toDate(value?: string): Date | undefined {
+  return value ? new Date(value) : undefined
+}
+
+function toApiFormat(log: AuditLogWithAdminRecord) {
+  return {
+    id: log.id,
+    adminUserId: log.adminUserId ?? null,
+    action: log.action,
+    entityType: log.entityType,
+    entityId: log.entityId ?? null,
+    details:
+      log.details && typeof log.details === 'object' && !Array.isArray(log.details)
+        ? (log.details as Record<string, unknown>)
+        : null,
+    ipAddress: log.ipAddress ?? null,
+    adminUser: log.adminUser
+      ? {
+          id: log.adminUser.id,
+          username: log.adminUser.username,
+          displayName: log.adminUser.displayName,
+        }
+      : null,
+    createdAt: log.createdAt?.toISOString() ?? null,
+  }
+}
+
+function getFilters(query: AuditLogListQuery) {
+  return {
+    adminUserId: query.adminUserId,
+    entityType: query.entityType,
+    entityId: query.entityId,
+    action: query.action,
+    startDate: toDate(query.startDate),
+    endDate: toDate(query.endDate),
+  }
+}
+
+export const auditLogsRouter = s.router(auditContract, {
+  getAuditLogs: async ({ query, req }) => {
+    const auth = requireAdmin(req)
+    if (auth) {
+      return auth
+    }
+
+    try {
+      const page = query.page ?? 1
+      const limit = query.limit ?? 50
+      const filters = getFilters(query)
+      const [auditLogs, total] = await Promise.all([
+        auditRepo.findAuditLogs(filters, { page, limit }),
+        auditRepo.countAuditLogs(filters),
+      ])
+
+      return {
+        status: 200 as const,
+        body: {
+          auditLogs: auditLogs.map((log) => toApiFormat(log)),
+          total,
+          page,
+          limit,
+          totalPages: Math.max(1, Math.ceil(total / limit)),
+        },
+      }
+    } catch (error) {
+      return {
+        status: 500 as const,
+        body: {
+          error: 'INTERNAL_ERROR',
+          message: error instanceof Error ? error.message : 'Failed to fetch audit logs',
+        },
+      }
+    }
+  },
+
+  getEntityAuditLogs: async ({ params, query, req }) => {
+    const auth = requireAdmin(req)
+    if (auth) {
+      return auth
+    }
+
+    try {
+      const page = query.page ?? 1
+      const limit = query.limit ?? 50
+      const filters = {
+        ...getFilters(query),
+        entityType: params.entityType,
+        entityId: params.entityId,
+      }
+      const [auditLogs, total] = await Promise.all([
+        auditRepo.findAuditLogs(filters, { page, limit }),
+        auditRepo.countAuditLogs(filters),
+      ])
+
+      return {
+        status: 200 as const,
+        body: {
+          auditLogs: auditLogs.map((log) => toApiFormat(log)),
+          total,
+          page,
+          limit,
+          totalPages: Math.max(1, Math.ceil(total / limit)),
+        },
+      }
+    } catch (error) {
+      return {
+        status: 500 as const,
+        body: {
+          error: 'INTERNAL_ERROR',
+          message: error instanceof Error ? error.message : 'Failed to fetch entity audit logs',
+        },
+      }
+    }
+  },
+
+  getAuditStats: async ({ req }) => {
+    const auth = requireAdmin(req)
+    if (auth) {
+      return auth
+    }
+
+    try {
+      const stats = await auditRepo.getStats({})
+
+      return {
+        status: 200 as const,
+        body: {
+          total: stats.total,
+          byAction: stats.byAction,
+          byEntityType: stats.byEntityType,
+          byAdmin: stats.byAdmin,
+          recentActivity: stats.recentActivity.map((log) => toApiFormat(log)),
+        },
+      }
+    } catch (error) {
+      return {
+        status: 500 as const,
+        body: {
+          error: 'INTERNAL_ERROR',
+          message: error instanceof Error ? error.message : 'Failed to fetch audit stats',
+        },
+      }
+    }
+  },
+
+  getAuditLogById: async ({ params, req }) => {
+    const auth = requireAdmin(req)
+    if (auth) {
+      return auth
+    }
+
+    try {
+      const log = await auditRepo.findById(params.id)
+
+      if (!log) {
+        return {
+          status: 404 as const,
+          body: {
+            error: 'NOT_FOUND',
+            message: `Audit log with ID '${params.id}' not found`,
+          },
+        }
+      }
+
+      return {
+        status: 200 as const,
+        body: toApiFormat(log),
+      }
+    } catch (error) {
+      return {
+        status: 500 as const,
+        body: {
+          error: 'INTERNAL_ERROR',
+          message: error instanceof Error ? error.message : 'Failed to fetch audit log',
+        },
+      }
+    }
+  },
+
+  createAuditLog: async ({ body, req }) => {
+    const auth = requireAdmin(req)
+    if (auth) {
+      return auth
+    }
+
+    try {
+      const created = await auditRepo.log({
+        adminUserId: null,
+        action: body.action,
+        entityType: body.entityType,
+        entityId: body.entityId ?? null,
+        details: body.details ?? {},
+        ipAddress: body.ipAddress ?? req.ip ?? req.socket.remoteAddress ?? 'unknown',
+      })
+
+      return {
+        status: 201 as const,
+        body: toApiFormat(created),
+      }
+    } catch (error) {
+      return {
+        status: 500 as const,
+        body: {
+          error: 'INTERNAL_ERROR',
+          message: error instanceof Error ? error.message : 'Failed to create audit log',
+        },
+      }
+    }
+  },
+})

--- a/apps/backend/src/routes/badges.ts
+++ b/apps/backend/src/routes/badges.ts
@@ -8,6 +8,9 @@ import type {
   DeleteBadgeInput,
   IdParam,
 } from '@sentinel/contracts'
+import type { Request } from 'express'
+import { formatAuditMemberName, logRequestAudit } from '../lib/audit-log.js'
+import { AuditRepository } from '../repositories/audit-repository.js'
 import { BadgeRepository } from '../repositories/badge-repository.js'
 import { MemberRepository } from '../repositories/member-repository.js'
 import { getPrismaClient } from '../lib/database.js'
@@ -18,6 +21,25 @@ const s = initServer()
 
 const badgeRepo = new BadgeRepository(getPrismaClient())
 const memberRepo = new MemberRepository(getPrismaClient())
+const auditRepo = new AuditRepository(getPrismaClient())
+
+async function getAssignedMemberAuditDetails(memberId?: string | null) {
+  if (!memberId) {
+    return {
+      assignedMemberId: null,
+      assignedMemberName: null,
+      assignedMemberServiceNumber: null,
+    }
+  }
+
+  const member = await memberRepo.findById(memberId)
+
+  return {
+    assignedMemberId: member?.id ?? memberId,
+    assignedMemberName: formatAuditMemberName(member),
+    assignedMemberServiceNumber: member?.serviceNumber ?? null,
+  }
+}
 
 /**
  * Badges route implementation using ts-rest
@@ -271,7 +293,7 @@ export const badgesRouter = s.router(badgeContract, {
   /**
    * Create new badge
    */
-  createBadge: async ({ body }: { body: CreateBadgeInput }) => {
+  createBadge: async ({ body, req }: { body: CreateBadgeInput; req: Request }) => {
     try {
       const initialAssignmentType =
         body.assignmentType === 'member' ? 'unassigned' : (body.assignmentType ?? 'unassigned')
@@ -298,6 +320,18 @@ export const badgesRouter = s.router(badgeContract, {
           }
         }
       }
+
+      await logRequestAudit(auditRepo, req, {
+        action: 'badge_create',
+        entityType: 'badge',
+        entityId: badge.id,
+        details: {
+          badgeSerialNumber: badge.serialNumber,
+          status: badge.status,
+          assignmentType: badge.assignmentType,
+          ...(await getAssignedMemberAuditDetails(badge.assignedToId)),
+        },
+      })
 
       return {
         status: 201 as const,
@@ -362,11 +396,19 @@ export const badgesRouter = s.router(badgeContract, {
   /**
    * Update existing badge
    */
-  updateBadge: async ({ params, body }: { params: IdParam; body: UpdateBadgeInput }) => {
+  updateBadge: async ({
+    params,
+    body,
+    req,
+  }: {
+    params: IdParam
+    body: UpdateBadgeInput
+    req: Request
+  }) => {
     try {
       // Update badge status if provided
-      let badge = await badgeRepo.findById(params.id)
-      if (!badge) {
+      const existingBadge = await badgeRepo.findById(params.id)
+      if (!existingBadge) {
         return {
           status: 404 as const,
           body: {
@@ -375,6 +417,7 @@ export const badgesRouter = s.router(badgeContract, {
           },
         }
       }
+      let badge = existingBadge
 
       if (body.status) {
         badge = await badgeService.updateStatus(params.id, body.status)
@@ -407,6 +450,37 @@ export const badgesRouter = s.router(badgeContract, {
             type: 'member',
           }
         }
+      }
+
+      if (existingBadge.status !== badge.status) {
+        await logRequestAudit(auditRepo, req, {
+          action: 'badge_status_change',
+          entityType: 'badge',
+          entityId: badge.id,
+          details: {
+            badgeSerialNumber: badge.serialNumber,
+            previousStatus: existingBadge.status,
+            currentStatus: badge.status,
+          },
+        })
+      }
+
+      if (
+        existingBadge.assignmentType !== badge.assignmentType ||
+        existingBadge.assignedToId !== badge.assignedToId
+      ) {
+        await logRequestAudit(auditRepo, req, {
+          action: badge.assignmentType === 'unassigned' ? 'badge_unassign' : 'badge_assign',
+          entityType: 'badge',
+          entityId: badge.id,
+          details: {
+            badgeSerialNumber: badge.serialNumber,
+            previousAssignmentType: existingBadge.assignmentType,
+            currentAssignmentType: badge.assignmentType,
+            previousAssignedMember: await getAssignedMemberAuditDetails(existingBadge.assignedToId),
+            currentAssignedMember: await getAssignedMemberAuditDetails(badge.assignedToId),
+          },
+        })
       }
 
       return {
@@ -471,8 +545,27 @@ export const badgesRouter = s.router(badgeContract, {
   /**
    * Assign badge to member or visitor
    */
-  assignBadge: async ({ params, body }: { params: IdParam; body: AssignBadgeInput }) => {
+  assignBadge: async ({
+    params,
+    body,
+    req,
+  }: {
+    params: IdParam
+    body: AssignBadgeInput
+    req: Request
+  }) => {
     try {
+      const existingBadge = await badgeRepo.findById(params.id)
+      if (!existingBadge) {
+        return {
+          status: 404 as const,
+          body: {
+            error: 'NOT_FOUND',
+            message: `Badge with ID '${params.id}' not found`,
+          },
+        }
+      }
+
       // Validate that the assigned entity exists
       if (body.assignmentType === 'member') {
         const member = await memberRepo.findById(body.assignedToId)
@@ -503,6 +596,19 @@ export const badgesRouter = s.router(badgeContract, {
           }
         }
       }
+
+      await logRequestAudit(auditRepo, req, {
+        action: 'badge_assign',
+        entityType: 'badge',
+        entityId: badge.id,
+        details: {
+          badgeSerialNumber: badge.serialNumber,
+          previousAssignmentType: existingBadge.assignmentType,
+          currentAssignmentType: badge.assignmentType,
+          previousAssignedMember: await getAssignedMemberAuditDetails(existingBadge.assignedToId),
+          currentAssignedMember: await getAssignedMemberAuditDetails(badge.assignedToId),
+        },
+      })
 
       return {
         status: 200 as const,
@@ -559,9 +665,33 @@ export const badgesRouter = s.router(badgeContract, {
   /**
    * Unassign badge
    */
-  unassignBadge: async ({ params }: { params: IdParam }) => {
+  unassignBadge: async ({ params, req }: { params: IdParam; req: Request }) => {
     try {
+      const existingBadge = await badgeRepo.findById(params.id)
+      if (!existingBadge) {
+        return {
+          status: 404 as const,
+          body: {
+            error: 'NOT_FOUND',
+            message: `Badge with ID '${params.id}' not found`,
+          },
+        }
+      }
+
       const badge = await badgeService.unassign(params.id)
+
+      await logRequestAudit(auditRepo, req, {
+        action: 'badge_unassign',
+        entityType: 'badge',
+        entityId: badge.id,
+        details: {
+          badgeSerialNumber: badge.serialNumber,
+          previousAssignmentType: existingBadge.assignmentType,
+          currentAssignmentType: badge.assignmentType,
+          previousAssignedMember: await getAssignedMemberAuditDetails(existingBadge.assignedToId),
+          currentAssignedMember: await getAssignedMemberAuditDetails(badge.assignedToId),
+        },
+      })
 
       return {
         status: 200 as const,
@@ -602,9 +732,41 @@ export const badgesRouter = s.router(badgeContract, {
   /**
    * Delete badge
    */
-  deleteBadge: async ({ params, body }: { params: IdParam; body: DeleteBadgeInput }) => {
+  deleteBadge: async ({
+    params,
+    body,
+    req,
+  }: {
+    params: IdParam
+    body: DeleteBadgeInput
+    req: Request
+  }) => {
     try {
+      const existingBadge = await badgeRepo.findById(params.id)
+      if (!existingBadge) {
+        return {
+          status: 404 as const,
+          body: {
+            error: 'NOT_FOUND',
+            message: `Badge with ID '${params.id}' not found`,
+          },
+        }
+      }
+
       await badgeService.delete(params.id, body)
+
+      await logRequestAudit(auditRepo, req, {
+        action: 'badge_delete',
+        entityType: 'badge',
+        entityId: params.id,
+        details: {
+          badgeSerialNumber: existingBadge.serialNumber,
+          status: existingBadge.status,
+          assignmentType: existingBadge.assignmentType,
+          assignedMember: await getAssignedMemberAuditDetails(existingBadge.assignedToId),
+          unassignFirst: body.unassignFirst ?? false,
+        },
+      })
 
       return {
         status: 200 as const,

--- a/apps/backend/src/routes/checkins.ts
+++ b/apps/backend/src/routes/checkins.ts
@@ -22,6 +22,7 @@ import { LiveDutyAssignmentService } from '../services/live-duty-assignment-serv
 import { getPrismaClient } from '../lib/database.js'
 import { broadcastCheckin } from '../websocket/broadcast.js'
 import { serviceLogger } from '../lib/logger.js'
+import { formatAuditMemberName, logRequestAudit } from '../lib/audit-log.js'
 import { canMemberEditHistory } from '../lib/history-permissions.js'
 import type { PrismaClientInstance } from '@sentinel/database'
 
@@ -736,7 +737,7 @@ export const checkinsRouter = s.router(checkinContract, {
   /**
    * Create new checkin
    */
-  createCheckin: async ({ body }: { body: CreateCheckinInput }) => {
+  createCheckin: async ({ body, req }: { body: CreateCheckinInput; req: Request }) => {
     try {
       // Block checkout if member holds lockup responsibility
       if (body.direction === 'out' && body.memberId) {
@@ -783,6 +784,22 @@ export const checkinsRouter = s.router(checkinContract, {
 
       if (!checkinWithMember) {
         throw new Error('Failed to fetch created checkin')
+      }
+
+      if (req.member) {
+        await logRequestAudit(auditRepo, req, {
+          action: 'checkin_manual_create',
+          entityType: 'checkin',
+          entityId: checkinWithMember.id,
+          details: {
+            memberName: formatAuditMemberName(checkinWithMember.member),
+            subjectMemberId: checkinWithMember.memberId ?? null,
+            direction: checkinWithMember.direction,
+            timestamp: checkinWithMember.timestamp.toISOString(),
+            kioskId: checkinWithMember.kioskId,
+            method: checkinWithMember.method ?? null,
+          },
+        })
       }
 
       // Broadcast checkin event for real-time updates

--- a/apps/backend/src/routes/dds.ts
+++ b/apps/backend/src/routes/dds.ts
@@ -12,12 +12,15 @@ import type { Request } from 'express'
 import { DdsService } from '../services/dds-service.js'
 import { PresenceService } from '../services/presence-service.js'
 import { getPrismaClient } from '../lib/database.js'
+import { formatAuditMemberName, logRequestAudit } from '../lib/audit-log.js'
 import { AccountLevel } from '../middleware/roles.js'
+import { AuditRepository } from '../repositories/audit-repository.js'
 
 const s = initServer()
 
 const ddsService = new DdsService(getPrismaClient())
 const presenceService = new PresenceService(getPrismaClient())
+const auditRepo = new AuditRepository(getPrismaClient())
 
 interface DdsAssignmentData {
   id: string
@@ -229,6 +232,30 @@ export const ddsRouter = s.router(ddsContract, {
     try {
       const assignment = await ddsService.acceptDds(params.id)
 
+      await auditRepo.log({
+        adminUserId: null,
+        action: 'dds_accept',
+        entityType: 'dds',
+        entityId: assignment.id,
+        details: {
+          actorMemberId: assignment.member.id,
+          actorName: formatAuditMemberName(assignment.member),
+          actorType: 'member',
+          memberName: formatAuditMemberName(assignment.member),
+          assignedDate:
+            assignment.assignedDate instanceof Date
+              ? assignment.assignedDate.toISOString()
+              : String(assignment.assignedDate),
+          acceptedAt:
+            assignment.acceptedAt instanceof Date
+              ? assignment.acceptedAt.toISOString()
+              : assignment.acceptedAt
+                ? String(assignment.acceptedAt)
+                : null,
+        },
+        ipAddress: 'unknown',
+      })
+
       return {
         status: 200 as const,
         body: {
@@ -307,7 +334,25 @@ export const ddsRouter = s.router(ddsContract, {
         }
       }
 
+      const previousAssignment = await ddsService.getCurrentDds()
       const assignment = await ddsService.setTodayDds(body.memberId, req.member.id, body.notes)
+
+      await logRequestAudit(auditRepo, req, {
+        action: 'dds_assign',
+        entityType: 'dds',
+        entityId: assignment.id,
+        details: {
+          memberName: formatAuditMemberName(assignment.member),
+          previousHolderName: previousAssignment?.member
+            ? formatAuditMemberName(previousAssignment.member)
+            : null,
+          notes: body.notes ?? null,
+          assignedDate:
+            assignment.assignedDate instanceof Date
+              ? assignment.assignedDate.toISOString()
+              : String(assignment.assignedDate),
+        },
+      })
 
       return {
         status: 200 as const,
@@ -368,7 +413,25 @@ export const ddsRouter = s.router(ddsContract, {
     try {
       const adminId = req.member?.id ?? 'system'
 
+      const previousAssignment = await ddsService.getCurrentDds()
       const assignment = await ddsService.assignDds(body.memberId, adminId, body.notes)
+
+      await logRequestAudit(auditRepo, req, {
+        action: 'dds_assign',
+        entityType: 'dds',
+        entityId: assignment.id,
+        details: {
+          memberName: formatAuditMemberName(assignment.member),
+          previousHolderName: previousAssignment?.member
+            ? formatAuditMemberName(previousAssignment.member)
+            : null,
+          notes: body.notes ?? null,
+          assignedDate:
+            assignment.assignedDate instanceof Date
+              ? assignment.assignedDate.toISOString()
+              : String(assignment.assignedDate),
+        },
+      })
 
       return {
         status: 200 as const,
@@ -429,7 +492,25 @@ export const ddsRouter = s.router(ddsContract, {
     try {
       const adminId = req.member?.id ?? 'system'
 
+      const previousAssignment = await ddsService.getCurrentDds()
       const assignment = await ddsService.transferDds(body.toMemberId, adminId, body.notes)
+
+      await logRequestAudit(auditRepo, req, {
+        action: 'dds_transfer',
+        entityType: 'dds',
+        entityId: assignment.id,
+        details: {
+          fromMemberName: previousAssignment?.member
+            ? formatAuditMemberName(previousAssignment.member)
+            : null,
+          toMemberName: formatAuditMemberName(assignment.member),
+          notes: body.notes ?? null,
+          assignedDate:
+            assignment.assignedDate instanceof Date
+              ? assignment.assignedDate.toISOString()
+              : String(assignment.assignedDate),
+        },
+      })
 
       return {
         status: 200 as const,
@@ -489,12 +570,25 @@ export const ddsRouter = s.router(ddsContract, {
   releaseDds: async ({ body, req }: { body: ReleaseDdsInput; req: Request }) => {
     try {
       const adminId = req.member?.id ?? 'system'
+      const previousAssignment = await ddsService.getCurrentDds()
 
       await ddsService.releaseDds(adminId, body.notes)
       const [nextDds, handover] = await Promise.all([
         ddsService.getNextWeekDds(),
         ddsService.getCurrentHandoverStatus(),
       ])
+
+      await logRequestAudit(auditRepo, req, {
+        action: 'dds_release',
+        entityType: 'dds',
+        entityId: previousAssignment?.id ?? null,
+        details: {
+          previousHolderName: previousAssignment?.member
+            ? formatAuditMemberName(previousAssignment.member)
+            : null,
+          notes: body.notes ?? null,
+        },
+      })
 
       return {
         status: 200 as const,

--- a/apps/backend/src/routes/lockup.ts
+++ b/apps/backend/src/routes/lockup.ts
@@ -1,6 +1,9 @@
 import { initServer } from '@ts-rest/express'
 import { lockupContract } from '@sentinel/contracts'
+import { formatAuditMemberName, logRequestAudit } from '../lib/audit-log.js'
 import { LockupService } from '../services/lockup-service.js'
+import { MemberRepository } from '../repositories/member-repository.js'
+import { AuditRepository } from '../repositories/audit-repository.js'
 import { BadgeRepository } from '../repositories/badge-repository.js'
 import { getPrismaClient } from '../lib/database.js'
 import { AccountLevel } from '../middleware/roles.js'
@@ -8,6 +11,8 @@ import { AccountLevel } from '../middleware/roles.js'
 const s = initServer()
 
 const lockupService = new LockupService(getPrismaClient())
+const memberRepository = new MemberRepository(getPrismaClient())
+const auditRepo = new AuditRepository(getPrismaClient())
 const badgeRepository = new BadgeRepository(getPrismaClient())
 
 /**
@@ -95,9 +100,25 @@ export const lockupRouter = s.router(lockupContract, {
   /**
    * Transfer lockup to another qualified member
    */
-  transferLockup: async ({ body }) => {
+  transferLockup: async ({ body, req }) => {
     try {
+      const previousStatus = await lockupService.getCurrentStatus()
       const result = await lockupService.transferLockup(body.toMemberId, body.reason, body.notes)
+
+      await logRequestAudit(auditRepo, req, {
+        action: 'lockup_transfer',
+        entityType: 'lockup',
+        entityId: result.transfer.id,
+        details: {
+          fromMemberName: previousStatus.currentHolder
+            ? formatAuditMemberName(previousStatus.currentHolder)
+            : null,
+          toMemberName: formatAuditMemberName(result.newHolder),
+          reason: result.transfer.reason,
+          notes: result.transfer.notes,
+          transferredAt: result.transfer.transferredAt.toISOString(),
+        },
+      })
 
       return {
         status: 200 as const,
@@ -240,9 +261,21 @@ export const lockupRouter = s.router(lockupContract, {
   /**
    * Acquire lockup (for initial assignment or when no holder exists)
    */
-  acquireLockup: async ({ params, body }) => {
+  acquireLockup: async ({ params, body, req }) => {
     try {
       await lockupService.acquireLockup(params.id, body?.notes)
+
+      const member = await memberRepository.findById(params.id)
+
+      await logRequestAudit(auditRepo, req, {
+        action: 'lockup_acquire',
+        entityType: 'lockup',
+        entityId: params.id,
+        details: {
+          holderName: formatAuditMemberName(member),
+          notes: body?.notes ?? null,
+        },
+      })
 
       return {
         status: 200 as const,
@@ -316,9 +349,22 @@ export const lockupRouter = s.router(lockupContract, {
   /**
    * Open building (transition from secured to open)
    */
-  openBuilding: async ({ params, body }) => {
+  openBuilding: async ({ params, body, req }) => {
     try {
       const status = await lockupService.openBuilding(params.id, body.note)
+
+      const member = await memberRepository.findById(params.id)
+
+      await logRequestAudit(auditRepo, req, {
+        action: 'lockup_open',
+        entityType: 'lockup',
+        entityId: params.id,
+        details: {
+          openerName: formatAuditMemberName(member),
+          note: body.note ?? null,
+          buildingStatus: status.buildingStatus,
+        },
+      })
 
       return {
         status: 200 as const,
@@ -551,9 +597,24 @@ export const lockupRouter = s.router(lockupContract, {
   /**
    * Execute building lockup
    */
-  executeLockup: async ({ params, body }) => {
+  executeLockup: async ({ params, body, req }) => {
     try {
       const result = await lockupService.executeLockup(params.id, body.note)
+
+      const member = await memberRepository.findById(params.id)
+
+      await logRequestAudit(auditRepo, req, {
+        action: 'lockup_execute',
+        entityType: 'lockup',
+        entityId: result.executionId,
+        details: {
+          executedByName: formatAuditMemberName(member),
+          note: body.note ?? null,
+          membersCheckedOut: result.checkedOut.members.length,
+          visitorsCheckedOut: result.checkedOut.visitors.length,
+          totalCheckedOut: result.checkedOut.members.length + result.checkedOut.visitors.length,
+        },
+      })
 
       return {
         status: 200 as const,

--- a/apps/backend/src/routes/members.ts
+++ b/apps/backend/src/routes/members.ts
@@ -8,19 +8,23 @@ import type {
   PreviewImportRequest,
   ExecuteImportRequest,
 } from '@sentinel/contracts'
+import type { Request } from 'express'
 import type { MemberStatus } from '@sentinel/types'
 import { MemberRepository } from '../repositories/member-repository.js'
+import { AuditRepository } from '../repositories/audit-repository.js'
 import { AutoQualificationService } from '../services/auto-qualification-service.js'
 import { badgeService } from '../services/badge-service.js'
 import { importService } from '../services/import-service.js'
 import { memberService } from '../services/member-service.js'
 import { getPrismaClient } from '../lib/database.js'
+import { formatAuditMemberName, logRequestAudit } from '../lib/audit-log.js'
 import { AccountLevel } from '../middleware/roles.js'
 import { ConflictError, NotFoundError } from '../middleware/error-handler.js'
 
 const s = initServer()
 
 const memberRepo = new MemberRepository(getPrismaClient())
+const auditRepo = new AuditRepository(getPrismaClient())
 const autoQualService = new AutoQualificationService(getPrismaClient())
 
 /**
@@ -203,13 +207,7 @@ export const membersRouter = s.router(memberContract, {
   /**
    * Create new member
    */
-  createMember: async ({
-    body,
-    req,
-  }: {
-    body: CreateMemberInput
-    req: { member?: { id?: string; accountLevel?: number } }
-  }) => {
+  createMember: async ({ body, req }: { body: CreateMemberInput; req: Request }) => {
     try {
       const actorLevel = req.member?.accountLevel ?? 0
       if (!req.member) {
@@ -265,6 +263,21 @@ export const membersRouter = s.router(memberContract, {
       } catch {
         // Non-blocking: don't fail create if sync errors
       }
+
+      await logRequestAudit(auditRepo, req, {
+        action: 'member_create',
+        entityType: 'member',
+        entityId: member.id,
+        details: {
+          memberName: formatAuditMemberName(member),
+          serviceNumber: member.serviceNumber,
+          divisionId: member.divisionId ?? null,
+          badgeId: member.badgeId ?? null,
+          accountLevel: member.accountLevel,
+          memberTypeId: member.memberTypeId ?? null,
+          memberStatusId: member.memberStatusId ?? null,
+        },
+      })
 
       return {
         status: 201 as const,
@@ -324,7 +337,7 @@ export const membersRouter = s.router(memberContract, {
   }: {
     params: IdParam
     body: UpdateMemberInput
-    req: { member?: { id?: string; accountLevel?: number } }
+    req: Request
   }) => {
     try {
       const actorLevel = req.member?.accountLevel ?? 0
@@ -356,6 +369,17 @@ export const membersRouter = s.router(memberContract, {
               message: `Your account level (${actorLevel}) cannot assign level ${body.accountLevel}`,
             },
           }
+        }
+      }
+
+      const existingMember = await memberRepo.findById(params.id)
+      if (!existingMember) {
+        return {
+          status: 404 as const,
+          body: {
+            error: 'NOT_FOUND',
+            message: `Member with ID '${params.id}' not found`,
+          },
         }
       }
 
@@ -396,6 +420,45 @@ export const membersRouter = s.router(memberContract, {
           // Non-blocking: don't fail update if sync errors
         }
       }
+
+      await logRequestAudit(auditRepo, req, {
+        action: 'member_update',
+        entityType: 'member',
+        entityId: finalMember.id,
+        details: {
+          memberName: formatAuditMemberName(finalMember),
+          serviceNumber: finalMember.serviceNumber,
+          requestedChanges: body,
+          previousState: {
+            serviceNumber: existingMember.serviceNumber,
+            rank: existingMember.rank,
+            firstName: existingMember.firstName,
+            lastName: existingMember.lastName,
+            middleInitial: existingMember.initials ?? null,
+            divisionId: existingMember.divisionId ?? null,
+            email: existingMember.email ?? null,
+            phoneNumber: existingMember.mobilePhone ?? null,
+            badgeId: existingMember.badgeId ?? null,
+            accountLevel: existingMember.accountLevel,
+            memberTypeId: existingMember.memberTypeId ?? null,
+            memberStatusId: existingMember.memberStatusId ?? null,
+          },
+          currentState: {
+            serviceNumber: finalMember.serviceNumber,
+            rank: finalMember.rank,
+            firstName: finalMember.firstName,
+            lastName: finalMember.lastName,
+            middleInitial: finalMember.initials ?? null,
+            divisionId: finalMember.divisionId ?? null,
+            email: finalMember.email ?? null,
+            phoneNumber: finalMember.mobilePhone ?? null,
+            badgeId: finalMember.badgeId ?? null,
+            accountLevel: finalMember.accountLevel,
+            memberTypeId: finalMember.memberTypeId ?? null,
+            memberStatusId: finalMember.memberStatusId ?? null,
+          },
+        },
+      })
 
       return {
         status: 200 as const,
@@ -482,9 +545,33 @@ export const membersRouter = s.router(memberContract, {
   /**
    * Delete member
    */
-  deleteMember: async ({ params }: { params: IdParam }) => {
+  deleteMember: async ({ params, req }: { params: IdParam; req: Request }) => {
     try {
+      const existingMember = await memberRepo.findById(params.id)
+      if (!existingMember) {
+        return {
+          status: 404 as const,
+          body: {
+            error: 'NOT_FOUND',
+            message: `Member with ID '${params.id}' not found`,
+          },
+        }
+      }
+
       await memberService.deactivate(params.id)
+
+      await logRequestAudit(auditRepo, req, {
+        action: 'member_delete',
+        entityType: 'member',
+        entityId: params.id,
+        details: {
+          memberName: formatAuditMemberName(existingMember),
+          serviceNumber: existingMember.serviceNumber,
+          divisionId: existingMember.divisionId ?? null,
+          badgeId: existingMember.badgeId ?? null,
+          archived: true,
+        },
+      })
 
       return {
         status: 200 as const,

--- a/apps/backend/src/routes/network-settings.ts
+++ b/apps/backend/src/routes/network-settings.ts
@@ -2,14 +2,17 @@ import { initServer } from '@ts-rest/express'
 import type { Request } from 'express'
 import { networkSettingContract } from '@sentinel/contracts'
 import { getPrismaClient } from '../lib/database.js'
+import { logRequestAudit } from '../lib/audit-log.js'
 import { getRequestClientIp } from '../lib/runtime-context.js'
 import { AccountLevel } from '../middleware/roles.js'
+import { AuditRepository } from '../repositories/audit-repository.js'
 import { HostHotspotRecoveryService } from '../services/host-hotspot-recovery-service.js'
 import { NetworkSettingsService } from '../services/network-settings-service.js'
 import { SystemUpdateRequestService } from '../services/system-update-request-service.js'
 
 const s = initServer()
 const networkSettingsService = new NetworkSettingsService(getPrismaClient())
+const auditRepo = new AuditRepository(getPrismaClient())
 
 function requireMember(req: Request) {
   if (!req.member) {
@@ -90,7 +93,20 @@ export const networkSettingsRouter = s.router(networkSettingContract, {
     }
 
     try {
+      const previousState = await networkSettingsService.getNetworkSettings()
       const state = await networkSettingsService.updateNetworkSettings(body.settings)
+
+      await logRequestAudit(auditRepo, req, {
+        action: 'network_settings_update',
+        entityType: 'network_settings',
+        entityId: null,
+        details: {
+          previousSettings: previousState.settings,
+          nextSettings: state.settings,
+          previousMetadata: previousState.metadata,
+          nextMetadata: state.metadata,
+        },
+      })
 
       return {
         status: 200 as const,
@@ -141,8 +157,7 @@ export const networkSettingsRouter = s.router(networkSettingContract, {
         status: 500 as const,
         body: {
           error: 'INTERNAL_ERROR',
-          message:
-            error instanceof Error ? error.message : 'Failed to queue host hotspot recovery',
+          message: error instanceof Error ? error.message : 'Failed to queue host hotspot recovery',
         },
       }
     }

--- a/apps/backend/src/routes/operational-timings.ts
+++ b/apps/backend/src/routes/operational-timings.ts
@@ -3,12 +3,15 @@ import { operationalTimingContract } from '@sentinel/contracts'
 import * as v from 'valibot'
 import { OperationalTimingsSettingsSchema } from '@sentinel/contracts'
 import type { Request } from 'express'
+import { logRequestAudit } from '../lib/audit-log.js'
 import { AccountLevel } from '../middleware/roles.js'
+import { AuditRepository } from '../repositories/audit-repository.js'
 import { OperationalTimingsService } from '../services/operational-timings-service.js'
 import { getPrismaClient } from '../lib/database.js'
 
 const s = initServer()
 const operationalTimingsService = new OperationalTimingsService(getPrismaClient())
+const auditRepo = new AuditRepository(getPrismaClient())
 
 function requireMember(req: Request) {
   if (!req.member) {
@@ -85,7 +88,19 @@ export const operationalTimingsRouter = s.router(operationalTimingContract, {
     }
 
     try {
+      const previousSettings = await operationalTimingsService.getOperationalTimings()
       const updated = await operationalTimingsService.updateOperationalTimings(parsed.output)
+
+      await logRequestAudit(auditRepo, req, {
+        action: 'operational_timings_update',
+        entityType: 'operational_timings',
+        entityId: null,
+        details: {
+          previousSettings: previousSettings.settings,
+          nextSettings: updated.settings,
+        },
+      })
+
       return {
         status: 200 as const,
         body: updated,

--- a/apps/backend/src/routes/remote-systems.ts
+++ b/apps/backend/src/routes/remote-systems.ts
@@ -3,14 +3,17 @@ import type { Request } from 'express'
 import { remoteSystemContract, type AdminRemoteSystem } from '@sentinel/contracts'
 import { Prisma } from '@sentinel/database'
 import { getPrismaClient } from '../lib/database.js'
+import { logRequestAudit } from '../lib/audit-log.js'
 import { shouldEnforceMainSystemLoginSelection } from '../lib/runtime-context.js'
 import { AccountLevel } from '../middleware/roles.js'
+import { AuditRepository } from '../repositories/audit-repository.js'
 import {
   DEPLOYMENT_REMOTE_SYSTEM_CODE,
   RemoteSystemRepository,
 } from '../repositories/remote-system-repository.js'
 
 const s = initServer()
+const auditRepo = new AuditRepository(getPrismaClient())
 
 function getRemoteSystemRepository(): RemoteSystemRepository {
   return new RemoteSystemRepository(getPrismaClient())
@@ -150,6 +153,19 @@ export const remoteSystemsRouter = s.router(remoteSystemContract, {
       })
       const usageCount = await remoteSystemRepository.countUsage(system.id)
 
+      await logRequestAudit(auditRepo, req, {
+        action: 'remote_system_create',
+        entityType: 'remote_system',
+        entityId: system.id,
+        details: {
+          remoteSystemCode: system.code,
+          remoteSystemName: system.name,
+          description: system.description ?? null,
+          displayOrder: system.displayOrder,
+          isActive: system.isActive,
+        },
+      })
+
       return {
         status: 201 as const,
         body: {
@@ -196,7 +212,30 @@ export const remoteSystemsRouter = s.router(remoteSystemContract, {
 
     try {
       const remoteSystemRepository = getRemoteSystemRepository()
+      const beforeSystems = await remoteSystemRepository.findAdminSystems()
       await remoteSystemRepository.reorder(body.remoteSystemIds)
+
+      const afterSystems = await remoteSystemRepository.findAdminSystems()
+
+      await logRequestAudit(auditRepo, req, {
+        action: 'remote_system_reorder',
+        entityType: 'remote_system',
+        entityId: null,
+        details: {
+          previousOrder: beforeSystems.map((system) => ({
+            id: system.id,
+            code: system.code,
+            name: system.name,
+            displayOrder: system.displayOrder,
+          })),
+          nextOrder: afterSystems.map((system) => ({
+            id: system.id,
+            code: system.code,
+            name: system.name,
+            displayOrder: system.displayOrder,
+          })),
+        },
+      })
 
       return {
         status: 200 as const,
@@ -234,6 +273,17 @@ export const remoteSystemsRouter = s.router(remoteSystemContract, {
 
     try {
       const remoteSystemRepository = getRemoteSystemRepository()
+      const existingSystem = await remoteSystemRepository.findById(params.id)
+      if (!existingSystem) {
+        return {
+          status: 404 as const,
+          body: {
+            error: 'NOT_FOUND',
+            message: 'Remote system not found',
+          },
+        }
+      }
+
       const system = await remoteSystemRepository.update(params.id, {
         code: body.code,
         name: body.name,
@@ -247,6 +297,31 @@ export const remoteSystemsRouter = s.router(remoteSystemContract, {
       ])
       const activeSessionCount =
         systems.find((item) => item.id === system.id)?.activeSessionCount ?? 0
+
+      await logRequestAudit(auditRepo, req, {
+        action: 'remote_system_update',
+        entityType: 'remote_system',
+        entityId: system.id,
+        details: {
+          remoteSystemCode: system.code,
+          remoteSystemName: system.name,
+          requestedChanges: body,
+          previousState: {
+            code: existingSystem.code,
+            name: existingSystem.name,
+            description: existingSystem.description ?? null,
+            displayOrder: existingSystem.displayOrder,
+            isActive: existingSystem.isActive,
+          },
+          currentState: {
+            code: system.code,
+            name: system.name,
+            description: system.description ?? null,
+            displayOrder: system.displayOrder,
+            isActive: system.isActive,
+          },
+        },
+      })
 
       return {
         status: 200 as const,
@@ -314,6 +389,17 @@ export const remoteSystemsRouter = s.router(remoteSystemContract, {
 
     try {
       const remoteSystemRepository = getRemoteSystemRepository()
+      const existingSystem = await remoteSystemRepository.findById(params.id)
+      if (!existingSystem) {
+        return {
+          status: 404 as const,
+          body: {
+            error: 'NOT_FOUND',
+            message: 'Remote system not found',
+          },
+        }
+      }
+
       const usageCount = await remoteSystemRepository.countUsage(params.id)
       if (usageCount > 0) {
         return {
@@ -326,6 +412,19 @@ export const remoteSystemsRouter = s.router(remoteSystemContract, {
       }
 
       await remoteSystemRepository.delete(params.id)
+
+      await logRequestAudit(auditRepo, req, {
+        action: 'remote_system_delete',
+        entityType: 'remote_system',
+        entityId: params.id,
+        details: {
+          remoteSystemCode: existingSystem.code,
+          remoteSystemName: existingSystem.name,
+          description: existingSystem.description ?? null,
+          displayOrder: existingSystem.displayOrder,
+          isActive: existingSystem.isActive,
+        },
+      })
 
       return {
         status: 200 as const,

--- a/apps/backend/src/routes/settings.ts
+++ b/apps/backend/src/routes/settings.ts
@@ -1,7 +1,9 @@
 import { initServer } from '@ts-rest/express'
 import { settingContract } from '@sentinel/contracts'
 import { SettingRepository } from '../repositories/setting-repository.js'
+import { AuditRepository } from '../repositories/audit-repository.js'
 import { getPrismaClient } from '../lib/database.js'
+import { logRequestAudit } from '../lib/audit-log.js'
 import type { Setting } from '../repositories/setting-repository.js'
 import type { SettingResponse } from '@sentinel/contracts'
 import type { Request } from 'express'
@@ -10,6 +12,7 @@ import { AccountLevel } from '../middleware/roles.js'
 const s = initServer()
 
 const settingRepo = new SettingRepository(getPrismaClient())
+const auditRepo = new AuditRepository(getPrismaClient())
 
 function requireMember(req: Request) {
   if (!req.member) {
@@ -163,6 +166,20 @@ export const settingsRouter = s.router(settingContract, {
         description: body.description,
       })
 
+      await logRequestAudit(auditRepo, req, {
+        action: 'setting_create',
+        entityType: 'settings',
+        entityId: setting.id,
+        details: {
+          settingKey: setting.key,
+          category: setting.category,
+          description: setting.description ?? null,
+          valueSnapshot: {
+            [setting.key]: setting.value,
+          },
+        },
+      })
+
       return {
         status: 201 as const,
         body: toApiFormat(setting),
@@ -199,9 +216,39 @@ export const settingsRouter = s.router(settingContract, {
     }
 
     try {
+      const existingSetting = await settingRepo.findByKey(params.key)
+      if (!existingSetting) {
+        return {
+          status: 404 as const,
+          body: {
+            error: 'NOT_FOUND',
+            message: `Setting with key '${params.key}' not found`,
+          },
+        }
+      }
+
       const setting = await settingRepo.updateByKey(params.key, {
         value: body.value,
         description: body.description,
+      })
+
+      await logRequestAudit(auditRepo, req, {
+        action: 'setting_update',
+        entityType: 'settings',
+        entityId: setting.id,
+        details: {
+          settingKey: setting.key,
+          category: setting.category,
+          description: setting.description ?? null,
+          previousValue: {
+            [setting.key]: existingSetting.value,
+          },
+          nextValue: {
+            [setting.key]: setting.value,
+          },
+          previousDescription: existingSetting.description ?? null,
+          nextDescription: setting.description ?? null,
+        },
       })
 
       return {
@@ -249,7 +296,32 @@ export const settingsRouter = s.router(settingContract, {
     }
 
     try {
+      const existingSetting = await settingRepo.findByKey(params.key)
+      if (!existingSetting) {
+        return {
+          status: 404 as const,
+          body: {
+            error: 'NOT_FOUND',
+            message: `Setting with key '${params.key}' not found`,
+          },
+        }
+      }
+
       await settingRepo.deleteByKey(params.key)
+
+      await logRequestAudit(auditRepo, req, {
+        action: 'setting_delete',
+        entityType: 'settings',
+        entityId: existingSetting.id,
+        details: {
+          settingKey: existingSetting.key,
+          category: existingSetting.category,
+          description: existingSetting.description ?? null,
+          deletedValue: {
+            [existingSetting.key]: existingSetting.value,
+          },
+        },
+      })
 
       return {
         status: 200 as const,

--- a/apps/backend/src/routes/system-status.ts
+++ b/apps/backend/src/routes/system-status.ts
@@ -1,4 +1,5 @@
 import { initServer } from '@ts-rest/express'
+import type { SystemStatusResponse } from '@sentinel/contracts'
 import { systemStatusContract } from '@sentinel/contracts'
 import { getPrismaClient } from '../lib/database.js'
 import { SystemStatusService } from '../services/system-status-service.js'
@@ -6,9 +7,31 @@ import { SystemStatusService } from '../services/system-status-service.js'
 const s = initServer()
 const systemStatusService = new SystemStatusService(getPrismaClient())
 
+function toKioskSafeSystemStatus(status: SystemStatusResponse): SystemStatusResponse {
+  return {
+    ...status,
+    database: {
+      ...status.database,
+      address: null,
+    },
+    network: {
+      ...status.network,
+      hostIpAddress: null,
+      hotspotScanDevice: null,
+      remoteTarget: null,
+    },
+    remoteSystems: {
+      ...status.remoteSystems,
+      activeCount: 0,
+      overflowCount: 0,
+      sessions: [],
+    },
+  }
+}
+
 export const systemStatusRouter = s.router(systemStatusContract, {
   getSystemStatus: async ({ req }) => {
-    if (!req.member) {
+    if (!req.member && !req.apiKey) {
       return {
         status: 401 as const,
         body: {
@@ -23,7 +46,7 @@ export const systemStatusRouter = s.router(systemStatusContract, {
 
       return {
         status: 200 as const,
-        body: status,
+        body: req.apiKey ? toKioskSafeSystemStatus(status) : status,
       }
     } catch (error) {
       return {

--- a/apps/backend/src/routes/tags.ts
+++ b/apps/backend/src/routes/tags.ts
@@ -1,6 +1,9 @@
 import { initServer } from '@ts-rest/express'
 import { tagContract } from '@sentinel/contracts'
 import type { AssignTagInput } from '@sentinel/contracts'
+import type { Request } from 'express'
+import { logRequestAudit, formatAuditMemberName } from '../lib/audit-log.js'
+import { AuditRepository } from '../repositories/audit-repository.js'
 import { TagRepository } from '../repositories/tag-repository.js'
 import { MemberRepository } from '../repositories/member-repository.js'
 import { getPrismaClient } from '../lib/database.js'
@@ -9,6 +12,7 @@ const s = initServer()
 
 const tagRepo = new TagRepository(getPrismaClient())
 const memberRepo = new MemberRepository(getPrismaClient())
+const auditRepo = new AuditRepository(getPrismaClient())
 
 /**
  * Tags route implementation using ts-rest
@@ -99,7 +103,15 @@ export const tagsRouter = s.router(tagContract, {
   /**
    * Assign a tag to a member
    */
-  assignTag: async ({ params, body }: { params: { memberId: string }; body: AssignTagInput }) => {
+  assignTag: async ({
+    params,
+    body,
+    req,
+  }: {
+    params: { memberId: string }
+    body: AssignTagInput
+    req: Request
+  }) => {
     try {
       // Verify member exists
       const member = await memberRepo.findById(params.memberId)
@@ -114,6 +126,18 @@ export const tagsRouter = s.router(tagContract, {
       }
 
       const memberTag = await tagRepo.assignTagToMember(params.memberId, body.tagId)
+
+      await logRequestAudit(auditRepo, req, {
+        action: 'member_tag_add',
+        entityType: 'member',
+        entityId: params.memberId,
+        details: {
+          memberName: formatAuditMemberName(member),
+          serviceNumber: member.serviceNumber,
+          tagId: memberTag.tagId,
+          tagName: memberTag.tag.name,
+        },
+      })
 
       return {
         status: 201 as const,
@@ -166,7 +190,13 @@ export const tagsRouter = s.router(tagContract, {
   /**
    * Remove a tag from a member
    */
-  removeTag: async ({ params }: { params: { memberId: string; tagId: string } }) => {
+  removeTag: async ({
+    params,
+    req,
+  }: {
+    params: { memberId: string; tagId: string }
+    req: Request
+  }) => {
     try {
       // Verify member exists
       const member = await memberRepo.findById(params.memberId)
@@ -180,7 +210,20 @@ export const tagsRouter = s.router(tagContract, {
         }
       }
 
+      const tag = await tagRepo.findById(params.tagId)
       await tagRepo.removeTagFromMember(params.memberId, params.tagId)
+
+      await logRequestAudit(auditRepo, req, {
+        action: 'member_tag_remove',
+        entityType: 'member',
+        entityId: params.memberId,
+        details: {
+          memberName: formatAuditMemberName(member),
+          serviceNumber: member.serviceNumber,
+          tagId: params.tagId,
+          tagName: tag?.name ?? null,
+        },
+      })
 
       return {
         status: 200 as const,

--- a/apps/backend/src/services/auth-service.ts
+++ b/apps/backend/src/services/auth-service.ts
@@ -6,7 +6,9 @@ import {
   type KioskResponsibilityStateResponse,
   type LoginStartOfDayAction,
 } from '@sentinel/contracts'
+import { formatAuditMemberName } from '../lib/audit-log.js'
 import { CheckinRepository } from '../repositories/checkin-repository.js'
+import { AuditRepository } from '../repositories/audit-repository.js'
 import { SessionRepository } from '../repositories/session-repository.js'
 import type { SessionMetadata, SessionWithMember } from '../repositories/session-repository.js'
 import { authLogger } from '../lib/logger.js'
@@ -91,6 +93,7 @@ export class AuthService {
   private prisma: PrismaClientInstance
   private sessionRepo: SessionRepository
   private checkinRepo: CheckinRepository
+  private auditRepo: AuditRepository
   private presenceService: PresenceService
   private ddsService: DdsService
   private lockupService: LockupService
@@ -99,6 +102,7 @@ export class AuthService {
     this.prisma = prisma
     this.sessionRepo = new SessionRepository(prisma)
     this.checkinRepo = new CheckinRepository(prisma)
+    this.auditRepo = new AuditRepository(prisma)
     this.presenceService = new PresenceService(prisma)
     this.ddsService = new DdsService(prisma)
     this.lockupService = new LockupService(prisma)
@@ -200,6 +204,23 @@ export class AuthService {
       remoteSystemId: remoteSystem.remoteSystemId,
       remoteSystemName: remoteSystem.remoteSystemName,
       ip: ipAddress,
+    })
+
+    await this.auditRepo.log({
+      adminUserId: null,
+      action: 'login',
+      entityType: 'session',
+      entityId: session.id,
+      details: {
+        actorMemberId: member.id,
+        actorName: formatAuditMemberName(member),
+        actorServiceNumber: member.serviceNumber,
+        actorType: 'member',
+        remoteSystemId: remoteSystem.remoteSystemId,
+        remoteSystemName: remoteSystem.remoteSystemName,
+        sessionId: session.id,
+      },
+      ipAddress: ipAddress ?? 'unknown',
     })
 
     return {
@@ -536,6 +557,7 @@ export class AuthService {
         firstName: true,
         lastName: true,
         displayName: true,
+        serviceNumber: true,
         division: {
           select: {
             name: true,
@@ -569,6 +591,25 @@ export class AuthService {
     })
 
     await this.presenceService.broadcastStatsUpdate()
+
+    await this.auditRepo.log({
+      adminUserId: null,
+      action: 'checkin_login',
+      entityType: 'checkin',
+      entityId: checkin.id,
+      details: {
+        actorMemberId: member.id,
+        actorName: formatAuditMemberName(member),
+        actorServiceNumber: member.serviceNumber,
+        actorType: 'member',
+        memberName: formatAuditMemberName(member),
+        memberRank: member.rank,
+        direction: 'in',
+        kioskId: remoteSystemId,
+        method: 'login',
+      },
+      ipAddress: 'unknown',
+    })
 
     return {
       created: true,

--- a/apps/backend/src/services/checkin-service.ts
+++ b/apps/backend/src/services/checkin-service.ts
@@ -1,6 +1,8 @@
 import type { PrismaClient } from '@sentinel/database'
 import { getPrismaClient } from '../lib/database.js'
+import { formatAuditMemberName } from '../lib/audit-log.js'
 import { CheckinRepository } from '../repositories/checkin-repository.js'
+import { AuditRepository } from '../repositories/audit-repository.js'
 import { BadgeRepository } from '../repositories/badge-repository.js'
 import { MemberRepository } from '../repositories/member-repository.js'
 import { PresenceService } from './presence-service.js'
@@ -38,6 +40,7 @@ interface CheckinResult {
 
 export class CheckinService {
   private checkinRepo: CheckinRepository
+  private auditRepo: AuditRepository
   private badgeRepo: BadgeRepository
   private memberRepo: MemberRepository
   private presenceService: PresenceService
@@ -45,6 +48,7 @@ export class CheckinService {
   constructor(prismaClient?: PrismaClient) {
     const prisma = prismaClient || getPrismaClient()
     this.checkinRepo = new CheckinRepository(prisma)
+    this.auditRepo = new AuditRepository(prisma)
     this.badgeRepo = new BadgeRepository(prisma)
     this.memberRepo = new MemberRepository(prisma)
     this.presenceService = new PresenceService(prisma)
@@ -183,6 +187,26 @@ export class CheckinService {
       direction,
       badgeSerial: serialNumber,
       kioskId: options.kioskId,
+    })
+
+    await this.auditRepo.log({
+      adminUserId: null,
+      action: 'checkin_scan',
+      entityType: 'checkin',
+      entityId: checkin.id,
+      details: {
+        actorMemberId: member.id,
+        actorName: formatAuditMemberName(member),
+        actorServiceNumber: member.serviceNumber,
+        actorType: 'member',
+        memberName: formatAuditMemberName(member),
+        memberRank: member.rank,
+        direction,
+        badgeSerialNumber: serialNumber,
+        kioskId: options.kioskId ?? null,
+        method: 'badge',
+      },
+      ipAddress: 'unknown',
     })
 
     return {

--- a/apps/backend/src/websocket/auth.ts
+++ b/apps/backend/src/websocket/auth.ts
@@ -1,5 +1,9 @@
 import { Socket } from 'socket.io'
 import { logger } from '../lib/logger.js'
+import {
+  authenticateKioskDeviceApiKey,
+  extractKioskDeviceApiKeyFromCookieHeader,
+} from '../lib/kiosk-device-auth.js'
 import { SessionRepository } from '../repositories/session-repository.js'
 import { getPrismaClient } from '../lib/database.js'
 import { AccountLevel } from '../middleware/roles.js'
@@ -47,10 +51,67 @@ export async function authenticateSocket(socket: Socket, next: (err?: Error) => 
     }
 
     const tokenFromAuth = socket.handshake.auth.token || socket.handshake.headers.authorization
-    const tokenFromCookie = extractSessionTokenFromCookieHeader(socket.handshake.headers.cookie)
-    const token = tokenFromAuth || tokenFromCookie
+    const sessionTokenFromCookie = extractSessionTokenFromCookieHeader(
+      socket.handshake.headers.cookie
+    )
+    const sessionToken = sessionTokenFromCookie
+      ? sessionTokenFromCookie
+      : typeof tokenFromAuth === 'string' && !tokenFromAuth.startsWith('sk_')
+        ? tokenFromAuth
+        : null
 
-    if (!token) {
+    if (sessionToken) {
+      const rawToken =
+        typeof sessionToken === 'string' && sessionToken.startsWith('Bearer ')
+          ? sessionToken.slice(7)
+          : sessionToken
+
+      const sessionRepo = new SessionRepository(getPrismaClient())
+      const session = await sessionRepo.findByToken(rawToken)
+
+      if (session) {
+        socket.data.memberId = session.member.id
+        socket.data.sessionId = session.id
+        socket.data.accountLevel = session.member.accountLevel
+
+        logger.info('WebSocket authenticated', {
+          socketId: socket.id,
+          memberId: session.member.id,
+          accountLevel: session.member.accountLevel,
+        })
+
+        return next()
+      }
+
+      logger.warn('WebSocket connection rejected: Invalid session token', {
+        socketId: socket.id,
+        address: socket.handshake.address,
+      })
+    }
+
+    const cookieApiKey = extractKioskDeviceApiKeyFromCookieHeader(socket.handshake.headers.cookie)
+    const rawApiKey =
+      typeof tokenFromAuth === 'string' && tokenFromAuth.startsWith('Bearer sk_')
+        ? tokenFromAuth.slice(7)
+        : typeof tokenFromAuth === 'string' && tokenFromAuth.startsWith('sk_')
+          ? tokenFromAuth
+          : cookieApiKey
+    const apiKey = authenticateKioskDeviceApiKey(rawApiKey)
+
+    if (apiKey) {
+      socket.data.apiKeyId = apiKey.id
+      socket.data.accountLevel = 0
+
+      logger.info('WebSocket authenticated with kiosk device API key', {
+        socketId: socket.id,
+        apiKeyId: apiKey.id,
+        apiKeyName: apiKey.name,
+      })
+
+      return next()
+    }
+
+    if (!sessionToken && !rawApiKey) {
       logger.warn('WebSocket connection rejected: No authentication token', {
         socketId: socket.id,
         address: socket.handshake.address,
@@ -58,33 +119,11 @@ export async function authenticateSocket(socket: Socket, next: (err?: Error) => 
       return next(new Error('Authentication required'))
     }
 
-    // Strip "Bearer " prefix if present
-    const rawToken =
-      typeof token === 'string' && token.startsWith('Bearer ') ? token.slice(7) : token
-
-    const sessionRepo = new SessionRepository(getPrismaClient())
-    const session = await sessionRepo.findByToken(rawToken)
-
-    if (!session) {
-      logger.warn('WebSocket connection rejected: Invalid session token', {
-        socketId: socket.id,
-        address: socket.handshake.address,
-      })
-      return next(new Error('Invalid authentication token'))
-    }
-
-    // Attach member info to socket
-    socket.data.memberId = session.member.id
-    socket.data.sessionId = session.id
-    socket.data.accountLevel = session.member.accountLevel
-
-    logger.info('WebSocket authenticated', {
+    logger.warn('WebSocket connection rejected: Invalid API key', {
       socketId: socket.id,
-      memberId: session.member.id,
-      accountLevel: session.member.accountLevel,
+      address: socket.handshake.address,
     })
-
-    next()
+    next(new Error('Invalid authentication token'))
   } catch (error) {
     logger.error('WebSocket authentication error', {
       error: error instanceof Error ? error.message : 'Unknown error',

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/app/kiosk/device-auth/route.ts
+++ b/apps/frontend-admin/src/app/kiosk/device-auth/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { buildLoginUrl } from '@/lib/post-login-destination'
+import { KIOSK_DEVICE_COOKIE_NAME, resolveKioskBootstrapNext } from '@/lib/kiosk-device-auth'
+import {
+  getConfiguredKioskDeviceApiKey,
+  getKioskDeviceCookieMaxAgeSeconds,
+} from '@/lib/kiosk-device-auth.server'
+
+function shouldUseSecureCookie(request: NextRequest): boolean {
+  return request.nextUrl.protocol === 'https:'
+}
+
+export async function GET(request: NextRequest) {
+  const nextPath = resolveKioskBootstrapNext(request.nextUrl.searchParams.get('next'))
+  const loginUrl = new globalThis.URL(buildLoginUrl('/kiosk'), request.url)
+  const configuredApiKey = getConfiguredKioskDeviceApiKey()
+
+  if (!configuredApiKey) {
+    const response = NextResponse.redirect(loginUrl)
+    response.cookies.delete(KIOSK_DEVICE_COOKIE_NAME)
+    return response
+  }
+
+  const response = NextResponse.redirect(new globalThis.URL(nextPath, request.url))
+  response.cookies.set(KIOSK_DEVICE_COOKIE_NAME, configuredApiKey, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: shouldUseSecureCookie(request),
+    maxAge: getKioskDeviceCookieMaxAgeSeconds(),
+    path: '/',
+  })
+
+  return response
+}
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+export const preferredRegion = 'auto'

--- a/apps/frontend-admin/src/components/auth/auth-hydrator.tsx
+++ b/apps/frontend-admin/src/components/auth/auth-hydrator.tsx
@@ -9,6 +9,7 @@ import {
   buildLoginUrl,
   resolvePostLoginDestinationHint,
 } from '@/lib/post-login-destination'
+import { isKioskRoute } from '@/lib/kiosk-device-auth'
 import { useAuthStore } from '@/store/auth-store'
 
 /**
@@ -21,6 +22,7 @@ export function AuthHydrator() {
   const pathname = usePathname()
   const { isAuthenticated, setAuth, updateSession, logout } = useAuthStore()
   const hasValidated = useRef(false)
+  const kioskRoute = isKioskRoute(pathname)
 
   const validateSession = useEffectEvent(async () => {
     try {
@@ -53,7 +55,7 @@ export function AuthHydrator() {
 
       if (response.status === 401) {
         logout()
-        if (pathname !== '/login') {
+        if (pathname !== '/login' && !kioskRoute) {
           router.replace(buildForcedReauthLoginUrl())
         }
         return
@@ -61,7 +63,7 @@ export function AuthHydrator() {
 
       if (isAuthenticated) {
         logout()
-        if (pathname !== '/login') {
+        if (pathname !== '/login' && !kioskRoute) {
           router.replace(buildLoginUrl(pathname, window.location.search))
         }
       }
@@ -85,7 +87,7 @@ export function AuthHydrator() {
 
       if (response.status === 401) {
         logout()
-        if (pathname !== '/login') {
+        if (pathname !== '/login' && !kioskRoute) {
           router.replace(buildForcedReauthLoginUrl())
         }
       }
@@ -130,7 +132,7 @@ export function AuthHydrator() {
       window.removeEventListener('focus', handleFocus)
       document.removeEventListener('visibilitychange', handleVisibilityChange)
     }
-  }, [isAuthenticated])
+  }, [isAuthenticated, kioskRoute])
 
   return null
 }

--- a/apps/frontend-admin/src/components/checkins/manual-checkin-modal.logic.test.ts
+++ b/apps/frontend-admin/src/components/checkins/manual-checkin-modal.logic.test.ts
@@ -3,6 +3,7 @@ import {
   evaluateManualCheckinEligibility,
   formatManualCheckinMemberLabel,
   type ManualCheckinMemberOption,
+  resolveManualCheckinTimestamp,
 } from './manual-checkin-modal.logic'
 
 function createMember(
@@ -75,6 +76,22 @@ describe('evaluateManualCheckinEligibility', () => {
     expect(result.selectedMemberEligible).toBe(false)
     expect(result.selectedMemberReason).toContain('not currently checked in')
   })
+
+  it('keeps the selected member eligible when they are no longer in the current member page', () => {
+    const members = [createMember('1')]
+    const selectedMember = createMember('999')
+
+    const result = evaluateManualCheckinEligibility({
+      members,
+      presentMemberIds: new Set(),
+      direction: 'in',
+      selectedMemberId: '999',
+      selectedMember,
+    })
+
+    expect(result.selectedMemberEligible).toBe(true)
+    expect(result.selectedMemberReason).toBeNull()
+  })
 })
 
 describe('formatManualCheckinMemberLabel', () => {
@@ -87,5 +104,30 @@ describe('formatManualCheckinMemberLabel', () => {
         })
       )
     ).toBe('PO2 Taylor Hunt (890)')
+  })
+})
+
+describe('resolveManualCheckinTimestamp', () => {
+  it('omits the timestamp when the field is blank', () => {
+    expect(resolveManualCheckinTimestamp('')).toEqual({
+      isoTimestamp: undefined,
+      error: null,
+    })
+  })
+
+  it('converts a local datetime value to ISO', () => {
+    const value = '2026-04-21T19:45'
+
+    expect(resolveManualCheckinTimestamp(value)).toEqual({
+      isoTimestamp: new Date(value).toISOString(),
+      error: null,
+    })
+  })
+
+  it('reports invalid datetime input', () => {
+    expect(resolveManualCheckinTimestamp('not-a-date')).toEqual({
+      isoTimestamp: undefined,
+      error: 'Enter a valid date and time or leave it blank.',
+    })
   })
 })

--- a/apps/frontend-admin/src/components/checkins/manual-checkin-modal.logic.ts
+++ b/apps/frontend-admin/src/components/checkins/manual-checkin-modal.logic.ts
@@ -15,6 +15,11 @@ export interface ManualCheckinEligibilityResult {
   selectedMemberReason: string | null
 }
 
+export interface ManualCheckinTimestampResolution {
+  isoTimestamp?: string
+  error: string | null
+}
+
 function getFormattedName(member: ManualCheckinMemberOption): string {
   return (
     member.displayName?.trim() || `${member.rank} ${member.lastName}, ${member.firstName}`.trim()
@@ -25,16 +30,43 @@ export function formatManualCheckinMemberLabel(member: ManualCheckinMemberOption
   return `${getFormattedName(member)} (${member.serviceNumber.slice(-3)})`
 }
 
+export function resolveManualCheckinTimestamp(value: string): ManualCheckinTimestampResolution {
+  const trimmedValue = value.trim()
+
+  if (trimmedValue.length === 0) {
+    return {
+      isoTimestamp: undefined,
+      error: null,
+    }
+  }
+
+  const parsedTimestamp = new Date(trimmedValue)
+
+  if (Number.isNaN(parsedTimestamp.getTime())) {
+    return {
+      isoTimestamp: undefined,
+      error: 'Enter a valid date and time or leave it blank.',
+    }
+  }
+
+  return {
+    isoTimestamp: parsedTimestamp.toISOString(),
+    error: null,
+  }
+}
+
 export function evaluateManualCheckinEligibility({
   members,
   presentMemberIds,
   direction,
   selectedMemberId,
+  selectedMember,
 }: {
   members: ManualCheckinMemberOption[]
   presentMemberIds: Set<string>
   direction: ManualCheckinDirection
   selectedMemberId: string | null
+  selectedMember?: ManualCheckinMemberOption | null
 }): ManualCheckinEligibilityResult {
   const eligibleMembers = members.filter((member) => {
     const isPresent = presentMemberIds.has(member.id)
@@ -49,9 +81,11 @@ export function evaluateManualCheckinEligibility({
     }
   }
 
-  const selectedMember = members.find((member) => member.id === selectedMemberId)
+  const resolvedSelectedMember =
+    members.find((member) => member.id === selectedMemberId) ??
+    (selectedMember?.id === selectedMemberId ? selectedMember : undefined)
 
-  if (!selectedMember) {
+  if (!resolvedSelectedMember) {
     return {
       eligibleMembers,
       selectedMemberEligible: false,
@@ -59,13 +93,13 @@ export function evaluateManualCheckinEligibility({
     }
   }
 
-  const isPresent = presentMemberIds.has(selectedMember.id)
+  const isPresent = presentMemberIds.has(resolvedSelectedMember.id)
 
   if (direction === 'in' && isPresent) {
     return {
       eligibleMembers,
       selectedMemberEligible: false,
-      selectedMemberReason: `${getFormattedName(selectedMember)} is already checked in.`,
+      selectedMemberReason: `${getFormattedName(resolvedSelectedMember)} is already checked in.`,
     }
   }
 
@@ -73,7 +107,7 @@ export function evaluateManualCheckinEligibility({
     return {
       eligibleMembers,
       selectedMemberEligible: false,
-      selectedMemberReason: `${getFormattedName(selectedMember)} is not currently checked in.`,
+      selectedMemberReason: `${getFormattedName(resolvedSelectedMember)} is not currently checked in.`,
     }
   }
 

--- a/apps/frontend-admin/src/components/checkins/manual-checkin-modal.tsx
+++ b/apps/frontend-admin/src/components/checkins/manual-checkin-modal.tsx
@@ -22,6 +22,7 @@ import { TID } from '@/lib/test-ids'
 import {
   evaluateManualCheckinEligibility,
   formatManualCheckinMemberLabel,
+  resolveManualCheckinTimestamp,
   type ManualCheckinDirection,
   type ManualCheckinMemberOption,
 } from './manual-checkin-modal.logic'
@@ -35,6 +36,7 @@ export function ManualCheckinModal({ open, onOpenChange }: ManualCheckinModalPro
   // eslint-disable-next-line no-undef -- DOM type available in browser build
   const searchInputRef = useRef<HTMLInputElement>(null)
   const [memberSearch, setMemberSearch] = useState('')
+  const [recordedAt, setRecordedAt] = useState('')
   const [direction, setDirection] = useState<ManualCheckinDirection>('in')
   const [selectedMemberInfo, setSelectedMemberInfo] = useState<{
     id: string
@@ -113,15 +115,18 @@ export function ManualCheckinModal({ open, onOpenChange }: ManualCheckinModalPro
         presentMemberIds,
         direction,
         selectedMemberId: selectedMemberInfo?.id ?? null,
+        selectedMember: selectedMemberInfo,
       }),
-    [direction, members, presentMemberIds, selectedMemberInfo?.id]
+    [direction, members, presentMemberIds, selectedMemberInfo]
   )
+  const timestampResolution = useMemo(() => resolveManualCheckinTimestamp(recordedAt), [recordedAt])
 
   // Reset state when modal closes
   useEffect(() => {
     if (!open) {
       setPendingCheckout(null)
       setMemberSearch('')
+      setRecordedAt('')
       setDirection('in')
       setSelectedMemberInfo(null)
       setSubmitError(null)
@@ -147,6 +152,10 @@ export function ManualCheckinModal({ open, onOpenChange }: ManualCheckinModalPro
 
     setSubmitError(null)
 
+    if (timestampResolution.error) {
+      return
+    }
+
     if (direction === 'out' && holdsLockup && !canCheckoutNormally) {
       setPendingCheckout({ memberId: selectedMemberInfo.id, direction })
       setShowLockupOptions(true)
@@ -159,6 +168,9 @@ export function ManualCheckinModal({ open, onOpenChange }: ManualCheckinModalPro
         direction,
         kioskId: 'ADMIN_MANUAL',
         method: 'manual',
+        ...(timestampResolution.isoTimestamp
+          ? { timestamp: timestampResolution.isoTimestamp }
+          : {}),
       }
       await createCheckin.mutateAsync(checkinData)
       onOpenChange(false)
@@ -177,6 +189,9 @@ export function ManualCheckinModal({ open, onOpenChange }: ManualCheckinModalPro
           direction: pendingCheckout.direction,
           kioskId: 'ADMIN_MANUAL',
           method: 'manual',
+          ...(timestampResolution.isoTimestamp
+            ? { timestamp: timestampResolution.isoTimestamp }
+            : {}),
         }
         await createCheckin.mutateAsync(checkinData)
       } catch (error) {
@@ -212,6 +227,7 @@ export function ManualCheckinModal({ open, onOpenChange }: ManualCheckinModalPro
   const canSubmit =
     hasSelectedMember &&
     eligibility.selectedMemberEligible &&
+    !timestampResolution.error &&
     !isFormBusy &&
     !(direction === 'out' && selectedMemberId && loadingCheckoutOptions)
 
@@ -284,6 +300,35 @@ export function ManualCheckinModal({ open, onOpenChange }: ManualCheckinModalPro
                 </button>
               </div>
             </fieldset>
+
+            <div className="grid gap-(--space-2)">
+              <label
+                className="input input-bordered input-sm w-full"
+                htmlFor={TID.checkins.manualModal.timestamp}
+              >
+                <span className="label">Recorded time</span>
+                <input
+                  id={TID.checkins.manualModal.timestamp}
+                  type="datetime-local"
+                  className="grow"
+                  value={recordedAt}
+                  onChange={(event) => {
+                    setRecordedAt(event.target.value)
+                    setSubmitError(null)
+                  }}
+                  disabled={isFormBusy}
+                  data-testid={TID.checkins.manualModal.timestamp}
+                />
+              </label>
+              <p className="text-xs text-base-content/55">
+                Leave blank to use the current local time.
+              </p>
+              {timestampResolution.error ? (
+                <p className="text-xs text-error" role="alert">
+                  {timestampResolution.error}
+                </p>
+              ) : null}
+            </div>
 
             <div className="grid gap-(--space-2)">
               <label className="input input-bordered input-sm w-full">

--- a/apps/frontend-admin/src/components/logs/logs-page.tsx
+++ b/apps/frontend-admin/src/components/logs/logs-page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useEffect } from 'react'
-import { Activity, Cable, PauseCircle, PlayCircle, Search, ShieldAlert, Trash2 } from 'lucide-react'
+import { useDeferredValue, useEffect, useState } from 'react'
+import { Activity, RefreshCw, ShieldAlert } from 'lucide-react'
 import {
   AppCard,
   AppCardContent,
@@ -9,21 +9,32 @@ import {
   AppCardHeader,
   AppCardTitle,
 } from '@/components/ui/AppCard'
-import { AppBadge, type AppBadgeStatus } from '@/components/ui/AppBadge'
+import { AppBadge } from '@/components/ui/AppBadge'
 import { EmptyState } from '@/components/ui/empty-state'
+import { TableSkeleton } from '@/components/ui/loading-skeleton'
 import { Chip, type ChipColor } from '@/components/ui/chip'
 import {
-  DEFAULT_LOG_FILTERS,
-  LOG_STREAM_LEVELS,
-  type LogStreamLevel,
-  useFilteredLogs,
-  useLogStats,
-  useLogViewer,
-  useLogViewerStore,
-} from '@/hooks/use-log-viewer'
-import { TID } from '@/lib/test-ids'
+  useAuditActivityFeed,
+  type ActivityArea,
+  type ActivityEntry,
+} from '@/hooks/use-audit-activity'
 import { cn } from '@/lib/utils'
 import { AccountLevel, useAuthStore } from '@/store/auth-store'
+
+const AREA_OPTIONS: Array<{
+  value: 'all' | ActivityArea
+  label: string
+  color: ChipColor
+}> = [
+  { value: 'all', label: 'All', color: 'default' },
+  { value: 'attendance', label: 'Attendance', color: 'blue' },
+  { value: 'members', label: 'Members', color: 'green' },
+  { value: 'badges', label: 'Badges', color: 'yellow' },
+  { value: 'settings', label: 'Settings', color: 'cyan' },
+  { value: 'responsibility', label: 'DDS & lockup', color: 'red' },
+  { value: 'access', label: 'Access', color: 'neutral' },
+  { value: 'admin', label: 'Admin', color: 'neutral' },
+]
 
 function formatTimestamp(timestamp: string): string {
   const date = new Date(timestamp)
@@ -33,11 +44,11 @@ function formatTimestamp(timestamp: string): string {
   }
 
   return new Intl.DateTimeFormat('en-CA', {
+    month: 'short',
+    day: '2-digit',
     hour: '2-digit',
     minute: '2-digit',
     second: '2-digit',
-    month: 'short',
-    day: '2-digit',
   }).format(date)
 }
 
@@ -58,137 +69,99 @@ function formatDateTime(timestamp: string): string {
   }).format(date)
 }
 
-function getLevelStatus(level: string): AppBadgeStatus {
-  switch (level) {
-    case 'error':
-      return 'error'
-    case 'warn':
-      return 'warning'
-    case 'info':
-    case 'http':
-      return 'info'
-    default:
-      return 'neutral'
-  }
+function getAreaLabel(area: ActivityArea): string {
+  return AREA_OPTIONS.find((option) => option.value === area)?.label ?? area
 }
 
-function getLevelChipColor(level: string): ChipColor {
-  switch (level) {
-    case 'error':
-      return 'error'
-    case 'warn':
-      return 'warning'
-    case 'info':
-    case 'http':
-      return 'info'
-    case 'verbose':
-      return 'secondary'
-    case 'debug':
-      return 'accent'
-    case 'silly':
-      return 'neutral'
-    default:
-      return 'default'
-  }
+function getAreaColor(area: ActivityArea): ChipColor {
+  return AREA_OPTIONS.find((option) => option.value === area)?.color ?? 'default'
 }
 
-function describeConnection(
-  isConnected: boolean,
-  isPaused: boolean
-): {
-  cardStatus: AppBadgeStatus
-  label: string
-  detail: string
-} {
-  if (!isConnected) {
-    return {
-      cardStatus: 'error',
-      label: 'Disconnected',
-      detail: 'Waiting for a live socket connection to the backend.',
-    }
+function renderDetails(details: Record<string, unknown> | null): string {
+  if (!details || Object.keys(details).length === 0) {
+    return 'No structured details'
   }
 
-  if (isPaused) {
-    return {
-      cardStatus: 'warning',
-      label: 'Paused',
-      detail: 'Incoming entries are buffered locally until you resume.',
-    }
-  }
-
-  return {
-    cardStatus: 'success',
-    label: 'Streaming',
-    detail: 'Live entries are flowing into the viewer.',
-  }
+  return JSON.stringify(details, null, 2)
 }
 
-function renderMetadata(metadata: Record<string, unknown> | undefined): string {
-  if (!metadata || Object.keys(metadata).length === 0) {
-    return 'No structured metadata'
+function matchesSearch(entry: ActivityEntry, search: string): boolean {
+  if (!search) {
+    return true
   }
 
-  return JSON.stringify(metadata, null, 2)
+  const haystack = [
+    entry.actionLabel,
+    entry.actorName,
+    entry.subjectLabel,
+    entry.summary,
+    entry.raw.action,
+    entry.raw.entityType,
+  ]
+    .join(' ')
+    .toLowerCase()
+
+  return haystack.includes(search)
 }
 
 function LogsPageContent() {
   const member = useAuthStore((state) => state.member)
   const canAccessLogs = (member?.accountLevel ?? 0) >= AccountLevel.ADMIN
+  const [search, setSearch] = useState('')
+  const deferredSearch = useDeferredValue(search.trim().toLowerCase())
+  const [areaFilter, setAreaFilter] = useState<'all' | ActivityArea>('all')
+  const [selectedEntryId, setSelectedEntryId] = useState<string | null>(null)
+  const { data, error, isError, isFetching, isLoading, refetch } =
+    useAuditActivityFeed(canAccessLogs)
 
-  useLogViewer(canAccessLogs)
+  const entries = data?.entries ?? []
+  const filteredEntries = entries.filter((entry) => {
+    if (areaFilter !== 'all' && entry.area !== areaFilter) {
+      return false
+    }
 
-  const logs = useFilteredLogs()
-  const stats = useLogStats()
-  const allLogs = useLogViewerStore((state) => state.logs)
-  const filters = useLogViewerStore((state) => state.filters)
-  const isConnected = useLogViewerStore((state) => state.isConnected)
-  const isPaused = useLogViewerStore((state) => state.isPaused)
-  const bufferedEntries = useLogViewerStore((state) => state.bufferedEntries)
-  const selectedLogId = useLogViewerStore((state) => state.selectedLogId)
-  const streamLevel = useLogViewerStore((state) => state.streamLevel)
-  const setFilter = useLogViewerStore((state) => state.setFilter)
-  const clearLogs = useLogViewerStore((state) => state.clearLogs)
-  const togglePause = useLogViewerStore((state) => state.togglePause)
-  const setSelectedLogId = useLogViewerStore((state) => state.setSelectedLogId)
-  const setStreamLevel = useLogViewerStore((state) => state.setStreamLevel)
-
-  const modules = [...new Set(allLogs.flatMap((log) => (log.module ? [log.module] : [])))].sort(
-    (left, right) => left.localeCompare(right)
-  )
-  const selectedLog =
-    logs.find((entry) => entry.id === selectedLogId) ??
-    allLogs.find((entry) => entry.id === selectedLogId) ??
+    return matchesSearch(entry, deferredSearch)
+  })
+  const selectedEntry =
+    filteredEntries.find((entry) => entry.id === selectedEntryId) ??
+    entries.find((entry) => entry.id === selectedEntryId) ??
     null
-  const connection = describeConnection(isConnected, isPaused)
+
+  const attendanceCount = filteredEntries.filter((entry) => entry.area === 'attendance').length
+  const profileCount = filteredEntries.filter(
+    (entry) => entry.area === 'members' || entry.area === 'badges' || entry.area === 'settings'
+  ).length
+  const responsibilityCount = filteredEntries.filter(
+    (entry) => entry.area === 'responsibility'
+  ).length
 
   useEffect(() => {
     if (!canAccessLogs) {
-      if (selectedLogId !== null) {
-        setSelectedLogId(null)
+      if (selectedEntryId !== null) {
+        setSelectedEntryId(null)
       }
       return
     }
 
-    if (logs.length === 0) {
-      if (selectedLogId !== null) {
-        setSelectedLogId(null)
+    if (filteredEntries.length === 0) {
+      if (selectedEntryId !== null) {
+        setSelectedEntryId(null)
       }
       return
     }
 
-    if (!selectedLogId || !logs.some((entry) => entry.id === selectedLogId)) {
-      setSelectedLogId(logs[0]?.id ?? null)
+    if (!selectedEntryId || !filteredEntries.some((entry) => entry.id === selectedEntryId)) {
+      setSelectedEntryId(filteredEntries[0]?.id ?? null)
     }
-  }, [canAccessLogs, logs, selectedLogId, setSelectedLogId])
+  }, [canAccessLogs, filteredEntries, selectedEntryId])
 
   if (!canAccessLogs) {
     return (
       <div className="space-y-(--space-4)">
         <div>
-          <h1 className="text-3xl font-semibold">Logs</h1>
+          <h1 className="text-3xl font-semibold">Activity log</h1>
           <p className="mt-(--space-1) max-w-3xl text-sm text-base-content/70">
-            Live operational log viewer for short-horizon incident triage and correlation-driven
-            debugging.
+            Recent admin actions, attendance scans, and responsibility handoffs.
           </p>
         </div>
 
@@ -197,7 +170,7 @@ function LogsPageContent() {
             <EmptyState
               icon={ShieldAlert}
               title="Admin access required"
-              description="The live logs viewer is restricted to admin and developer accounts because it can expose operational diagnostics and sensitive context."
+              description="The activity log is restricted to admin and developer accounts."
             />
           </AppCardContent>
         </AppCard>
@@ -209,421 +182,254 @@ function LogsPageContent() {
     <div className="space-y-(--space-4)">
       <div className="flex flex-wrap items-end justify-between gap-(--space-4)">
         <div>
-          <h1 className="text-3xl font-semibold">Logs</h1>
+          <h1 className="text-3xl font-semibold">Activity log</h1>
           <p className="mt-(--space-1) max-w-3xl text-sm text-base-content/70">
-            Filter by severity, module, search terms, and correlation IDs before broad scans. This
-            viewer uses live socket updates plus a short in-memory history buffer from the backend.
+            Recent admin actions, attendance scans, and responsibility handoffs. This view now
+            prioritizes what operators actually do instead of backend socket noise.
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-(--space-2)">
-          <AppBadge status={connection.cardStatus}>{connection.label}</AppBadge>
-          {isPaused && bufferedEntries.length > 0 ? (
-            <AppBadge status="warning">{bufferedEntries.length} buffered</AppBadge>
-          ) : null}
-          <AppBadge status="info">Level {streamLevel}</AppBadge>
+          <AppBadge status="info">Latest {entries.length}</AppBadge>
+          <AppBadge status="info">15s refresh</AppBadge>
+          <AppBadge status={isFetching ? 'warning' : 'success'} pulse={isFetching}>
+            {isFetching ? 'Refreshing' : 'Current'}
+          </AppBadge>
+          <button
+            type="button"
+            className="btn btn-sm btn-outline"
+            onClick={() => {
+              void refetch()
+            }}
+          >
+            <RefreshCw className={cn('h-4 w-4', isFetching && 'animate-spin')} />
+            Refresh
+          </button>
         </div>
       </div>
 
       <section className="grid gap-(--space-4) md:grid-cols-2 xl:grid-cols-4">
-        <AppCard status={connection.cardStatus} variant="elevated">
+        <AppCard status="info" variant="elevated">
           <AppCardHeader>
             <AppCardTitle className="flex items-center gap-(--space-2)">
-              <Cable className="h-4 w-4" />
-              Connection
+              <Activity className="h-4 w-4" />
+              Visible events
             </AppCardTitle>
-            <AppCardDescription>{connection.detail}</AppCardDescription>
+            <AppCardDescription>Rows matching the current filters.</AppCardDescription>
           </AppCardHeader>
           <AppCardContent className="pt-0">
-            <p className="text-2xl font-semibold">{connection.label}</p>
+            <p className="text-2xl font-semibold">{filteredEntries.length}</p>
+            <p className="mt-(--space-1) text-xs text-base-content/70">
+              {data?.total ?? 0} total audited rows available
+            </p>
           </AppCardContent>
         </AppCard>
 
         <AppCard status="info">
           <AppCardHeader>
-            <AppCardTitle className="flex items-center gap-(--space-2)">
-              <Activity className="h-4 w-4" />
-              Live rate
-            </AppCardTitle>
-            <AppCardDescription>
-              Average events per second across the visible stream.
-            </AppCardDescription>
+            <AppCardTitle>Attendance</AppCardTitle>
+            <AppCardDescription>Scans, manual attendance, and checkout edits.</AppCardDescription>
           </AppCardHeader>
           <AppCardContent className="pt-0">
-            <p className="text-2xl font-semibold">{stats.rate.toFixed(1)}/s</p>
-            <p className="mt-(--space-1) text-xs text-base-content/70">
-              {stats.total} retained entries in memory
-            </p>
-          </AppCardContent>
-        </AppCard>
-
-        <AppCard status={stats.errors > 0 ? 'error' : 'neutral'}>
-          <AppCardHeader>
-            <AppCardTitle>Errors</AppCardTitle>
-            <AppCardDescription>
-              Critical entries that usually need immediate triage.
-            </AppCardDescription>
-          </AppCardHeader>
-          <AppCardContent className="pt-0">
-            <p className="text-2xl font-semibold">{stats.errors}</p>
-            <p className="mt-(--space-1) text-xs text-base-content/70">
-              {stats.warnings} warnings currently retained
-            </p>
+            <p className="text-2xl font-semibold">{attendanceCount}</p>
           </AppCardContent>
         </AppCard>
 
         <AppCard status="neutral">
           <AppCardHeader>
-            <AppCardTitle>Viewer state</AppCardTitle>
-            <AppCardDescription>
-              Entries that match the active filters in this session.
-            </AppCardDescription>
+            <AppCardTitle>Profiles & settings</AppCardTitle>
+            <AppCardDescription>Members, badges, and configuration changes.</AppCardDescription>
           </AppCardHeader>
           <AppCardContent className="pt-0">
-            <p className="text-2xl font-semibold">{logs.length}</p>
-            <p className="mt-(--space-1) text-xs text-base-content/70">
-              {filters.levels.length} level filters, {filters.modules.length} module filters
-            </p>
+            <p className="text-2xl font-semibold">{profileCount}</p>
+          </AppCardContent>
+        </AppCard>
+
+        <AppCard status="warning">
+          <AppCardHeader>
+            <AppCardTitle>DDS & lockup</AppCardTitle>
+            <AppCardDescription>Responsibility changes that affect operations.</AppCardDescription>
+          </AppCardHeader>
+          <AppCardContent className="pt-0">
+            <p className="text-2xl font-semibold">{responsibilityCount}</p>
           </AppCardContent>
         </AppCard>
       </section>
 
-      <AppCard>
-        <AppCardHeader>
-          <AppCardTitle>Viewer controls</AppCardTitle>
-          <AppCardDescription>
-            Pause the live stream when bursts get noisy, or narrow scope before searching.
-          </AppCardDescription>
-        </AppCardHeader>
-        <AppCardContent className="space-y-(--space-4)">
-          <div className="grid gap-(--space-3) xl:grid-cols-[minmax(0,1.3fr)_minmax(0,1fr)_12rem_auto]">
-            <label className="form-control w-full">
-              <span className="mb-(--space-1) text-xs font-medium uppercase tracking-wide text-base-content/65">
-                Search
-              </span>
-              <div className="input input-bordered input-sm flex items-center gap-(--space-2)">
-                <Search className="h-4 w-4 text-base-content/50" />
+      <div className="grid gap-(--space-4) xl:grid-cols-[minmax(0,2.1fr)_minmax(24rem,1fr)]">
+        <AppCard status="info">
+          <AppCardHeader>
+            <AppCardTitle>Recent activity</AppCardTitle>
+            <AppCardDescription>
+              Search across actors, subjects, actions, and summaries.
+            </AppCardDescription>
+          </AppCardHeader>
+          <AppCardContent className="space-y-(--space-4)">
+            <div className="flex flex-wrap items-center gap-(--space-3)">
+              <label className="input input-bordered flex min-w-[18rem] flex-1 items-center gap-(--space-2)">
+                <span className="text-xs font-medium uppercase tracking-[0.08em] text-base-content/60">
+                  Search
+                </span>
                 <input
                   type="text"
                   className="grow"
-                  placeholder="Message or metadata"
-                  value={filters.search}
-                  onChange={(event) => setFilter({ search: event.target.value })}
-                  data-testid={TID.logs.search}
+                  placeholder="Member, badge, setting, DDS, lockup..."
+                  value={search}
+                  onChange={(event) => {
+                    setSearch(event.target.value)
+                  }}
                 />
-              </div>
-            </label>
-
-            <label className="form-control w-full">
-              <span className="mb-(--space-1) text-xs font-medium uppercase tracking-wide text-base-content/65">
-                Correlation ID
-              </span>
-              <input
-                type="text"
-                className="input input-bordered input-sm w-full"
-                placeholder="Filter a related incident chain"
-                value={filters.correlationId}
-                onChange={(event) => setFilter({ correlationId: event.target.value })}
-              />
-            </label>
-
-            <label className="form-control w-full">
-              <span className="mb-(--space-1) text-xs font-medium uppercase tracking-wide text-base-content/65">
-                Stream level
-              </span>
-              <select
-                className="select select-bordered select-sm w-full"
-                value={streamLevel}
-                onChange={(event) => setStreamLevel(event.target.value as LogStreamLevel)}
-                data-testid={TID.logs.streamLevel}
-              >
-                {LOG_STREAM_LEVELS.map((level) => (
-                  <option key={level} value={level}>
-                    {level}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <div className="flex flex-wrap items-end gap-(--space-2)">
-              <button
-                type="button"
-                className={cn('btn btn-sm', isPaused ? 'btn-warning' : 'btn-outline')}
-                onClick={() => togglePause()}
-                data-testid={TID.logs.pauseResumeBtn}
-              >
-                {isPaused ? (
-                  <PlayCircle className="h-4 w-4" />
-                ) : (
-                  <PauseCircle className="h-4 w-4" />
-                )}
-                {isPaused ? 'Resume stream' : 'Pause stream'}
-              </button>
-              <button
-                type="button"
-                className="btn btn-sm btn-outline"
-                onClick={() => setFilter({ ...DEFAULT_LOG_FILTERS })}
-                data-testid={TID.logs.clearFiltersBtn}
-              >
-                Clear filters
-              </button>
-              <button
-                type="button"
-                className="btn btn-sm btn-outline"
-                onClick={() => clearLogs()}
-                data-testid={TID.logs.clearLogsBtn}
-              >
-                <Trash2 className="h-4 w-4" />
-                Clear history
-              </button>
-            </div>
-          </div>
-
-          <div className="space-y-(--space-3)">
-            <div className="space-y-(--space-2)">
-              <div className="flex flex-wrap items-center gap-(--space-2)">
-                <p className="text-xs font-medium uppercase tracking-wide text-base-content/65">
-                  Level filters
-                </p>
-                <p className="text-xs text-base-content/55">
-                  Narrow to the severity band you want to investigate.
-                </p>
-              </div>
+              </label>
               <div className="flex flex-wrap gap-(--space-2)">
-                {LOG_STREAM_LEVELS.map((level) => {
-                  const isActive = filters.levels.includes(level)
-
-                  return (
-                    <button
-                      key={level}
-                      type="button"
-                      className="rounded-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-                      aria-pressed={isActive}
-                      onClick={() =>
-                        setFilter({
-                          levels: isActive
-                            ? filters.levels.filter((value) => value !== level)
-                            : [...filters.levels, level],
-                        })
-                      }
-                      data-testid={TID.logs.levelToggle(level)}
+                {AREA_OPTIONS.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => {
+                      setAreaFilter(option.value)
+                    }}
+                  >
+                    <Chip
+                      color={option.color}
+                      variant={areaFilter === option.value ? 'solid' : 'soft'}
                     >
-                      <Chip
-                        color={getLevelChipColor(level)}
-                        variant={isActive ? 'soft' : 'bordered'}
-                        size="sm"
-                        showDot
-                      >
-                        {level}
-                      </Chip>
-                    </button>
-                  )
-                })}
+                      {option.label}
+                    </Chip>
+                  </button>
+                ))}
               </div>
             </div>
 
-            <div className="space-y-(--space-2)">
-              <div className="flex flex-wrap items-center gap-(--space-2)">
-                <p className="text-xs font-medium uppercase tracking-wide text-base-content/65">
-                  Module filters
-                </p>
-                <p className="text-xs text-base-content/55">
-                  Use modules to isolate a subsystem before broad search terms.
-                </p>
-              </div>
-              <div className="flex flex-wrap gap-(--space-2)">
-                {modules.length > 0 ? (
-                  modules.map((moduleName) => {
-                    const isActive = filters.modules.includes(moduleName)
-
-                    return (
-                      <button
-                        key={moduleName}
-                        type="button"
-                        className="rounded-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-                        aria-pressed={isActive}
-                        onClick={() =>
-                          setFilter({
-                            modules: isActive
-                              ? filters.modules.filter((value) => value !== moduleName)
-                              : [...filters.modules, moduleName],
-                          })
-                        }
-                        data-testid={TID.logs.moduleToggle(moduleName)}
-                      >
-                        <Chip variant={isActive ? 'soft' : 'bordered'} size="sm">
-                          {moduleName}
-                        </Chip>
-                      </button>
-                    )
-                  })
-                ) : (
-                  <p className="text-sm text-base-content/55">
-                    Module chips will appear once the stream includes named subsystems.
-                  </p>
-                )}
-              </div>
-            </div>
-          </div>
-        </AppCardContent>
-      </AppCard>
-
-      <div className="grid gap-(--space-4) xl:grid-cols-[minmax(0,2fr)_minmax(22rem,1fr)]">
-        <AppCard className="overflow-hidden">
-          <AppCardHeader>
-            <AppCardTitle>Live entries</AppCardTitle>
-            <AppCardDescription>
-              Select a row to inspect stack traces, correlation IDs, and metadata.
-            </AppCardDescription>
-          </AppCardHeader>
-          <AppCardContent className="min-h-0 p-0">
-            {logs.length > 0 ? (
-              <div className="max-h-[65vh] overflow-auto">
-                <table className="table table-pin-rows table-sm" data-testid={TID.logs.table}>
-                  <thead className="bg-base-200 text-xs uppercase tracking-wide text-base-content/65">
-                    <tr>
+            {isLoading ? (
+              <TableSkeleton rows={10} cols={6} />
+            ) : isError ? (
+              <EmptyState
+                icon={ShieldAlert}
+                title="Unable to load the activity log"
+                description={
+                  error instanceof Error ? error.message : 'The activity log could not be loaded.'
+                }
+              />
+            ) : filteredEntries.length === 0 ? (
+              <EmptyState
+                icon={Activity}
+                title="No matching activity"
+                description="Try broadening the filters or clearing the search text."
+              />
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="table table-sm">
+                  <thead>
+                    <tr className="text-xs uppercase tracking-[0.08em] text-base-content/60">
                       <th>Time</th>
-                      <th>Level</th>
-                      <th>Module</th>
-                      <th>Message</th>
-                      <th>Correlation</th>
+                      <th>Area</th>
+                      <th>Action</th>
+                      <th>Actor</th>
+                      <th>Subject</th>
+                      <th>Summary</th>
                     </tr>
                   </thead>
                   <tbody>
-                    {logs.map((entry) => {
-                      const isSelected = entry.id === selectedLog?.id
-
-                      return (
-                        <tr
-                          key={entry.id}
-                          className={cn(
-                            'cursor-pointer align-top transition-colors',
-                            isSelected
-                              ? 'bg-primary-fadded text-primary-fadded-content'
-                              : 'hover:bg-base-200/70'
-                          )}
-                          onClick={() => setSelectedLogId(entry.id)}
-                          data-testid={TID.logs.row}
-                        >
-                          <td className="font-mono text-xs whitespace-nowrap">
-                            {formatTimestamp(entry.timestamp)}
-                          </td>
-                          <td>
-                            <AppBadge status={getLevelStatus(entry.level)} size="sm">
-                              {entry.level}
-                            </AppBadge>
-                          </td>
-                          <td className="font-mono text-xs text-base-content/70">
-                            {entry.module ?? 'system'}
-                          </td>
-                          <td className="max-w-xl">
-                            <div className="line-clamp-2 text-sm leading-snug">{entry.message}</div>
-                          </td>
-                          <td className="font-mono text-xs text-base-content/70">
-                            {entry.correlationId ? (
-                              <span className="truncate">{entry.correlationId}</span>
-                            ) : (
-                              '—'
-                            )}
-                          </td>
-                        </tr>
-                      )
-                    })}
+                    {filteredEntries.map((entry) => (
+                      <tr
+                        key={entry.id}
+                        className={cn(
+                          'cursor-pointer border-base-300/60 transition-colors',
+                          selectedEntry?.id === entry.id
+                            ? 'bg-info-fadded text-info-fadded-content'
+                            : 'hover:bg-base-200'
+                        )}
+                        onClick={() => {
+                          setSelectedEntryId(entry.id)
+                        }}
+                      >
+                        <td className="font-mono text-xs">{formatTimestamp(entry.timestamp)}</td>
+                        <td>
+                          <Chip color={getAreaColor(entry.area)} variant="soft" size="sm">
+                            {getAreaLabel(entry.area)}
+                          </Chip>
+                        </td>
+                        <td className="font-medium">{entry.actionLabel}</td>
+                        <td>{entry.actorName}</td>
+                        <td>{entry.subjectLabel}</td>
+                        <td className="max-w-[28rem] truncate">{entry.summary}</td>
+                      </tr>
+                    ))}
                   </tbody>
                 </table>
-              </div>
-            ) : (
-              <div className="p-(--space-6)">
-                <EmptyState
-                  icon={Activity}
-                  title="No matching logs"
-                  description="Adjust the filters or wait for the live stream to deliver the next entries."
-                />
               </div>
             )}
           </AppCardContent>
         </AppCard>
 
-        <AppCard className="overflow-hidden">
+        <AppCard status={selectedEntry ? 'info' : 'neutral'}>
           <AppCardHeader>
-            <AppCardTitle>Selected entry</AppCardTitle>
+            <AppCardTitle>Selected activity</AppCardTitle>
             <AppCardDescription>
-              Use this panel for full message context, stack traces, and structured metadata.
+              Structured details for the currently highlighted entry.
             </AppCardDescription>
           </AppCardHeader>
           <AppCardContent className="space-y-(--space-4)">
-            {selectedLog ? (
+            {!selectedEntry ? (
+              <EmptyState
+                icon={Activity}
+                title="Choose an activity row"
+                description="Select an entry from the table to inspect its details."
+              />
+            ) : (
               <>
-                <div className="flex flex-wrap items-center gap-(--space-2)">
-                  <AppBadge status={getLevelStatus(selectedLog.level)}>
-                    {selectedLog.level}
-                  </AppBadge>
-                  <Chip variant="soft" size="sm">
-                    {selectedLog.module ?? 'system'}
-                  </Chip>
-                  {selectedLog.correlationId ? (
-                    <Chip variant="bordered" size="sm">
-                      {selectedLog.correlationId}
+                <div className="space-y-(--space-3)">
+                  <div className="flex flex-wrap items-center gap-(--space-2)">
+                    <Chip color={getAreaColor(selectedEntry.area)} variant="soft">
+                      {getAreaLabel(selectedEntry.area)}
                     </Chip>
-                  ) : null}
-                </div>
-
-                <div className="space-y-(--space-2)">
-                  <div className="rounded-box border border-base-300 bg-base-200 p-(--space-3)">
-                    <p className="text-xs font-semibold uppercase tracking-wide text-base-content/65">
-                      Message
-                    </p>
-                    <p className="mt-(--space-2) text-sm leading-relaxed">{selectedLog.message}</p>
+                    <AppBadge status="info">{selectedEntry.actionLabel}</AppBadge>
                   </div>
-
-                  <dl className="grid gap-(--space-2) sm:grid-cols-2">
-                    <div className="rounded-box border border-base-300 bg-base-100 p-(--space-3)">
-                      <dt className="text-xs font-semibold uppercase tracking-wide text-base-content/65">
-                        Timestamp
-                      </dt>
-                      <dd className="mt-(--space-1) font-mono text-xs">
-                        {formatDateTime(selectedLog.timestamp)}
-                      </dd>
-                    </div>
-                    <div className="rounded-box border border-base-300 bg-base-100 p-(--space-3)">
-                      <dt className="text-xs font-semibold uppercase tracking-wide text-base-content/65">
-                        User ID
-                      </dt>
-                      <dd className="mt-(--space-1) font-mono text-xs">
-                        {selectedLog.userId ?? 'Unavailable'}
-                      </dd>
-                    </div>
-                  </dl>
-                </div>
-
-                <div className="space-y-(--space-2)">
                   <div>
-                    <p className="text-xs font-semibold uppercase tracking-wide text-base-content/65">
-                      Metadata
-                    </p>
-                    <pre className="mt-(--space-2) overflow-auto rounded-box border border-base-300 bg-base-100 p-(--space-3) text-xs leading-relaxed text-base-content/80">
-                      {renderMetadata(selectedLog.metadata)}
-                    </pre>
+                    <p className="text-lg font-semibold">{selectedEntry.subjectLabel}</p>
+                    <p className="text-sm text-base-content/70">{selectedEntry.summary}</p>
                   </div>
+                </div>
 
-                  {selectedLog.stack ? (
-                    <div>
-                      <p className="text-xs font-semibold uppercase tracking-wide text-base-content/65">
-                        Stack trace
-                      </p>
-                      <pre className="mt-(--space-2) overflow-auto rounded-box border border-base-300 bg-base-100 p-(--space-3) text-xs leading-relaxed text-base-content/80">
-                        {selectedLog.stack}
-                      </pre>
-                    </div>
-                  ) : null}
+                <div className="grid gap-(--space-3) text-sm sm:grid-cols-2">
+                  <div className="rounded-none bg-base-200 p-(--space-3)">
+                    <p className="text-xs uppercase tracking-[0.08em] text-base-content/60">
+                      Actor
+                    </p>
+                    <p className="mt-(--space-1) font-medium">{selectedEntry.actorName}</p>
+                  </div>
+                  <div className="rounded-none bg-base-200 p-(--space-3)">
+                    <p className="text-xs uppercase tracking-[0.08em] text-base-content/60">
+                      Logged at
+                    </p>
+                    <p className="mt-(--space-1) font-medium">
+                      {formatDateTime(selectedEntry.timestamp)}
+                    </p>
+                  </div>
+                  <div className="rounded-none bg-base-200 p-(--space-3)">
+                    <p className="text-xs uppercase tracking-[0.08em] text-base-content/60">
+                      Action code
+                    </p>
+                    <p className="mt-(--space-1) font-mono text-xs">{selectedEntry.raw.action}</p>
+                  </div>
+                  <div className="rounded-none bg-base-200 p-(--space-3)">
+                    <p className="text-xs uppercase tracking-[0.08em] text-base-content/60">
+                      Entity type
+                    </p>
+                    <p className="mt-(--space-1) font-mono text-xs">
+                      {selectedEntry.raw.entityType}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="space-y-(--space-2)">
+                  <p className="text-xs uppercase tracking-[0.08em] text-base-content/60">
+                    Structured details
+                  </p>
+                  <pre className="max-h-[32rem] overflow-auto rounded-none bg-base-200 p-(--space-3) text-xs leading-6 text-base-content/80">
+                    {renderDetails(selectedEntry.raw.details)}
+                  </pre>
                 </div>
               </>
-            ) : (
-              <EmptyState
-                icon={Cable}
-                title="Select a log entry"
-                description="Click an entry in the table to inspect its complete details."
-                className="py-(--space-10)"
-              />
             )}
           </AppCardContent>
         </AppCard>

--- a/apps/frontend-admin/src/hooks/use-audit-activity.ts
+++ b/apps/frontend-admin/src/hooks/use-audit-activity.ts
@@ -1,0 +1,525 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import type { AuditLogWithAdminResponse } from '@sentinel/contracts'
+import { apiClient } from '@/lib/api-client'
+
+export type ActivityArea =
+  | 'attendance'
+  | 'members'
+  | 'badges'
+  | 'settings'
+  | 'responsibility'
+  | 'access'
+  | 'admin'
+  | 'other'
+
+export interface ActivityEntry {
+  id: string
+  timestamp: string
+  area: ActivityArea
+  actionLabel: string
+  actorName: string
+  subjectLabel: string
+  summary: string
+  raw: AuditLogWithAdminResponse
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function getString(value: Record<string, unknown> | null, key: string): string | null {
+  if (!value) {
+    return null
+  }
+
+  const rawValue = value[key]
+  return typeof rawValue === 'string' && rawValue.trim().length > 0 ? rawValue.trim() : null
+}
+
+function getNumber(value: Record<string, unknown> | null, key: string): number | null {
+  if (!value) {
+    return null
+  }
+
+  const rawValue = value[key]
+  return typeof rawValue === 'number' && Number.isFinite(rawValue) ? rawValue : null
+}
+
+function getRecord(
+  value: Record<string, unknown> | null,
+  key: string
+): Record<string, unknown> | null {
+  if (!value) {
+    return null
+  }
+
+  const nestedValue = value[key]
+  return isRecord(nestedValue) ? nestedValue : null
+}
+
+function getArrayLength(value: Record<string, unknown> | null, key: string): number | null {
+  if (!value) {
+    return null
+  }
+
+  const nestedValue = value[key]
+  return Array.isArray(nestedValue) ? nestedValue.length : null
+}
+
+function getNestedString(
+  value: Record<string, unknown> | null,
+  key: string,
+  nestedKey: string
+): string | null {
+  return getString(getRecord(value, key), nestedKey)
+}
+
+function formatFieldName(field: string): string {
+  return field
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_.-]+/g, ' ')
+    .toLowerCase()
+}
+
+function getChangedFieldSummary(details: Record<string, unknown> | null): string | null {
+  const requestedChanges = getRecord(details, 'requestedChanges')
+  if (requestedChanges) {
+    const keys = Object.keys(requestedChanges)
+    if (keys.length > 0) {
+      return `Changed ${keys.map(formatFieldName).join(', ')}`
+    }
+  }
+
+  const changes = getRecord(details, 'changes')
+  if (changes) {
+    const keys = Object.keys(changes)
+    if (keys.length > 0) {
+      return `Changed ${keys.map(formatFieldName).join(', ')}`
+    }
+  }
+
+  return null
+}
+
+function formatArea(action: string): ActivityArea {
+  if (action.startsWith('checkin_')) {
+    return 'attendance'
+  }
+
+  if (action.startsWith('member_')) {
+    return 'members'
+  }
+
+  if (action.startsWith('badge_')) {
+    return 'badges'
+  }
+
+  if (
+    action.startsWith('setting_') ||
+    action.startsWith('network_settings_') ||
+    action.startsWith('operational_timings_') ||
+    action.startsWith('remote_system_')
+  ) {
+    return 'settings'
+  }
+
+  if (action.startsWith('dds_') || action.startsWith('lockup_')) {
+    return 'responsibility'
+  }
+
+  if (action === 'login' || action === 'logout' || action === 'login_failed') {
+    return 'access'
+  }
+
+  if (action.startsWith('admin_') || action.startsWith('password_') || action.startsWith('role_')) {
+    return 'admin'
+  }
+
+  return 'other'
+}
+
+function describeActivity(
+  log: AuditLogWithAdminResponse
+): Omit<ActivityEntry, 'id' | 'timestamp' | 'actorName' | 'raw'> {
+  const details = log.details ?? null
+  const action = log.action
+  const area = formatArea(action)
+  const memberName =
+    getString(details, 'memberName') ??
+    getString(details, 'holderName') ??
+    getString(details, 'openerName') ??
+    getString(details, 'executedByName') ??
+    getString(details, 'previousHolderName') ??
+    getString(details, 'toMemberName') ??
+    getString(details, 'subjectMemberId') ??
+    'Unknown'
+  const badgeSerialNumber = getString(details, 'badgeSerialNumber')
+  const settingKey = getString(details, 'settingKey')
+  const remoteSystemName = getString(details, 'remoteSystemName')
+  const direction = getString(details, 'direction')
+  const kioskId = getString(details, 'kioskId')
+  const reason = getString(details, 'reason') ?? getString(details, 'editReason')
+  const previousAssignedMemberName = getNestedString(
+    details,
+    'previousAssignedMember',
+    'assignedMemberName'
+  )
+  const currentAssignedMemberName =
+    getNestedString(details, 'currentAssignedMember', 'assignedMemberName') ??
+    getString(details, 'assignedMemberName')
+
+  switch (action) {
+    case 'login':
+      return {
+        area,
+        actionLabel: 'Logged in',
+        subjectLabel: getString(details, 'actorName') ?? memberName,
+        summary: remoteSystemName
+          ? `Started a session on ${remoteSystemName}`
+          : 'Started a session',
+      }
+    case 'member_create':
+      return {
+        area,
+        actionLabel: 'Created member',
+        subjectLabel: memberName,
+        summary: getString(details, 'serviceNumber')
+          ? `Service number ${getString(details, 'serviceNumber')}`
+          : 'Member record created',
+      }
+    case 'member_update':
+      return {
+        area,
+        actionLabel: 'Updated profile',
+        subjectLabel: memberName,
+        summary: getChangedFieldSummary(details) ?? 'Member profile updated',
+      }
+    case 'member_delete':
+      return {
+        area,
+        actionLabel: 'Archived member',
+        subjectLabel: memberName,
+        summary: 'Member record archived',
+      }
+    case 'member_tag_add':
+      return {
+        area,
+        actionLabel: 'Added tag',
+        subjectLabel: memberName,
+        summary: getString(details, 'tagName') ?? 'Member tag added',
+      }
+    case 'member_tag_remove':
+      return {
+        area,
+        actionLabel: 'Removed tag',
+        subjectLabel: memberName,
+        summary: getString(details, 'tagName') ?? 'Member tag removed',
+      }
+    case 'badge_create':
+      return {
+        area,
+        actionLabel: 'Created badge',
+        subjectLabel: badgeSerialNumber ?? 'Badge',
+        summary: currentAssignedMemberName
+          ? `Assigned to ${currentAssignedMemberName}`
+          : getString(details, 'assignmentType') === 'unassigned'
+            ? 'Created as unassigned'
+            : 'Badge created',
+      }
+    case 'badge_assign':
+      return {
+        area,
+        actionLabel: 'Assigned badge',
+        subjectLabel: badgeSerialNumber ?? 'Badge',
+        summary: currentAssignedMemberName
+          ? `Assigned to ${currentAssignedMemberName}`
+          : 'Badge assignment updated',
+      }
+    case 'badge_unassign':
+      return {
+        area,
+        actionLabel: 'Unassigned badge',
+        subjectLabel: badgeSerialNumber ?? 'Badge',
+        summary: previousAssignedMemberName
+          ? `Removed from ${previousAssignedMemberName}`
+          : 'Badge unassigned',
+      }
+    case 'badge_status_change':
+      return {
+        area,
+        actionLabel: 'Changed badge status',
+        subjectLabel: badgeSerialNumber ?? 'Badge',
+        summary:
+          getString(details, 'previousStatus') && getString(details, 'currentStatus')
+            ? `${getString(details, 'previousStatus')} -> ${getString(details, 'currentStatus')}`
+            : 'Badge status updated',
+      }
+    case 'badge_delete':
+      return {
+        area,
+        actionLabel: 'Deleted badge',
+        subjectLabel: badgeSerialNumber ?? 'Badge',
+        summary: 'Badge removed from inventory',
+      }
+    case 'setting_create':
+      return {
+        area,
+        actionLabel: 'Created setting',
+        subjectLabel: settingKey ?? 'Setting',
+        summary: getString(details, 'category')
+          ? `${getString(details, 'category')} setting created`
+          : 'Setting created',
+      }
+    case 'setting_update':
+      return {
+        area,
+        actionLabel: 'Updated setting',
+        subjectLabel: settingKey ?? 'Setting',
+        summary: 'Setting value updated',
+      }
+    case 'setting_delete':
+      return {
+        area,
+        actionLabel: 'Deleted setting',
+        subjectLabel: settingKey ?? 'Setting',
+        summary: 'Setting removed',
+      }
+    case 'network_settings_update': {
+      const nextSettings = getRecord(details, 'nextSettings')
+      const approvedSsids = nextSettings?.approvedSsids
+      const ssidCount = Array.isArray(approvedSsids) ? approvedSsids.length : null
+
+      return {
+        area,
+        actionLabel: 'Updated network settings',
+        subjectLabel: 'Network settings',
+        summary:
+          typeof ssidCount === 'number'
+            ? `${ssidCount} approved Wi-Fi networks`
+            : 'Network settings updated',
+      }
+    }
+    case 'operational_timings_update': {
+      const nextSettings = getRecord(details, 'nextSettings')
+      const keyCount = nextSettings ? Object.keys(nextSettings).length : 0
+
+      return {
+        area,
+        actionLabel: 'Updated timings',
+        subjectLabel: 'Operational timings',
+        summary: keyCount > 0 ? `${keyCount} timing values saved` : 'Operational timings updated',
+      }
+    }
+    case 'remote_system_create':
+      return {
+        area,
+        actionLabel: 'Created remote system',
+        subjectLabel: remoteSystemName ?? 'Remote system',
+        summary: getString(details, 'remoteSystemCode')
+          ? `Code ${getString(details, 'remoteSystemCode')}`
+          : 'Remote system created',
+      }
+    case 'remote_system_update':
+      return {
+        area,
+        actionLabel: 'Updated remote system',
+        subjectLabel: remoteSystemName ?? 'Remote system',
+        summary: getChangedFieldSummary(details) ?? 'Remote system updated',
+      }
+    case 'remote_system_delete':
+      return {
+        area,
+        actionLabel: 'Deleted remote system',
+        subjectLabel: remoteSystemName ?? 'Remote system',
+        summary: getString(details, 'remoteSystemCode')
+          ? `Removed ${getString(details, 'remoteSystemCode')}`
+          : 'Remote system deleted',
+      }
+    case 'remote_system_reorder': {
+      const orderCount = getArrayLength(details, 'nextOrder')
+
+      return {
+        area,
+        actionLabel: 'Reordered remote systems',
+        subjectLabel: 'Remote systems',
+        summary:
+          typeof orderCount === 'number' && orderCount > 0
+            ? `${orderCount} systems reordered`
+            : 'Remote systems reordered',
+      }
+    }
+    case 'checkin_scan':
+      return {
+        area,
+        actionLabel: direction === 'out' ? 'Scanned out' : 'Scanned in',
+        subjectLabel: memberName,
+        summary: kioskId ? `Badge scan at ${kioskId}` : 'Badge scan recorded',
+      }
+    case 'checkin_login':
+      return {
+        area,
+        actionLabel: 'Login check-in',
+        subjectLabel: memberName,
+        summary: kioskId ? `Auto check-in at ${kioskId}` : 'Auto check-in from login',
+      }
+    case 'checkin_manual_create':
+      return {
+        area,
+        actionLabel: direction === 'out' ? 'Manual check-out' : 'Manual check-in',
+        subjectLabel: memberName,
+        summary: kioskId ? `Recorded at ${kioskId}` : 'Manual attendance entry',
+      }
+    case 'checkin_manual_checkout':
+      return {
+        area,
+        actionLabel: 'Force checkout',
+        subjectLabel: memberName,
+        summary: reason ? `Reason: ${reason}` : 'Manual checkout recorded',
+      }
+    case 'checkin_update':
+      return {
+        area,
+        actionLabel: 'Edited attendance',
+        subjectLabel: memberName,
+        summary: reason
+          ? `Reason: ${reason}`
+          : (getChangedFieldSummary(details) ?? 'Attendance updated'),
+      }
+    case 'checkin_delete':
+      return {
+        area,
+        actionLabel: 'Deleted attendance',
+        subjectLabel: memberName,
+        summary: 'Attendance entry removed',
+      }
+    case 'dds_accept':
+      return {
+        area,
+        actionLabel: 'Accepted DDS',
+        subjectLabel: 'DDS',
+        summary: memberName,
+      }
+    case 'dds_assign':
+      return {
+        area,
+        actionLabel: 'Assigned DDS',
+        subjectLabel: 'DDS',
+        summary: getString(details, 'previousHolderName')
+          ? `${getString(details, 'previousHolderName')} -> ${memberName}`
+          : memberName,
+      }
+    case 'dds_transfer':
+      return {
+        area,
+        actionLabel: 'Transferred DDS',
+        subjectLabel: 'DDS',
+        summary:
+          getString(details, 'fromMemberName') && getString(details, 'toMemberName')
+            ? `${getString(details, 'fromMemberName')} -> ${getString(details, 'toMemberName')}`
+            : 'DDS transferred',
+      }
+    case 'dds_release':
+      return {
+        area,
+        actionLabel: 'Released DDS',
+        subjectLabel: 'DDS',
+        summary: getString(details, 'previousHolderName') ?? 'DDS released',
+      }
+    case 'lockup_acquire':
+      return {
+        area,
+        actionLabel: 'Acquired lockup',
+        subjectLabel: 'Lockup',
+        summary: memberName,
+      }
+    case 'lockup_open':
+      return {
+        area,
+        actionLabel: 'Opened building',
+        subjectLabel: 'Lockup',
+        summary: memberName,
+      }
+    case 'lockup_transfer':
+      return {
+        area,
+        actionLabel: 'Transferred lockup',
+        subjectLabel: 'Lockup',
+        summary:
+          getString(details, 'fromMemberName') && getString(details, 'toMemberName')
+            ? `${getString(details, 'fromMemberName')} -> ${getString(details, 'toMemberName')}`
+            : 'Lockup transferred',
+      }
+    case 'lockup_execute':
+      return {
+        area,
+        actionLabel: 'Executed lockup',
+        subjectLabel: 'Lockup',
+        summary:
+          getNumber(details, 'totalCheckedOut') !== null
+            ? `${getNumber(details, 'totalCheckedOut')} people checked out`
+            : 'Lockup executed',
+      }
+    default:
+      return {
+        area,
+        actionLabel: formatFieldName(action).replace(/\b\w/g, (char) => char.toUpperCase()),
+        subjectLabel: log.entityType,
+        summary: 'Activity recorded',
+      }
+  }
+}
+
+function getActorName(log: AuditLogWithAdminResponse): string {
+  const details = log.details ?? null
+
+  return (
+    log.adminUser?.displayName ??
+    getString(details, 'actorName') ??
+    getString(details, 'editorName') ??
+    'System'
+  )
+}
+
+function normalizeActivity(log: AuditLogWithAdminResponse): ActivityEntry {
+  const description = describeActivity(log)
+
+  return {
+    id: log.id,
+    timestamp: log.createdAt ?? '',
+    actorName: getActorName(log),
+    raw: log,
+    ...description,
+  }
+}
+
+export function useAuditActivityFeed(enabled: boolean, limit: number = 250) {
+  return useQuery({
+    queryKey: ['audit-activity', limit],
+    queryFn: async () => {
+      const response = await apiClient.auditLogs.getAuditLogs({
+        query: {
+          page: '1',
+          limit: String(limit),
+        },
+      })
+
+      if (response.status !== 200) {
+        const message =
+          response.body && typeof response.body === 'object' && 'message' in response.body
+            ? String((response.body as { message?: unknown }).message ?? 'Failed to fetch activity')
+            : 'Failed to fetch activity'
+
+        throw new Error(message)
+      }
+
+      return {
+        entries: response.body.auditLogs.map((log) => normalizeActivity(log)),
+        total: response.body.total,
+      }
+    },
+    enabled,
+    refetchInterval: 15000,
+  })
+}

--- a/apps/frontend-admin/src/lib/kiosk-device-auth.server.ts
+++ b/apps/frontend-admin/src/lib/kiosk-device-auth.server.ts
@@ -1,0 +1,21 @@
+/* global process */
+
+const KIOSK_DEVICE_API_KEY_ENV = 'SENTINEL_KIOSK_DEVICE_API_KEY'
+const KIOSK_DEVICE_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30
+
+export function getConfiguredKioskDeviceApiKey(): string | null {
+  const configured = process.env[KIOSK_DEVICE_API_KEY_ENV]?.trim()
+  if (!configured) {
+    return null
+  }
+
+  return configured.startsWith('sk_') ? configured : null
+}
+
+export function isKioskDeviceAuthConfigured(): boolean {
+  return getConfiguredKioskDeviceApiKey() !== null
+}
+
+export function getKioskDeviceCookieMaxAgeSeconds(): number {
+  return KIOSK_DEVICE_COOKIE_MAX_AGE_SECONDS
+}

--- a/apps/frontend-admin/src/lib/kiosk-device-auth.test.ts
+++ b/apps/frontend-admin/src/lib/kiosk-device-auth.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import {
+  hasKioskDeviceCookie,
+  isKioskDeviceBootstrapRoute,
+  isKioskRoute,
+  resolveKioskBootstrapNext,
+} from './kiosk-device-auth'
+
+describe('kiosk device auth helpers', () => {
+  it('detects kiosk routes and bootstrap route consistently', () => {
+    expect(isKioskRoute('/kiosk')).toBe(true)
+    expect(isKioskRoute('/kiosk/front-entrance')).toBe(true)
+    expect(isKioskRoute('/dashboard')).toBe(false)
+
+    expect(isKioskDeviceBootstrapRoute('/kiosk/device-auth')).toBe(true)
+    expect(isKioskDeviceBootstrapRoute('/kiosk')).toBe(false)
+  })
+
+  it('treats only non-empty cookie values as device auth cookies', () => {
+    expect(hasKioskDeviceCookie('sk_kiosk_cookie')).toBe(true)
+    expect(hasKioskDeviceCookie('   ')).toBe(false)
+    expect(hasKioskDeviceCookie(null)).toBe(false)
+  })
+
+  it('sanitizes kiosk bootstrap redirects to kiosk-only internal paths', () => {
+    expect(resolveKioskBootstrapNext('/kiosk')).toBe('/kiosk')
+    expect(resolveKioskBootstrapNext('/kiosk?mode=front')).toBe('/kiosk?mode=front')
+    expect(resolveKioskBootstrapNext('/kiosk/front-entrance')).toBe('/kiosk/front-entrance')
+
+    expect(resolveKioskBootstrapNext('/dashboard')).toBe('/kiosk')
+    expect(resolveKioskBootstrapNext('https://example.com/kiosk')).toBe('/kiosk')
+    expect(resolveKioskBootstrapNext('//example.com/kiosk')).toBe('/kiosk')
+    expect(resolveKioskBootstrapNext(undefined)).toBe('/kiosk')
+  })
+})

--- a/apps/frontend-admin/src/lib/kiosk-device-auth.ts
+++ b/apps/frontend-admin/src/lib/kiosk-device-auth.ts
@@ -1,0 +1,37 @@
+export const KIOSK_DEVICE_COOKIE_NAME = 'sentinel-kiosk-device'
+export const KIOSK_DEVICE_BOOTSTRAP_PATH = '/kiosk/device-auth'
+
+export function hasKioskDeviceCookie(value: string | null | undefined): boolean {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+export function isKioskRoute(pathname: string | null | undefined): boolean {
+  return pathname === '/kiosk' || pathname?.startsWith('/kiosk/') === true
+}
+
+export function isKioskDeviceBootstrapRoute(pathname: string | null | undefined): boolean {
+  return pathname === KIOSK_DEVICE_BOOTSTRAP_PATH
+}
+
+export function resolveKioskBootstrapNext(
+  value: string | null | undefined
+): '/kiosk' | `/kiosk${string}` {
+  if (!value) {
+    return '/kiosk'
+  }
+
+  const candidate = value.trim()
+  if (!candidate.startsWith('/') || candidate.startsWith('//')) {
+    return '/kiosk'
+  }
+
+  if (
+    candidate === '/kiosk' ||
+    candidate.startsWith('/kiosk/') ||
+    candidate.startsWith('/kiosk?')
+  ) {
+    return candidate as '/kiosk' | `/kiosk${string}`
+  }
+
+  return '/kiosk'
+}

--- a/apps/frontend-admin/src/lib/test-ids.ts
+++ b/apps/frontend-admin/src/lib/test-ids.ts
@@ -129,6 +129,7 @@ export const TID = {
     },
     manualModal: {
       dialog: 'manual-checkin-dialog',
+      timestamp: 'manual-checkin-timestamp',
       memberSearch: 'manual-checkin-member-search',
       clearMember: 'manual-checkin-clear-member',
       memberOption: (id: string) => `manual-checkin-member-${id}`,

--- a/apps/frontend-admin/src/proxy.ts
+++ b/apps/frontend-admin/src/proxy.ts
@@ -2,13 +2,40 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { buildLoginUrl } from '@/lib/post-login-destination'
+import {
+  KIOSK_DEVICE_BOOTSTRAP_PATH,
+  KIOSK_DEVICE_COOKIE_NAME,
+  hasKioskDeviceCookie,
+  isKioskDeviceBootstrapRoute,
+  isKioskRoute,
+} from '@/lib/kiosk-device-auth'
+import { isKioskDeviceAuthConfigured } from '@/lib/kiosk-device-auth.server'
 
 export function proxy(request: NextRequest) {
+  const pathname = request.nextUrl.pathname
+  if (isKioskDeviceBootstrapRoute(pathname)) {
+    return NextResponse.next()
+  }
+
   const sessionCookie = request.cookies.get('sentinel-session')
+  const kioskDeviceCookie = request.cookies.get(KIOSK_DEVICE_COOKIE_NAME)
+
+  if (isKioskRoute(pathname)) {
+    if (sessionCookie?.value || hasKioskDeviceCookie(kioskDeviceCookie?.value)) {
+      return NextResponse.next()
+    }
+
+    if (isKioskDeviceAuthConfigured()) {
+      const bootstrapUrl = new URL(KIOSK_DEVICE_BOOTSTRAP_PATH, request.url)
+      const nextPath = `${pathname}${request.nextUrl.search}`
+      bootstrapUrl.searchParams.set('next', nextPath)
+      return NextResponse.redirect(bootstrapUrl)
+    }
+  }
 
   if (!sessionCookie?.value) {
-    const loginUrl = new URL(buildLoginUrl(request.nextUrl.pathname), request.url)
-    loginUrl.searchParams.set('redirect', request.nextUrl.pathname)
+    const loginUrl = new URL(buildLoginUrl(pathname), request.url)
+    loginUrl.searchParams.set('redirect', pathname)
     return NextResponse.redirect(loginUrl)
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/contracts/src/contracts/audit.contract.ts
+++ b/packages/contracts/src/contracts/audit.contract.ts
@@ -28,11 +28,47 @@ export const auditContract = c.router({
       200: AuditLogListResponseSchema,
       400: ErrorResponseSchema,
       401: ErrorResponseSchema,
+      403: ErrorResponseSchema,
       500: ErrorResponseSchema,
     },
     summary: 'List all audit logs',
     description:
       'Get paginated list of audit logs with optional filtering by admin user, entity type, and date range',
+  },
+
+  /**
+   * Get audit logs for a specific entity
+   */
+  getEntityAuditLogs: {
+    method: 'GET',
+    path: '/api/audit-logs/entity/:entityType/:entityId',
+    pathParams: c.type<{ entityType: string; entityId: string }>(),
+    query: AuditLogListQuerySchema,
+    responses: {
+      200: AuditLogListResponseSchema,
+      400: ErrorResponseSchema,
+      401: ErrorResponseSchema,
+      403: ErrorResponseSchema,
+      500: ErrorResponseSchema,
+    },
+    summary: 'Get entity audit logs',
+    description: 'Get all audit logs for a specific entity',
+  },
+
+  /**
+   * Get audit log statistics
+   */
+  getAuditStats: {
+    method: 'GET',
+    path: '/api/audit-logs/stats',
+    responses: {
+      200: AuditLogStatsResponseSchema,
+      401: ErrorResponseSchema,
+      403: ErrorResponseSchema,
+      500: ErrorResponseSchema,
+    },
+    summary: 'Get audit log statistics',
+    description: 'Get audit log statistics (by action, entity type, admin user)',
   },
 
   /**
@@ -46,6 +82,7 @@ export const auditContract = c.router({
       200: AuditLogWithAdminResponseSchema,
       400: ErrorResponseSchema,
       401: ErrorResponseSchema,
+      403: ErrorResponseSchema,
       404: ErrorResponseSchema,
       500: ErrorResponseSchema,
     },
@@ -64,42 +101,10 @@ export const auditContract = c.router({
       201: AuditLogWithAdminResponseSchema,
       400: ErrorResponseSchema,
       401: ErrorResponseSchema,
+      403: ErrorResponseSchema,
       500: ErrorResponseSchema,
     },
     summary: 'Create audit log',
     description: 'Create a new audit log entry (usually done automatically by middleware)',
-  },
-
-  /**
-   * Get audit logs for a specific entity
-   */
-  getEntityAuditLogs: {
-    method: 'GET',
-    path: '/api/audit-logs/entity/:entityType/:entityId',
-    pathParams: c.type<{ entityType: string; entityId: string }>(),
-    query: AuditLogListQuerySchema,
-    responses: {
-      200: AuditLogListResponseSchema,
-      400: ErrorResponseSchema,
-      401: ErrorResponseSchema,
-      500: ErrorResponseSchema,
-    },
-    summary: 'Get entity audit logs',
-    description: 'Get all audit logs for a specific entity',
-  },
-
-  /**
-   * Get audit log statistics
-   */
-  getAuditStats: {
-    method: 'GET',
-    path: '/api/audit-logs/stats',
-    responses: {
-      200: AuditLogStatsResponseSchema,
-      401: ErrorResponseSchema,
-      500: ErrorResponseSchema,
-    },
-    summary: 'Get audit log statistics',
-    description: 'Get audit log statistics (by action, entity type, admin user)',
   },
 })

--- a/packages/contracts/src/schemas/audit.schema.ts
+++ b/packages/contracts/src/schemas/audit.schema.ts
@@ -83,7 +83,7 @@ export const AuditLogWithAdminResponseSchema = v.object({
 export const AuditLogListQuerySchema = v.object({
   page: v.optional(v.pipe(v.string(), v.transform(Number), v.number(), v.minValue(1))),
   limit: v.optional(
-    v.pipe(v.string(), v.transform(Number), v.number(), v.minValue(1), v.maxValue(100))
+    v.pipe(v.string(), v.transform(Number), v.number(), v.minValue(1), v.maxValue(250))
   ),
   adminUserId: v.optional(v.pipe(v.string(), v.uuid())),
   entityType: v.optional(v.string()),

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## What changed
- add admin audit activity APIs and frontend log viewing support
- add kiosk device API key authentication across backend, proxy, and frontend bootstrap flow
- fix manual in/out so selected members remain valid and admins can set manual presence timestamps

## Why
- improve release readiness for admin observability, kiosk deployment, and manual attendance correction workflows
- bundle the v2.6.1 fixes and features already prepared on this branch into a single release candidate

## User impact
- admins can inspect audit activity from the logs UI
- kiosk/device flows can authenticate with device API keys
- manual attendance now supports explicit check-in/check-out times

## Validation
- `pnpm version:check`
- `pnpm --filter @sentinel/backend typecheck`
- `pnpm --filter frontend-admin typecheck`
- `pnpm --filter frontend-admin exec vitest run src/components/checkins/manual-checkin-modal.logic.test.ts src/lib/kiosk-device-auth.test.ts`
