### PR TITLE
[codex] Prepare v2.6.3 release

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/app/dashboard/page.tsx
+++ b/apps/frontend-admin/src/app/dashboard/page.tsx
@@ -3,6 +3,7 @@ import { StatusStats } from '@/components/dashboard/status-stats'
 import { PersonCardGrid } from '@/components/dashboard/person-card-grid'
 import { DashboardDdsChecklistDrawer } from '@/components/dashboard/dashboard-dds-checklist-drawer'
 import { DashboardHelpLauncher } from '@/components/help/dashboard-help-launcher'
+import { AppBadge } from '@/components/ui/AppBadge'
 
 export default function DashboardPage() {
   return (
@@ -14,6 +15,18 @@ export default function DashboardPage() {
         <h1 className="sr-only">Dashboard</h1>
 
         <SecurityAlertsBar />
+
+        <section
+          aria-label="Dashboard update verification marker"
+          className="alert border border-info/25 bg-info-fadded text-info-fadded-content shadow-[var(--shadow-1)]"
+        >
+          <AppBadge status="info" size="sm">
+            Update test
+          </AppBadge>
+          <span className="text-sm font-medium">
+            Dashboard verification marker: April 22 update build
+          </span>
+        </section>
 
         <section>
           <StatusStats />

--- a/deploy/_common.sh
+++ b/deploy/_common.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 DEPLOY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENV_FILE="${DEPLOY_DIR}/.env"
+CANONICAL_ENV_FILE="/etc/sentinel/appliance.env"
 STATE_FILE="${DEPLOY_DIR}/.appliance-state"
 BASE_COMPOSE_FILE="${DEPLOY_DIR}/docker-compose.yml"
 GRAFANA_OVERRIDE_FILE="${DEPLOY_DIR}/docker-compose.grafana-lan.yml"
@@ -158,6 +159,35 @@ require_explicit_version() {
 }
 
 ensure_env_file() {
+  local resolved_env_file canonical_dir env_dir
+  canonical_dir="$(dirname "${CANONICAL_ENV_FILE}")"
+  env_dir="$(dirname "${ENV_FILE}")"
+
+  if [[ -f "${CANONICAL_ENV_FILE}" ]]; then
+    if [[ -f "${ENV_FILE}" && ! -L "${ENV_FILE}" ]]; then
+      if ! cmp -s "${ENV_FILE}" "${CANONICAL_ENV_FILE}" 2>/dev/null; then
+        if [[ -w "${CANONICAL_ENV_FILE}" ]] || [[ -w "${canonical_dir}" ]]; then
+          cp "${ENV_FILE}" "${CANONICAL_ENV_FILE}"
+          chmod 600 "${CANONICAL_ENV_FILE}"
+        else
+          run_root cp "${ENV_FILE}" "${CANONICAL_ENV_FILE}"
+          run_root chmod 600 "${CANONICAL_ENV_FILE}"
+        fi
+      fi
+      if [[ -w "${env_dir}" ]]; then
+        ln -sfn "${CANONICAL_ENV_FILE}" "${ENV_FILE}"
+      else
+        run_root ln -sfn "${CANONICAL_ENV_FILE}" "${ENV_FILE}"
+      fi
+    elif [[ ! -e "${ENV_FILE}" && ! -L "${ENV_FILE}" ]]; then
+      if [[ -w "${env_dir}" ]]; then
+        ln -sfn "${CANONICAL_ENV_FILE}" "${ENV_FILE}"
+      else
+        run_root ln -sfn "${CANONICAL_ENV_FILE}" "${ENV_FILE}"
+      fi
+    fi
+  fi
+
   if [[ ! -f "${ENV_FILE}" ]]; then
     [[ -f "${DEPLOY_DIR}/.env.example" ]] || die "Missing .env.example"
 
@@ -169,15 +199,17 @@ ensure_env_file() {
     fi
   fi
 
+  resolved_env_file="$(resolve_managed_file_path "${ENV_FILE}")"
+
   if [[ "${EUID}" -ne 0 ]]; then
-    if [[ ! -w "${ENV_FILE}" ]]; then
-      run_root chown "${USER}:$(id -gn "${USER}")" "${ENV_FILE}"
-      chmod 600 "${ENV_FILE}"
+    if [[ ! -w "${resolved_env_file}" ]]; then
+      run_root chown "${USER}:$(id -gn "${USER}")" "${resolved_env_file}"
+      chmod 600 "${resolved_env_file}"
     fi
   elif [[ -n "${SUDO_USER:-}" ]]; then
-    if [[ ! -w "${ENV_FILE}" ]]; then
-      run_root chown "${SUDO_USER}:$(id -gn "${SUDO_USER}")" "${ENV_FILE}"
-      chmod 600 "${ENV_FILE}"
+    if [[ ! -w "${resolved_env_file}" ]]; then
+      run_root chown "${SUDO_USER}:$(id -gn "${SUDO_USER}")" "${resolved_env_file}"
+      chmod 600 "${resolved_env_file}"
     fi
   fi
 }
@@ -349,19 +381,33 @@ SNAPSHOT
 
 upsert_env() {
   local key="${1}" value="${2}" file="${3:-$ENV_FILE}"
-  if grep -qE "^${key}=" "${file}"; then
-    if [[ -w "${file}" && -w "$(dirname "${file}")" ]]; then
-      sed -i "s#^${key}=.*#${key}=${value}#" "${file}"
+  local resolved_file
+  resolved_file="$(resolve_managed_file_path "${file}")"
+
+  if grep -qE "^${key}=" "${resolved_file}"; then
+    if [[ -w "${resolved_file}" && -w "$(dirname "${resolved_file}")" ]]; then
+      sed -i "s#^${key}=.*#${key}=${value}#" "${resolved_file}"
     else
-      run_root sed -i "s#^${key}=.*#${key}=${value}#" "${file}"
+      run_root sed -i "s#^${key}=.*#${key}=${value}#" "${resolved_file}"
     fi
   else
-    if [[ -w "${file}" ]]; then
-      printf '%s=%s\n' "${key}" "${value}" >>"${file}"
+    if [[ -w "${resolved_file}" ]]; then
+      printf '%s=%s\n' "${key}" "${value}" >>"${resolved_file}"
     else
-      printf '%s=%s\n' "${key}" "${value}" | run_root tee -a "${file}" >/dev/null
+      printf '%s=%s\n' "${key}" "${value}" | run_root tee -a "${resolved_file}" >/dev/null
     fi
   fi
+}
+
+resolve_managed_file_path() {
+  local path="${1:-}"
+
+  if [[ -L "${path}" || -e "${path}" ]]; then
+    readlink -f "${path}" 2>/dev/null || printf '%s\n' "${path}"
+    return 0
+  fi
+
+  printf '%s\n' "${path}"
 }
 
 load_state() {

--- a/deploy/upgrade-launcher.sh
+++ b/deploy/upgrade-launcher.sh
@@ -56,7 +56,12 @@ log() {
 }
 
 setup_logging() {
-  mkdir -p "${LOG_DIR}"
+  if ! mkdir -p "${LOG_DIR}" 2>/dev/null || [[ ! -w "${LOG_DIR}" ]]; then
+    local fallback_root
+    fallback_root="${XDG_STATE_HOME:-${HOME:-/tmp}/.local/state}"
+    LOG_DIR="${fallback_root}/sentinel"
+    mkdir -p "${LOG_DIR}"
+  fi
   LOG_FILE="${LOG_DIR}/upgrade-$(date +%Y%m%d-%H%M%S).log"
   exec > >(tee -a "${LOG_FILE}") 2>&1
   log "Log file: ${LOG_FILE}"
@@ -207,16 +212,16 @@ extract_release_brief() {
   RELEASE_HIGHLIGHTS=""
 
   if command_exists python3; then
-    mapfile -t parsed < <(printf '%s' "${json}" | python3 - <<'PY'
+    mapfile -t parsed < <(python3 -c '
 import json
 import sys
 
 d = json.load(sys.stdin)
-name = d.get('name') or ''
-tag = d.get('tag_name') or ''
-published = d.get('published_at') or ''
-url = d.get('html_url') or ''
-body = d.get('body') or ''
+name = d.get("name") or ""
+tag = d.get("tag_name") or ""
+published = d.get("published_at") or ""
+url = d.get("html_url") or ""
+body = d.get("body") or ""
 
 print(name)
 print(tag)
@@ -228,13 +233,12 @@ for raw in body.splitlines():
     line = raw.strip()
     if not line:
         continue
-    if line.startswith(('- ', '* ', '##', '###')):
+    if line.startswith(("- ", "* ", "##", "###")):
         print(line)
         count += 1
         if count >= 5:
             break
-PY
-)
+' <<<"${json}")
 
     RELEASE_TITLE="${parsed[0]:-}"
     local parsed_tag="${parsed[1]:-}"
@@ -714,7 +718,7 @@ curl -fL --retry 3 --retry-delay 1 -o "${CHECKSUM_FILE}" "${CHECKSUM_URL}"
 
 EXPECTED_HASH="$(awk -v file="$(basename "${DEB_FILE}")" '
   {
-    gsub("*", "", $2)
+    gsub(/\*/, "", $2)
     if ($2 == file) {
       print $1
       exit

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

This release prepares `v2.6.3` with three focused changes:

- fixes `upgrade-launcher.sh` so it can fall back to a user-writable log location, parse release metadata correctly, and verify checksum assets without the broken `awk` pattern
- fixes deploy env management so `/opt/sentinel/deploy/.env` stays linked to `/etc/sentinel/appliance.env` instead of drifting into a standalone file during updates
- adds a small dashboard verification banner so the updated frontend build is easy to confirm after a self-update

## Why

`v2.6.2` exposed two real deployment issues during live validation:

- `upgrade-launcher.sh` could fail before package install because of log directory permissions, empty stdin in the Python release-brief parser, and invalid checksum parsing
- successful deploy updates could leave `/etc/sentinel/appliance.env` behind at the previous version because `sed -i` replaced the `.env` symlink with a regular file

This release fixes both deployment regressions and adds an obvious UI marker for the next updater smoke test.

## User impact

- release-driven upgrades should complete without the `tee`, JSON decode, or checksum parsing failures seen on `v2.6.2`
- deployed appliances should keep a single canonical env file in `/etc/sentinel/appliance.env`
- operators will see a compact `Update test` marker on the dashboard after the frontend update lands

## Validation

- `pnpm version:check`
- `bash -n deploy/_common.sh deploy/upgrade-launcher.sh deploy/update.sh deploy/install.sh deploy/rollback.sh`
- `pnpm --filter frontend-admin typecheck`
- `./deploy/deb/build-deb.sh --version v2.6.3`

## Notes

- this PR also bumps all workspace package versions from `2.6.2` to `2.6.3`
- the dashboard marker is intentionally small and non-disruptive so it can be used as a visible post-update check
