### PR TITLE
[codex] Prepare v2.6.4 release

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/routes/system-update.test.ts
+++ b/apps/backend/src/routes/system-update.test.ts
@@ -98,6 +98,7 @@ async function createBridgeServer(
 describe('systemUpdateRouter', () => {
   const originalAppVersion = process.env.APP_VERSION
   const originalStateRoot = process.env.SYSTEM_UPDATE_STATE_ROOT
+  const originalApplianceStatePath = process.env.SENTINEL_APPLIANCE_STATE
   const originalSocketPath = process.env.SYSTEM_UPDATE_BRIDGE_SOCKET_PATH
   const originalReleaseRepository = process.env.SYSTEM_UPDATE_RELEASE_REPOSITORY
 
@@ -112,6 +113,12 @@ describe('systemUpdateRouter', () => {
       delete process.env.SYSTEM_UPDATE_STATE_ROOT
     } else {
       process.env.SYSTEM_UPDATE_STATE_ROOT = originalStateRoot
+    }
+
+    if (originalApplianceStatePath === undefined) {
+      delete process.env.SENTINEL_APPLIANCE_STATE
+    } else {
+      process.env.SENTINEL_APPLIANCE_STATE = originalApplianceStatePath
     }
 
     if (originalSocketPath === undefined) {
@@ -168,6 +175,7 @@ describe('systemUpdateRouter', () => {
 
     process.env.APP_VERSION = 'v2.6.1'
     process.env.SYSTEM_UPDATE_STATE_ROOT = stateRoot
+    process.env.SENTINEL_APPLIANCE_STATE = join(stateRoot, 'missing-appliance-state.json')
     process.env.SYSTEM_UPDATE_BRIDGE_SOCKET_PATH = socketPath
     process.env.SYSTEM_UPDATE_RELEASE_REPOSITORY = ''
 
@@ -220,6 +228,7 @@ describe('systemUpdateRouter', () => {
 
     process.env.APP_VERSION = 'v2.6.1'
     process.env.SYSTEM_UPDATE_STATE_ROOT = stateRoot
+    process.env.SENTINEL_APPLIANCE_STATE = join(stateRoot, 'missing-appliance-state.json')
     process.env.SYSTEM_UPDATE_RELEASE_REPOSITORY = ''
 
     try {
@@ -237,11 +246,93 @@ describe('systemUpdateRouter', () => {
     }
   })
 
+  it('reports the appliance state version after a completed update even if the backend process is older', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'sentinel-system-update-state-'))
+    const applianceStatePath = join(stateRoot, 'appliance-state.json')
+    await mkdir(join(stateRoot, 'jobs'), { recursive: true })
+    await writeJson(
+      join(stateRoot, 'current-job.json'),
+      createJob({
+        status: 'completed',
+        currentVersion: 'v2.6.3',
+        latestVersion: 'v2.6.3',
+        targetVersion: 'v2.6.3',
+        finishedAt: '2026-04-22T12:10:00.000Z',
+        message: 'Sentinel updated successfully to v2.6.3.',
+      })
+    )
+    await writeJson(applianceStatePath, {
+      schemaVersion: 1,
+      withObs: false,
+      allowGrafanaLan: false,
+      allowWikiLan: false,
+      lanCidr: '192.168.0.0/16',
+      currentVersion: 'v2.6.3',
+      previousVersion: 'v2.6.2',
+    })
+
+    process.env.APP_VERSION = 'v2.6.2'
+    process.env.SYSTEM_UPDATE_STATE_ROOT = stateRoot
+    process.env.SENTINEL_APPLIANCE_STATE = applianceStatePath
+    process.env.SYSTEM_UPDATE_RELEASE_REPOSITORY = ''
+
+    try {
+      const app = createTestApp(5)
+      const response = await request(app).get('/api/admin/system/update')
+
+      expect(response.status).toBe(200)
+      expect(response.body).toMatchObject({
+        currentVersion: 'v2.6.3',
+        currentJob: {
+          status: 'completed',
+          currentVersion: 'v2.6.3',
+        },
+      })
+    } finally {
+      await rm(stateRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects starting the same target again when appliance state is already on that version', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'sentinel-system-update-state-'))
+    const applianceStatePath = join(stateRoot, 'appliance-state.json')
+    await writeJson(applianceStatePath, {
+      schemaVersion: 1,
+      withObs: false,
+      allowGrafanaLan: false,
+      allowWikiLan: false,
+      lanCidr: '192.168.0.0/16',
+      currentVersion: 'v2.6.3',
+      previousVersion: 'v2.6.2',
+    })
+
+    process.env.APP_VERSION = 'v2.6.2'
+    process.env.SYSTEM_UPDATE_STATE_ROOT = stateRoot
+    process.env.SENTINEL_APPLIANCE_STATE = applianceStatePath
+    process.env.SYSTEM_UPDATE_RELEASE_REPOSITORY = ''
+
+    try {
+      const app = createTestApp(5)
+      const response = await request(app)
+        .post('/api/admin/system/update')
+        .send({ targetVersion: 'v2.6.3' })
+
+      expect(response.status).toBe(409)
+      expect(response.body).toMatchObject({
+        error: 'CONFLICT',
+        message: 'Target version v2.6.3 is not newer than the current version v2.6.3',
+      })
+    } finally {
+      await rm(stateRoot, { recursive: true, force: true })
+    }
+  })
+
   it('surfaces bridge/socket failures as internal errors', async () => {
     const stateRoot = await mkdtemp(join(tmpdir(), 'sentinel-system-update-state-'))
 
     process.env.APP_VERSION = 'v2.6.1'
     process.env.SYSTEM_UPDATE_STATE_ROOT = stateRoot
+    process.env.SENTINEL_APPLIANCE_STATE = join(stateRoot, 'missing-appliance-state.json')
     process.env.SYSTEM_UPDATE_BRIDGE_SOCKET_PATH = join(stateRoot, 'missing.sock')
     process.env.SYSTEM_UPDATE_RELEASE_REPOSITORY = ''
 

--- a/apps/backend/src/services/system-update-status-service.ts
+++ b/apps/backend/src/services/system-update-status-service.ts
@@ -7,9 +7,10 @@ import {
   isStableVersionTag,
   resolveServiceVersionTag,
 } from '../lib/service-version.js'
-import { sanitizeSystemUpdateJob } from '../lib/system-update-state.js'
+import { isSystemUpdateJobTerminal, sanitizeSystemUpdateJob } from '../lib/system-update-state.js'
 
 const DEFAULT_STATE_ROOT = '/var/lib/sentinel/updater'
+const DEFAULT_APPLIANCE_STATE_PATH = '/var/lib/sentinel/appliance/state.json'
 const DEFAULT_RELEASE_API_BASE = 'https://api.github.com/repos'
 
 interface LatestReleaseSummary {
@@ -23,16 +24,22 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 export class SystemUpdateStatusService {
   private readonly stateRoot: string
+  private readonly applianceStatePath: string
   private readonly releaseRepository: string
   private readonly releaseApiBase: string
 
   constructor(options?: {
     stateRoot?: string
+    applianceStatePath?: string
     releaseRepository?: string
     releaseApiBase?: string
   }) {
     this.stateRoot =
       options?.stateRoot ?? process.env.SYSTEM_UPDATE_STATE_ROOT ?? DEFAULT_STATE_ROOT
+    this.applianceStatePath =
+      options?.applianceStatePath ??
+      process.env.SENTINEL_APPLIANCE_STATE ??
+      DEFAULT_APPLIANCE_STATE_PATH
     this.releaseRepository =
       options?.releaseRepository ??
       process.env.SYSTEM_UPDATE_RELEASE_REPOSITORY ??
@@ -46,7 +53,15 @@ export class SystemUpdateStatusService {
   async getStatus(): Promise<SystemUpdateStatusResponse> {
     const currentJob = await this.readCurrentJob()
     const releaseSummary = await this.fetchLatestReleaseSummary()
-    const currentVersion = resolveServiceVersionTag() ?? currentJob?.currentVersion ?? null
+    const applianceStateVersion = await this.readApplianceCurrentVersion()
+    const completedJobVersion =
+      currentJob && isSystemUpdateJobTerminal(currentJob.status) ? currentJob.currentVersion : null
+    const currentVersion =
+      applianceStateVersion ??
+      completedJobVersion ??
+      resolveServiceVersionTag() ??
+      currentJob?.currentVersion ??
+      null
     const latestVersion = releaseSummary.latestVersion ?? currentJob?.latestVersion ?? null
 
     return {
@@ -153,6 +168,41 @@ export class SystemUpdateStatusService {
         latestVersion: null,
         latestReleaseUrl: null,
       }
+    }
+  }
+
+  private async readApplianceCurrentVersion(): Promise<string | null> {
+    let rawText: string
+
+    try {
+      rawText = await readFile(this.applianceStatePath, 'utf-8')
+    } catch (error) {
+      if (isMissingFileError(error)) {
+        return null
+      }
+
+      serviceLogger.warn('Unable to read Sentinel appliance state', {
+        path: this.applianceStatePath,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      })
+      return null
+    }
+
+    try {
+      const payload: unknown = JSON.parse(rawText)
+      if (!isRecord(payload)) {
+        return null
+      }
+
+      const currentVersion =
+        typeof payload.currentVersion === 'string' ? payload.currentVersion.trim() : ''
+      return isStableVersionTag(currentVersion) ? currentVersion : null
+    } catch (error) {
+      serviceLogger.warn('Unable to parse Sentinel appliance state', {
+        path: this.applianceStatePath,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      })
+      return null
     }
   }
 }

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/components/settings/system-update-panel.tsx
+++ b/apps/frontend-admin/src/components/settings/system-update-panel.tsx
@@ -12,6 +12,7 @@ import {
   AppCardTitle,
 } from '@/components/ui/AppCard'
 import { AppAlert } from '@/components/ui/AppAlert'
+import { AppBadge } from '@/components/ui/AppBadge'
 import {
   Dialog,
   DialogContent,
@@ -74,6 +75,34 @@ function formatTimestamp(value: string | null): string {
   return timestamp.toLocaleString()
 }
 
+function getPrimaryStepDescription(
+  step: SystemUpdateJobStatus,
+  currentJob: SystemUpdateJob | null
+): string {
+  if (!currentJob) {
+    return step === 'completed' ? 'Sentinel returns to steady state after verification.' : 'Pending'
+  }
+
+  const currentIndex = PRIMARY_FLOW.indexOf(currentJob.status)
+  const stepIndex = PRIMARY_FLOW.indexOf(step)
+  const isActive = currentJob.status === step
+  const isCompleted = currentIndex >= 0 && stepIndex <= currentIndex
+
+  if (isActive) {
+    return currentJob.message
+  }
+
+  if (isCompleted) {
+    if (step === 'completed' && currentJob.status === 'completed') {
+      return currentJob.message
+    }
+
+    return 'Completed'
+  }
+
+  return step === 'completed' ? 'Sentinel returns to steady state after verification.' : 'Pending'
+}
+
 function getCardStatus(job: SystemUpdateJob | null, updateAvailable: boolean) {
   if (job && isFailureStatus(job.status)) {
     return 'warning' as const
@@ -84,7 +113,7 @@ function getCardStatus(job: SystemUpdateJob | null, updateAvailable: boolean) {
   }
 
   if (updateAvailable) {
-    return 'warning' as const
+    return 'info' as const
   }
 
   return 'success' as const
@@ -132,6 +161,68 @@ function getSummaryHeading(job: SystemUpdateJob | null, updateAvailable: boolean
   }
 
   return 'Sentinel is up to date'
+}
+
+function getTerminalJobBadgeStatus(status: SystemUpdateJobStatus) {
+  switch (status) {
+    case 'completed':
+      return 'success'
+    case 'failed':
+      return 'error'
+    case 'rollback_attempted':
+    case 'rolled_back':
+      return 'warning'
+    default:
+      return 'info'
+  }
+}
+
+function getUpdateStateBadge(job: SystemUpdateJob | null, updateAvailable: boolean) {
+  if (job) {
+    if (job.status === 'completed') {
+      return { status: 'success' as const, label: 'Completed' }
+    }
+
+    if (job.status === 'failed') {
+      return { status: 'error' as const, label: 'Failed' }
+    }
+
+    if (job.status === 'rollback_attempted' || job.status === 'rolled_back') {
+      return { status: 'warning' as const, label: formatStepLabel(job.status) }
+    }
+
+    return { status: 'info' as const, label: formatStepLabel(job.status) }
+  }
+
+  if (updateAvailable) {
+    return { status: 'info' as const, label: 'Update available' }
+  }
+
+  return { status: 'success' as const, label: 'Current' }
+}
+
+function getNextActionGuidance(job: SystemUpdateJob | null, updateAvailable: boolean) {
+  if (job && !isTerminalStatus(job.status)) {
+    return 'The appliance updater is running on the host and will keep going if this page reconnects.'
+  }
+
+  if (job?.status === 'completed') {
+    return 'No action is needed until a newer stable release is published.'
+  }
+
+  if (job?.status === 'rolled_back' || job?.status === 'rollback_attempted') {
+    return 'Review the rollback result before starting another update.'
+  }
+
+  if (job?.status === 'failed') {
+    return 'Review the last failure summary before retrying the update.'
+  }
+
+  if (updateAvailable) {
+    return 'Review the latest stable release and start the update when you are ready.'
+  }
+
+  return 'No action is needed until a newer stable release is published.'
 }
 
 export function SystemUpdatePanel() {
@@ -205,6 +296,8 @@ export function SystemUpdatePanel() {
 
   const summaryTone = getSummaryTone(currentJob, status.updateAvailable)
   const summaryHeading = getSummaryHeading(currentJob, status.updateAvailable)
+  const showLiveProgress = currentJob ? !isTerminalStatus(currentJob.status) : false
+  const updateStateBadge = getUpdateStateBadge(currentJob, status.updateAvailable)
 
   return (
     <div className="space-y-4" data-testid={TID.settings.updates.panel}>
@@ -274,15 +367,15 @@ export function SystemUpdatePanel() {
 
           <div className="stats stats-vertical w-full border border-base-300 bg-base-200 lg:stats-horizontal">
             <div className="stat">
-              <div className="stat-title">Current version</div>
-              <div className="stat-value text-2xl font-mono">
+              <div className="stat-title">Installed version</div>
+              <div className="stat-value text-2xl font-mono text-base-content">
                 {status.currentVersion ?? 'Unknown'}
               </div>
               <div className="stat-desc">Installed Sentinel package/runtime version</div>
             </div>
             <div className="stat">
               <div className="stat-title">Latest stable</div>
-              <div className="stat-value text-2xl font-mono">
+              <div className="stat-value text-2xl font-mono text-base-content">
                 {status.latestVersion ?? 'Unknown'}
               </div>
               <div className="stat-desc">
@@ -303,36 +396,27 @@ export function SystemUpdatePanel() {
             </div>
             <div className="stat">
               <div className="stat-title">Update state</div>
-              <div className="stat-value text-xl">
-                {currentJob
-                  ? formatStepLabel(currentJob.status)
-                  : status.updateAvailable
-                    ? 'Available'
-                    : 'Current'}
+              <div className="mt-2">
+                <AppBadge status={updateStateBadge.status}>{updateStateBadge.label}</AppBadge>
               </div>
-              <div className="stat-desc">
+              <div className="stat-desc mt-3">
                 {currentJob
-                  ? `Job ${currentJob.jobId.slice(0, 20)}...`
+                  ? `Requested ${formatTimestamp(currentJob.requestedAt)}`
                   : status.updateAvailable
-                    ? `Target ${status.latestVersion ?? 'unknown'}`
-                    : 'No active job'}
+                    ? 'Ready to start from this page'
+                    : 'No update currently running'}
               </div>
             </div>
           </div>
 
           <div className="grid gap-4 xl:grid-cols-[minmax(0,1.25fr)_minmax(18rem,0.75fr)]">
             <section className="rounded-box border border-base-300 bg-base-100 p-(--space-4)">
-              <div className="flex items-center justify-between gap-(--space-3)">
-                <div>
-                  <h3 className="text-base font-semibold">Next action</h3>
-                  <p className="mt-1 text-sm text-base-content/70">
-                    The backend only requests updates. The host-side updater owns install, restart,
-                    health checks, and rollback.
-                  </p>
-                </div>
-                <div className="badge badge-outline badge-lg">
-                  {status.updateAvailable ? 'Update available' : 'No update queued'}
-                </div>
+              <div>
+                <h3 className="text-base font-semibold">Next action</h3>
+                <p className="mt-1 text-sm text-base-content/70">
+                  Start updates here and let the appliance finish them in the background, even if
+                  this page reconnects while services restart.
+                </p>
               </div>
 
               <dl className="mt-4 grid gap-(--space-3) text-sm sm:grid-cols-2">
@@ -346,12 +430,10 @@ export function SystemUpdatePanel() {
                 </div>
                 <div className="rounded-box border border-base-300 bg-base-200 p-(--space-3)">
                   <dt className="text-xs font-semibold uppercase tracking-wide text-base-content/60">
-                    Eligibility
+                    Guidance
                   </dt>
                   <dd className="mt-1 text-base-content">
-                    {status.updateAvailable
-                      ? 'A newer stable release is available.'
-                      : 'This appliance is already on the latest known stable release.'}
+                    {getNextActionGuidance(currentJob, status.updateAvailable)}
                   </dd>
                 </div>
                 <div className="rounded-box border border-base-300 bg-base-200 p-(--space-3)">
@@ -380,7 +462,9 @@ export function SystemUpdatePanel() {
                     ) : (
                       <ServerCog className="h-4 w-4 text-info" />
                     )}
-                    <h4 className="text-sm font-semibold">Current job details</h4>
+                    <h4 className="text-sm font-semibold">
+                      {hasActiveJob ? 'Current job details' : 'Latest job details'}
+                    </h4>
                   </div>
                   <dl className="mt-3 grid gap-(--space-2) text-sm">
                     <div className="flex items-start justify-between gap-(--space-3)">
@@ -414,63 +498,135 @@ export function SystemUpdatePanel() {
             </section>
 
             <section className="rounded-box border border-base-300 bg-base-100 p-(--space-4)">
-              <h3 className="text-base font-semibold">Progress</h3>
+              <h3 className="text-base font-semibold">
+                {showLiveProgress ? 'Progress' : 'Last run'}
+              </h3>
               <p className="mt-1 text-sm text-base-content/70">
-                The updater persists job state on disk, so this view can reconnect after backend or
-                browser restarts.
+                {showLiveProgress
+                  ? 'The updater persists job state on disk, so this view can reconnect after backend or browser restarts.'
+                  : currentJob
+                    ? 'The most recent finished update request stays visible here after the live progress timeline clears.'
+                    : 'No update is running right now. Start a new request when a newer stable release is available.'}
               </p>
 
-              <ul className="steps steps-vertical mt-4 w-full">
-                {PRIMARY_FLOW.map((step) => {
-                  const currentIndex = currentJob ? PRIMARY_FLOW.indexOf(currentJob.status) : -1
-                  const stepIndex = PRIMARY_FLOW.indexOf(step)
-                  const isActive = currentJob?.status === step
-                  const isCompleted = currentIndex >= 0 && stepIndex <= currentIndex
-
-                  return (
-                    <li
-                      key={step}
-                      className={`step ${isCompleted || isActive ? 'step-primary' : ''}`}
-                    >
-                      <div className="text-left">
-                        <div className="font-medium">{formatStepLabel(step)}</div>
-                        <div className="text-xs text-base-content/60">
-                          {isActive
-                            ? currentJob?.message
-                            : step === 'completed'
-                              ? 'Sentinel returns to steady state after verification.'
-                              : 'Pending'}
-                        </div>
-                      </div>
-                    </li>
-                  )
-                })}
-              </ul>
-
-              {currentJob && isFailureStatus(currentJob.status) && (
-                <div className="mt-4 border-t border-base-300 pt-(--space-4)">
-                  <h4 className="text-sm font-semibold">Recovery states</h4>
-                  <ul className="steps steps-vertical mt-3 w-full">
-                    {FAILURE_FLOW.map((step) => {
-                      const currentIndex = FAILURE_FLOW.indexOf(currentJob.status)
-                      const stepIndex = FAILURE_FLOW.indexOf(step)
+              {showLiveProgress ? (
+                <>
+                  <ul className="steps steps-vertical mt-4 w-full">
+                    {PRIMARY_FLOW.map((step) => {
+                      const currentIndex = currentJob ? PRIMARY_FLOW.indexOf(currentJob.status) : -1
+                      const stepIndex = PRIMARY_FLOW.indexOf(step)
+                      const isActive = currentJob?.status === step
                       const isCompleted = currentIndex >= 0 && stepIndex <= currentIndex
 
                       return (
-                        <li key={step} className={`step ${isCompleted ? 'step-warning' : ''}`}>
+                        <li
+                          key={step}
+                          className={`step ${isCompleted || isActive ? 'step-primary' : ''}`}
+                        >
                           <div className="text-left">
-                            <div className="flex items-center gap-(--space-2)">
-                              {step === 'rolled_back' && <RotateCcw className="h-3.5 w-3.5" />}
-                              <span className="font-medium">{formatStepLabel(step)}</span>
-                            </div>
+                            <div className="font-medium">{formatStepLabel(step)}</div>
                             <div className="text-xs text-base-content/60">
-                              {step === currentJob.status ? currentJob.message : 'Not reached'}
+                              {getPrimaryStepDescription(step, currentJob)}
                             </div>
                           </div>
                         </li>
                       )
                     })}
                   </ul>
+
+                  {currentJob && isFailureStatus(currentJob.status) && (
+                    <div className="mt-4 border-t border-base-300 pt-(--space-4)">
+                      <h4 className="text-sm font-semibold">Recovery states</h4>
+                      <ul className="steps steps-vertical mt-3 w-full">
+                        {FAILURE_FLOW.map((step) => {
+                          const currentIndex = FAILURE_FLOW.indexOf(currentJob.status)
+                          const stepIndex = FAILURE_FLOW.indexOf(step)
+                          const isCompleted = currentIndex >= 0 && stepIndex <= currentIndex
+
+                          return (
+                            <li key={step} className={`step ${isCompleted ? 'step-warning' : ''}`}>
+                              <div className="text-left">
+                                <div className="flex items-center gap-(--space-2)">
+                                  {step === 'rolled_back' && <RotateCcw className="h-3.5 w-3.5" />}
+                                  <span className="font-medium">{formatStepLabel(step)}</span>
+                                </div>
+                                <div className="text-xs text-base-content/60">
+                                  {step === currentJob.status ? currentJob.message : 'Not reached'}
+                                </div>
+                              </div>
+                            </li>
+                          )
+                        })}
+                      </ul>
+                    </div>
+                  )}
+                </>
+              ) : currentJob ? (
+                <div className="mt-4 space-y-4">
+                  <div className="rounded-box border border-base-300 bg-base-200 p-(--space-4)">
+                    <div className="flex flex-wrap items-start justify-between gap-(--space-3)">
+                      <div className="space-y-(--space-1)">
+                        <p className="text-sm font-semibold">Most recent update request</p>
+                        <p className="text-sm text-base-content/70">{currentJob.message}</p>
+                      </div>
+                      <AppBadge status={getTerminalJobBadgeStatus(currentJob.status)} size="sm">
+                        {formatStepLabel(currentJob.status)}
+                      </AppBadge>
+                    </div>
+
+                    <dl className="mt-4 grid gap-(--space-3) text-sm sm:grid-cols-2">
+                      <div className="rounded-box border border-base-300 bg-base-100 p-(--space-3)">
+                        <dt className="text-xs font-semibold uppercase tracking-wide text-base-content/60">
+                          Target version
+                        </dt>
+                        <dd className="mt-1 font-mono text-base-content">
+                          {currentJob.targetVersion}
+                        </dd>
+                      </div>
+                      <div className="rounded-box border border-base-300 bg-base-100 p-(--space-3)">
+                        <dt className="text-xs font-semibold uppercase tracking-wide text-base-content/60">
+                          Finished
+                        </dt>
+                        <dd className="mt-1 text-base-content">
+                          {formatTimestamp(currentJob.finishedAt ?? currentJob.startedAt)}
+                        </dd>
+                      </div>
+                      <div className="rounded-box border border-base-300 bg-base-100 p-(--space-3)">
+                        <dt className="text-xs font-semibold uppercase tracking-wide text-base-content/60">
+                          Requested by
+                        </dt>
+                        <dd className="mt-1 text-base-content">
+                          {currentJob.requestedBy.memberName}
+                        </dd>
+                      </div>
+                      <div className="rounded-box border border-base-300 bg-base-100 p-(--space-3)">
+                        <dt className="text-xs font-semibold uppercase tracking-wide text-base-content/60">
+                          Next action
+                        </dt>
+                        <dd className="mt-1 text-base-content">
+                          {currentJob.status === 'completed'
+                            ? 'No action needed.'
+                            : currentJob.status === 'rolled_back'
+                              ? 'Review the appliance before retrying another update.'
+                              : 'Review the failure summary and updater logs before retrying.'}
+                        </dd>
+                      </div>
+                    </dl>
+                  </div>
+
+                  {currentJob.failureSummary && (
+                    <AppAlert
+                      tone={currentJob.status === 'failed' ? 'error' : 'warning'}
+                      heading="Last run summary"
+                    >
+                      {currentJob.failureSummary}
+                    </AppAlert>
+                  )}
+                </div>
+              ) : (
+                <div className="mt-4 rounded-box border border-base-300 bg-base-200 p-(--space-4) text-sm text-base-content/70">
+                  No update is currently running. When a newer stable release is available, start it
+                  here and this panel will switch to a live progress timeline.
                 </div>
               )}
             </section>

--- a/deploy/deb/assets/usr/lib/sentinel/sentinel-updater
+++ b/deploy/deb/assets/usr/lib/sentinel/sentinel-updater
@@ -91,6 +91,10 @@ def configure_logging() -> None:
     )
 
 
+def normalize_health_version(value: str | None) -> str | None:
+    return normalize_version_tag(value)
+
+
 def load_job(path: Path) -> dict[str, Any]:
     job = read_json_file(path)
     if not isinstance(job, dict):
@@ -342,20 +346,48 @@ def install_deb(deb_path: Path, job_logger: JobLogger) -> None:
         raise UpdaterError("installing", "Package installation failed in both the primary and fallback paths.")
 
 
-def wait_for_health(job_logger: JobLogger) -> None:
+def wait_for_health(job_logger: JobLogger, expected_version: str | None = None) -> None:
     deadline = time.monotonic() + HEALTH_TIMEOUT_SECONDS
     request = urllib.request.Request(HEALTH_URL, headers={"User-Agent": "sentinel-updater/1.0"})
     while time.monotonic() < deadline:
         try:
             with urllib.request.urlopen(request, timeout=5) as response:
                 if 200 <= response.status < 300:
-                    job_logger.write_line(f"Health check passed at {HEALTH_URL}")
+                    payload = json.loads(response.read().decode("utf-8"))
+                    if expected_version is not None:
+                        reported_version = None
+                        if isinstance(payload, dict):
+                            raw_version = payload.get("version")
+                            if isinstance(raw_version, str):
+                                reported_version = normalize_health_version(raw_version.strip())
+
+                        if reported_version != expected_version:
+                            job_logger.write_line(
+                                "Health endpoint responded but reported version "
+                                f"{reported_version or 'unknown'} instead of {expected_version}"
+                            )
+                            time.sleep(3)
+                            continue
+
+                    job_logger.write_line(
+                        f"Health check passed at {HEALTH_URL}"
+                        + (
+                            f" with expected version {expected_version}"
+                            if expected_version is not None
+                            else ""
+                        )
+                    )
                     return
         except Exception:  # noqa: BLE001
             pass
         time_left = max(0, int(deadline - time.monotonic()))
         job_logger.write_line(f"Waiting for {HEALTH_URL} ({time_left}s remaining)")
         time.sleep(3)
+    if expected_version is not None:
+        raise UpdaterError(
+            "health_check",
+            f"Health check did not confirm Sentinel {expected_version} at {HEALTH_URL}.",
+        )
     raise UpdaterError("health_check", f"Health check did not succeed at {HEALTH_URL}.")
 
 
@@ -481,7 +513,7 @@ def rollback(job: dict[str, Any], previous_artifact: dict[str, str], job_logger:
 
     install_deb(Path(previous_artifact["debPath"]), job_logger)
     restart_stack(previous_state, job_logger)
-    wait_for_health(job_logger)
+    wait_for_health(job_logger, expected_version=previous_artifact["version"])
 
     job["currentVersion"] = previous_artifact["version"]
     update_job(
@@ -562,7 +594,7 @@ def execute_update(job: dict[str, Any], job_logger: JobLogger) -> None:
 
     update_job(job, status="health_check", message="Running post-update verification.", job_logger=job_logger)
     run_backend_post_update(state, job_logger)
-    wait_for_health(job_logger)
+    wait_for_health(job_logger, expected_version=target_version)
 
     job["currentVersion"] = target_version
     update_job(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
### What

- harden the host updater so completion requires `/healthz` to report the expected target version
- make backend update status prefer the canonical appliance state after completed jobs
- add backend tests covering completed-version reporting and duplicate target rejection
- simplify the Updates page UX so terminal jobs show a compact last-run summary instead of a stale progress rail
- reduce warning-heavy styling on the Updates page and consolidate state messaging into a clearer top summary
- bump the workspace and release artifacts to `2.6.4`

### Why

The `v2.6.3` UI-driven update flow could report a false success. The updater only waited for a healthy response, not proof that the appliance was actually serving the requested version. That led to a confusing UI state where the page could show a completed update while the appliance still reported `v2.6.2`.

This PR fixes the host-side completion criteria, makes the backend status source more trustworthy, and cleans up the Updates page so operators see one clear current state instead of repeated warning text and a progress rail that remains visible after the run is over.

### User Impact

- completed updates will only report success once the appliance health endpoint confirms the target version
- the Updates page will show a clearer `Last run` summary after a terminal job instead of leaving the live progress rail onscreen
- top-of-page status messaging is less noisy and uses semantic emphasis more intentionally

### Validation

```bash
pnpm version:check
pnpm --filter @sentinel/backend typecheck
pnpm --filter frontend-admin typecheck
pnpm --filter frontend-admin exec vitest run --root /home/sentinel000/Projects/Sentinel apps/backend/src/routes/system-update.test.ts
python3 -m py_compile deploy/deb/assets/usr/lib/sentinel/sentinel-updater deploy/deb/assets/usr/lib/sentinel/sentinel_update_common.py
./deploy/deb/build-deb.sh --version v2.6.4
```

### Risks / Follow-Ups

- I could not do a rendered local browser sanity pass because no local frontend route was reachable on ports `3000-3003` in this session.
- A follow-up polish pass could further simplify the remaining technical details block if we want an even more operator-focused Updates page.
