### PR TITLE
[codex] Prepare v2.6.7 release

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/app/dashboard/page.tsx
+++ b/apps/frontend-admin/src/app/dashboard/page.tsx
@@ -1,9 +1,12 @@
+import Link from 'next/link'
 import { SecurityAlertsBar } from '@/components/dashboard/security-alerts-bar'
 import { StatusStats } from '@/components/dashboard/status-stats'
 import { PersonCardGrid } from '@/components/dashboard/person-card-grid'
 import { DashboardDdsChecklistDrawer } from '@/components/dashboard/dashboard-dds-checklist-drawer'
 import { DashboardHelpLauncher } from '@/components/help/dashboard-help-launcher'
+import { AppAlert } from '@/components/ui/AppAlert'
 import { AppBadge } from '@/components/ui/AppBadge'
+import { TID } from '@/lib/test-ids'
 
 export default function DashboardPage() {
   return (
@@ -16,16 +19,42 @@ export default function DashboardPage() {
 
         <SecurityAlertsBar />
 
-        <section
-          aria-label="Dashboard update verification marker"
-          className="alert border border-info/25 bg-info-fadded text-info-fadded-content shadow-[var(--shadow-1)]"
-        >
-          <AppBadge status="info" size="sm">
-            Update test
-          </AppBadge>
-          <span className="text-sm font-medium">
-            Dashboard verification marker: April 22 update build
-          </span>
+        <section aria-label="Dashboard update verification tools">
+          <AppAlert
+            tone="info"
+            heading="Update verification shortcuts"
+            description="Jump straight into the new update flow or open the host-side trace log from the dashboard."
+            meta={
+              <AppBadge status="info" size="sm">
+                Update test
+              </AppBadge>
+            }
+            actions={
+              <div className="flex flex-wrap justify-end gap-(--space-2)">
+                <Link
+                  href="/settings?tab=updates"
+                  className="btn btn-sm btn-outline"
+                  data-testid={TID.dashboard.updateBanner.updatesLink}
+                >
+                  Open updates
+                </Link>
+                <Link
+                  href="/settings?tab=updates&trace=open"
+                  className="btn btn-sm btn-primary"
+                  data-testid={TID.dashboard.updateBanner.traceLink}
+                >
+                  Open update log
+                </Link>
+              </div>
+            }
+            className="shadow-[var(--shadow-1)]"
+            data-testid={TID.dashboard.updateBanner.panel}
+          >
+            <p className="text-sm text-base-content/80">
+              Use these shortcuts to validate both the update request flow and the update log viewer
+              without leaving the dashboard first.
+            </p>
+          </AppAlert>
         </section>
 
         <section>

--- a/apps/frontend-admin/src/app/settings/page.tsx
+++ b/apps/frontend-admin/src/app/settings/page.tsx
@@ -66,6 +66,10 @@ function SettingsPageContent() {
     }
 
     const params = new globalThis.URLSearchParams(searchParams.toString())
+    if (nextTab !== 'updates') {
+      params.delete('trace')
+    }
+
     if (nextTab === 'member-types') {
       params.delete('tab')
     } else {

--- a/apps/frontend-admin/src/components/settings/system-update-panel.tsx
+++ b/apps/frontend-admin/src/components/settings/system-update-panel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
 import type { SystemUpdateJob, SystemUpdateJobStatus } from '@sentinel/contracts'
 import { Download, ExternalLink, RefreshCw, RotateCcw, ServerCog, ShieldAlert } from 'lucide-react'
 import { toast } from 'sonner'
@@ -240,8 +241,10 @@ function shouldAutoOpenTraceLog(job: SystemUpdateJob | null): boolean {
 export function SystemUpdatePanel() {
   const member = useAuthStore((state) => state.member)
   const canStartUpdates = (member?.accountLevel ?? 0) >= AccountLevel.ADMIN
+  const searchParams = useSearchParams()
+  const traceRequested = searchParams.get('trace') === 'open'
   const [confirmOpen, setConfirmOpen] = useState(false)
-  const [tracePanelOpen, setTracePanelOpen] = useState(false)
+  const [tracePanelOpen, setTracePanelOpen] = useState(traceRequested)
 
   const systemUpdateQuery = useSystemUpdateStatus({
     enabled: Boolean(member),
@@ -269,6 +272,12 @@ export function SystemUpdatePanel() {
       setTracePanelOpen(true)
     }
   }, [autoOpenTraceLog, currentJob?.jobId, currentJob?.status])
+
+  useEffect(() => {
+    if (traceRequested) {
+      setTracePanelOpen(true)
+    }
+  }, [traceRequested])
 
   const handleRefresh = async () => {
     await systemUpdateQuery.refetch()

--- a/apps/frontend-admin/src/lib/test-ids.ts
+++ b/apps/frontend-admin/src/lib/test-ids.ts
@@ -279,6 +279,11 @@ export const TID = {
     row: 'log-row',
   },
   dashboard: {
+    updateBanner: {
+      panel: 'dashboard-update-banner',
+      updatesLink: 'dashboard-update-banner-updates-link',
+      traceLink: 'dashboard-update-banner-trace-link',
+    },
     ddsDrawer: {
       open: 'dashboard-dds-drawer-open',
       close: 'dashboard-dds-drawer-close',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## What changed
- replace the static dashboard update test marker with actionable shortcuts to the Updates page and the update trace log
- allow the Updates tab to auto-open the trace log when linked with the new dashboard shortcut
- clear the trace-specific query parameter when operators navigate away from the Updates tab
- add dashboard test IDs for the new verification links
- bump the workspace version from `2.6.6` to `2.6.7`

## Why
The new Update and Update Log flow is in place, but the dashboard still exposed only a dead verification banner. This release turns that banner into a practical operator shortcut so the new flow can be exercised directly from the dashboard.

## Impact
- operators can jump from the dashboard straight into the Updates workflow
- operators can open the update trace viewer in one click for quicker verification
- the release artifacts and workspace packages now align on `2.6.7`

## Validation
- `pnpm version:check`
- `pnpm --filter frontend-admin typecheck`
- `pnpm --filter frontend-admin lint` (passes with the repo's existing warning set in unrelated files)

## Notes
- I could not complete a live browser sanity pass in this workspace session because no local frontend route was reachable on port `3001` when verification was attempted.