### PR TITLE
[codex] Prepare v2.6.5 release

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/routes/system-update.test.ts
+++ b/apps/backend/src/routes/system-update.test.ts
@@ -293,6 +293,50 @@ describe('systemUpdateRouter', () => {
     }
   })
 
+  it('suppresses a stale completed updater job when the appliance version moved ahead manually', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'sentinel-system-update-state-'))
+    const applianceStatePath = join(stateRoot, 'appliance-state.json')
+    await mkdir(join(stateRoot, 'jobs'), { recursive: true })
+    await writeJson(
+      join(stateRoot, 'current-job.json'),
+      createJob({
+        status: 'completed',
+        currentVersion: 'v2.6.3',
+        latestVersion: 'v2.6.3',
+        targetVersion: 'v2.6.3',
+        finishedAt: '2026-04-22T12:10:00.000Z',
+        message: 'Sentinel updated successfully to v2.6.3.',
+      })
+    )
+    await writeJson(applianceStatePath, {
+      schemaVersion: 1,
+      withObs: false,
+      allowGrafanaLan: false,
+      allowWikiLan: false,
+      lanCidr: '192.168.0.0/16',
+      currentVersion: 'v2.6.4',
+      previousVersion: 'v2.6.3',
+    })
+
+    process.env.APP_VERSION = 'v2.6.3'
+    process.env.SYSTEM_UPDATE_STATE_ROOT = stateRoot
+    process.env.SENTINEL_APPLIANCE_STATE = applianceStatePath
+    process.env.SYSTEM_UPDATE_RELEASE_REPOSITORY = ''
+
+    try {
+      const app = createTestApp(5)
+      const response = await request(app).get('/api/admin/system/update')
+
+      expect(response.status).toBe(200)
+      expect(response.body).toMatchObject({
+        currentVersion: 'v2.6.4',
+        currentJob: null,
+      })
+    } finally {
+      await rm(stateRoot, { recursive: true, force: true })
+    }
+  })
+
   it('rejects starting the same target again when appliance state is already on that version', async () => {
     const stateRoot = await mkdtemp(join(tmpdir(), 'sentinel-system-update-state-'))
     const applianceStatePath = join(stateRoot, 'appliance-state.json')

--- a/apps/backend/src/services/system-update-status-service.ts
+++ b/apps/backend/src/services/system-update-status-service.ts
@@ -51,9 +51,12 @@ export class SystemUpdateStatusService {
   }
 
   async getStatus(): Promise<SystemUpdateStatusResponse> {
-    const currentJob = await this.readCurrentJob()
-    const releaseSummary = await this.fetchLatestReleaseSummary()
     const applianceStateVersion = await this.readApplianceCurrentVersion()
+    const currentJob = this.filterSupersededTerminalJob(
+      await this.readCurrentJob(),
+      applianceStateVersion
+    )
+    const releaseSummary = await this.fetchLatestReleaseSummary()
     const completedJobVersion =
       currentJob && isSystemUpdateJobTerminal(currentJob.status) ? currentJob.currentVersion : null
     const currentVersion =
@@ -74,6 +77,43 @@ export class SystemUpdateStatusService {
         compareVersionTags(currentVersion, latestVersion) < 0,
       currentJob,
     }
+  }
+
+  private filterSupersededTerminalJob(
+    currentJob: SystemUpdateJob | null,
+    applianceStateVersion: string | null
+  ): SystemUpdateJob | null {
+    if (!currentJob || !applianceStateVersion || !isSystemUpdateJobTerminal(currentJob.status)) {
+      return currentJob
+    }
+
+    const terminalJobVersion = this.resolveTerminalJobVersion(currentJob)
+    if (terminalJobVersion === null) {
+      return currentJob
+    }
+
+    if (compareVersionTags(terminalJobVersion, applianceStateVersion) === 0) {
+      return currentJob
+    }
+
+    serviceLogger.warn(
+      'Ignoring stale terminal Sentinel updater job that no longer matches the appliance version',
+      {
+        jobId: currentJob.jobId,
+        jobStatus: currentJob.status,
+        terminalJobVersion,
+        applianceStateVersion,
+      }
+    )
+    return null
+  }
+
+  private resolveTerminalJobVersion(currentJob: SystemUpdateJob): string | null {
+    if (currentJob.currentVersion) {
+      return currentJob.currentVersion
+    }
+
+    return currentJob.status === 'completed' ? currentJob.targetVersion : null
   }
 
   async getJob(jobId: string): Promise<SystemUpdateJob | null> {

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/deploy/_common.sh
+++ b/deploy/_common.sh
@@ -4,7 +4,11 @@ set -euo pipefail
 DEPLOY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENV_FILE="${DEPLOY_DIR}/.env"
 CANONICAL_ENV_FILE="/etc/sentinel/appliance.env"
+CANONICAL_STATE_FILE="/var/lib/sentinel/appliance/state.json"
 STATE_FILE="${DEPLOY_DIR}/.appliance-state"
+UPDATER_STATE_ROOT="/var/lib/sentinel/updater"
+CURRENT_JOB_FILE="${UPDATER_STATE_ROOT}/current-job.json"
+UPDATER_JOBS_DIR="${UPDATER_STATE_ROOT}/jobs"
 BASE_COMPOSE_FILE="${DEPLOY_DIR}/docker-compose.yml"
 GRAFANA_OVERRIDE_FILE="${DEPLOY_DIR}/docker-compose.grafana-lan.yml"
 WIKI_OVERRIDE_FILE="${DEPLOY_DIR}/docker-compose.wiki-lan.yml"
@@ -410,6 +414,99 @@ resolve_managed_file_path() {
   printf '%s\n' "${path}"
 }
 
+json_escape() {
+  printf '%s' "${1:-}" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+json_bool() {
+  if [[ "${1:-false}" == "true" ]]; then
+    printf 'true'
+  else
+    printf 'false'
+  fi
+}
+
+write_canonical_state() {
+  local state_dir tmp_file updated_at
+  state_dir="$(dirname "${CANONICAL_STATE_FILE}")"
+  tmp_file="$(mktemp)"
+  updated_at="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+  cat >"${tmp_file}" <<JSON
+{
+  "allowGrafanaLan": $(json_bool "${ALLOW_GRAFANA_LAN:-false}"),
+  "allowWikiLan": $(json_bool "${ALLOW_WIKI_LAN:-false}"),
+  "currentVersion": "$(json_escape "${CURRENT_VERSION:-}")",
+  "lanCidr": "$(json_escape "${LAN_CIDR:-}")",
+  "previousVersion": "$(json_escape "${PREVIOUS_VERSION:-}")",
+  "schemaVersion": 1,
+  "updatedAt": "$(json_escape "${updated_at}")",
+  "withObs": $(json_bool "${WITH_OBS:-false}")
+}
+JSON
+
+  run_root install -d -m 755 "${state_dir}"
+  run_root install -m 644 "${tmp_file}" "${CANONICAL_STATE_FILE}"
+  rm -f "${tmp_file}"
+}
+
+archive_superseded_terminal_job() {
+  local current_version archived_path
+  current_version="${CURRENT_VERSION:-}"
+
+  [[ -n "${current_version}" ]] || return 0
+
+  if ! archived_path="$(
+    run_root python3 - "${CURRENT_JOB_FILE}" "${UPDATER_JOBS_DIR}" "${current_version}" <<'PY'
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+current_job_path = Path(sys.argv[1])
+jobs_dir = Path(sys.argv[2])
+current_version = sys.argv[3].strip()
+
+if not current_job_path.exists():
+    raise SystemExit(0)
+
+with current_job_path.open("r", encoding="utf-8") as handle:
+    job = json.load(handle)
+
+status = str(job.get("status", "")).strip()
+if status not in {"completed", "failed", "rollback_attempted", "rolled_back"}:
+    raise SystemExit(0)
+
+job_current_version = str(job.get("currentVersion", "")).strip()
+job_target_version = str(job.get("targetVersion", "")).strip()
+job_version = job_current_version or (job_target_version if status == "completed" else "")
+
+if not job_version or job_version == current_version:
+    raise SystemExit(0)
+
+job_id = str(job.get("jobId", "current-job")).strip() or "current-job"
+safe_job_id = re.sub(r"[^A-Za-z0-9._-]+", "-", job_id)
+timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d-%H%M%S")
+
+jobs_dir.mkdir(parents=True, exist_ok=True)
+archive_path = jobs_dir / f"{safe_job_id}-manual-superseded-{timestamp}.json"
+shutil.move(str(current_job_path), archive_path)
+print(archive_path)
+PY
+  )"; then
+    warn "Unable to reconcile updater history with the manual Sentinel version ${current_version}."
+    return 0
+  fi
+
+  if [[ -n "${archived_path}" ]]; then
+    log "Archived superseded updater history at ${archived_path}."
+  fi
+}
+
 load_state() {
   if [[ -f "${STATE_FILE}" ]]; then
     # shellcheck disable=SC1090
@@ -430,6 +527,8 @@ LAN_CIDR=${LAN_CIDR:-}
 CURRENT_VERSION=${CURRENT_VERSION:-}
 PREVIOUS_VERSION=${PREVIOUS_VERSION:-}
 STATE
+
+  write_canonical_state
 }
 
 set_compose_file_args() {

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -189,7 +189,6 @@ upsert_env "CORS_ORIGIN" "${CURRENT_CORS}"
 
 CURRENT_VERSION="${TARGET_VERSION}"
 PREVIOUS_VERSION=""
-save_state
 set_compose_file_args
 
 ensure_compose_pull_with_login_fallback
@@ -201,6 +200,9 @@ if ! wait_for_healthz 240; then
   print_health_diagnostics
   die "Install failed health gate check at /healthz"
 fi
+
+save_state
+archive_superseded_terminal_job
 
 if command -v systemctl >/dev/null 2>&1; then
   write_systemd_unit

--- a/deploy/rollback.sh
+++ b/deploy/rollback.sh
@@ -73,7 +73,6 @@ CURRENT_VERSION="${TARGET_VERSION}"
 PREVIOUS_VERSION="${PREV_FOR_SWAP}"
 
 upsert_env "SENTINEL_VERSION" "${TARGET_VERSION}"
-save_state
 
 ensure_compose_pull_with_login_fallback
 compose up -d
@@ -83,6 +82,9 @@ if ! wait_for_healthz 240; then
   print_health_diagnostics
   die "Rollback failed health gate check at /healthz"
 fi
+
+save_state
+archive_superseded_terminal_job
 
 if command -v systemctl >/dev/null 2>&1; then
   write_systemd_unit

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -268,8 +268,6 @@ if [[ -n "${SERVER_IP}" && ",${CURRENT_CORS}," != *",http://${SERVER_IP},"* ]]; 
 fi
 upsert_env "CORS_ORIGIN" "${CURRENT_CORS}"
 
-save_state
-
 ensure_compose_pull_with_login_fallback
 compose up -d
 
@@ -282,6 +280,9 @@ if ! wait_for_healthz 240; then
   print_health_diagnostics
   die "Update failed health gate check at /healthz"
 fi
+
+save_state
+archive_superseded_terminal_job
 
 if command -v systemctl >/dev/null 2>&1; then
   write_systemd_unit

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary
- keep the canonical appliance state file in sync during manual install, update, and rollback flows
- archive superseded terminal updater job history after successful manual host-side version changes
- ignore stale terminal updater jobs in the status API when they no longer match the installed appliance version
- add regression coverage for stale completed-job suppression and bump the workspace to `2.6.5`

## Root cause
The Updates page could snap back to an older version after a successful manual host update because two sources drifted:

1. `deploy/update.sh` updated the runtime without reconciling `/var/lib/sentinel/appliance/state.json` and stale `current-job.json` history.
2. The backend status service still returned a terminal updater job even when that job no longer matched the installed appliance version.

That let an old completed `v2.6.3` job keep dominating the page after the appliance had already moved to `v2.6.4`.

## User impact
- manual host updates now publish the correct canonical version only after the new runtime passes health checks
- superseded updater history no longer overrides a newer successful manual update in the UI
- the status API falls back to the real installed appliance version when stale terminal job history drifts

## Validation
- `pnpm --filter @sentinel/backend typecheck`
- `pnpm --filter frontend-admin exec vitest run --root /home/sentinel000/Projects/Sentinel apps/backend/src/routes/system-update.test.ts`
- `bash -n deploy/_common.sh deploy/update.sh deploy/install.sh deploy/rollback.sh deploy/upgrade-launcher.sh`
- `pnpm version:check`
- `./deploy/deb/build-deb.sh --version v2.6.5`
