### PR TITLE
feat(release): prepare v2.7.0

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "2.6.7",
+  "version": "2.7.0",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/scripts/seed-default-enums.ts
+++ b/apps/backend/scripts/seed-default-enums.ts
@@ -882,6 +882,7 @@ async function ensureRemoteSystems(): Promise<number> {
 }
 
 async function ensureNetworkSettings(): Promise<boolean> {
+  const defaultApprovedSsid = process.env.HOTSPOT_SSID?.trim() || 'Stone Frigate'
   const existing = await prisma.setting.findUnique({
     where: { key: 'network.approved_ssids' },
     select: { id: true },
@@ -894,7 +895,7 @@ async function ensureNetworkSettings(): Promise<boolean> {
   await prisma.setting.create({
     data: {
       key: 'network.approved_ssids',
-      value: { approvedSsids: ['Stone Frigate'] },
+      value: { approvedSsids: [defaultApprovedSsid] },
       category: 'network',
       description: 'Approved Wi-Fi SSID allowlist used for Sentinel hotspot validation.',
     },

--- a/apps/backend/src/routes/system-status.ts
+++ b/apps/backend/src/routes/system-status.ts
@@ -17,6 +17,7 @@ function toKioskSafeSystemStatus(status: SystemStatusResponse): SystemStatusResp
     network: {
       ...status.network,
       hostIpAddress: null,
+      hotspotDevice: null,
       hotspotScanDevice: null,
       remoteTarget: null,
     },

--- a/apps/backend/src/services/host-network-status-service.ts
+++ b/apps/backend/src/services/host-network-status-service.ts
@@ -5,9 +5,14 @@ const DEFAULT_NETWORK_STATUS_FILE_PATH = '/var/run/sentinel/network-status/netwo
 
 export interface HostNetworkTelemetry {
   generatedAt: Date
+  issueCode: string | null
   wifiConnected: boolean | null
   currentSsid: string | null
   hostIpAddress: string | null
+  hotspotProfilePresent: boolean | null
+  hotspotAdapterApproved: boolean | null
+  scanAdapterPresent: boolean | null
+  hotspotDevice: string | null
   hotspotSsid: string | null
   hotspotScanDevice: string | null
   hotspotSsidVisibleFromLaptop: boolean | null
@@ -52,9 +57,14 @@ function parseTelemetry(payload: unknown): HostNetworkTelemetry | null {
 
   return {
     generatedAt,
+    issueCode: normalizeNullableString(payload.issueCode),
     wifiConnected: normalizeNullableBoolean(payload.wifiConnected),
     currentSsid: normalizeNullableString(payload.currentSsid),
     hostIpAddress: normalizeNullableString(payload.hostIpAddress),
+    hotspotProfilePresent: normalizeNullableBoolean(payload.hotspotProfilePresent),
+    hotspotAdapterApproved: normalizeNullableBoolean(payload.hotspotAdapterApproved),
+    scanAdapterPresent: normalizeNullableBoolean(payload.scanAdapterPresent),
+    hotspotDevice: normalizeNullableString(payload.hotspotDevice),
     hotspotSsid: normalizeNullableString(payload.hotspotSsid),
     hotspotScanDevice: normalizeNullableString(payload.hotspotScanDevice),
     hotspotSsidVisibleFromLaptop: normalizeNullableBoolean(payload.hotspotSsidVisibleFromLaptop),

--- a/apps/backend/src/services/network-settings-service.ts
+++ b/apps/backend/src/services/network-settings-service.ts
@@ -6,7 +6,7 @@ import { SettingRepository } from '../repositories/setting-repository.js'
 import { logger } from '../lib/logger.js'
 
 const NETWORK_SETTINGS_KEY = 'network.approved_ssids'
-const DEFAULT_APPROVED_SSID = 'Stone Frigate'
+const DEFAULT_APPROVED_SSID = process.env.HOTSPOT_SSID?.trim() || 'Stone Frigate'
 const LEGACY_DEFAULT_APPROVED_SSID_KEYS = new Set(['hmcschippawa'])
 const DEFAULT_NETWORK_SETTINGS: NetworkSettings = {
   approvedSsids: [DEFAULT_APPROVED_SSID],

--- a/apps/backend/src/services/system-status-service.test.ts
+++ b/apps/backend/src/services/system-status-service.test.ts
@@ -99,9 +99,14 @@ describe('SystemStatusService', () => {
       telemetryResult: {
         telemetry: {
           generatedAt: new Date('2026-04-01T11:59:40.000Z'),
+          issueCode: 'none',
           wifiConnected: true,
           currentSsid: 'Coffee-Shop',
           hostIpAddress: '192.168.8.1',
+          hotspotProfilePresent: true,
+          hotspotAdapterApproved: true,
+          scanAdapterPresent: true,
+          hotspotDevice: 'wlxb8fbb3c4e8ae',
           hotspotSsid: 'Stone Frigate',
           hotspotScanDevice: 'wlan0',
           hotspotSsidVisibleFromLaptop: true,
@@ -118,6 +123,7 @@ describe('SystemStatusService', () => {
     const result = await service.getSystemStatus()
 
     expect(result.network.status).toBe('warning')
+    expect(result.network.issueCode).toBe('unapproved_ssid')
     expect(result.network.approvedSsid).toBe(false)
     expect(result.network.currentSsid).toBe('Coffee-Shop')
     expect(result.network.hostIpAddress).toBe('192.168.8.1')
@@ -132,9 +138,14 @@ describe('SystemStatusService', () => {
       telemetryResult: {
         telemetry: {
           generatedAt: new Date('2026-04-01T11:59:40.000Z'),
+          issueCode: 'none',
           wifiConnected: true,
           currentSsid: 'Stone Frigate',
           hostIpAddress: '192.168.8.1',
+          hotspotProfilePresent: true,
+          hotspotAdapterApproved: true,
+          scanAdapterPresent: true,
+          hotspotDevice: 'wlxb8fbb3c4e8ae',
           hotspotSsid: 'Stone Frigate',
           hotspotScanDevice: 'wlan0',
           hotspotSsidVisibleFromLaptop: true,
@@ -151,6 +162,7 @@ describe('SystemStatusService', () => {
     const result = await service.getSystemStatus()
 
     expect(result.network.status).toBe('healthy')
+    expect(result.network.issueCode).toBe('none')
     expect(result.network.approvedSsid).toBe(true)
     expect(result.network.hostIpAddress).toBe('192.168.8.1')
     expect(result.network.message).toBe('Connected to approved Wi-Fi network')
@@ -162,9 +174,14 @@ describe('SystemStatusService', () => {
       telemetryResult: {
         telemetry: {
           generatedAt: new Date('2026-04-01T11:59:40.000Z'),
+          issueCode: 'hotspot_not_visible',
           wifiConnected: true,
           currentSsid: 'Stone Frigate',
           hostIpAddress: '10.42.0.1',
+          hotspotProfilePresent: true,
+          hotspotAdapterApproved: true,
+          scanAdapterPresent: true,
+          hotspotDevice: 'wlxb8fbb3c4e8ae',
           hotspotSsid: 'Stone Frigate',
           hotspotScanDevice: 'wlp2s0',
           hotspotSsidVisibleFromLaptop: false,
@@ -181,8 +198,77 @@ describe('SystemStatusService', () => {
     const result = await service.getSystemStatus()
 
     expect(result.network.status).toBe('warning')
+    expect(result.network.issueCode).toBe('hotspot_not_visible')
     expect(result.network.hotspotSsidVisibleFromLaptop).toBe(false)
     expect(result.network.message).toContain('not visible')
+  })
+
+  it('marks network status warning when a second scan radio is unavailable', async () => {
+    const { service } = createService({
+      telemetryResult: {
+        telemetry: {
+          generatedAt: new Date('2026-04-01T11:59:40.000Z'),
+          issueCode: 'scan_adapter_missing',
+          wifiConnected: true,
+          currentSsid: 'Stone Frigate',
+          hostIpAddress: '10.42.0.1',
+          hotspotProfilePresent: true,
+          hotspotAdapterApproved: true,
+          scanAdapterPresent: false,
+          hotspotDevice: 'wlxb8fbb3c4e8ae',
+          hotspotSsid: 'Stone Frigate',
+          hotspotScanDevice: null,
+          hotspotSsidVisibleFromLaptop: null,
+          internetReachable: true,
+          remoteTarget: null,
+          remoteReachable: null,
+          portalRecoveryLikely: false,
+          message: 'A second Wi-Fi radio is unavailable for hotspot verification.',
+        },
+        error: null,
+      },
+    })
+
+    const result = await service.getSystemStatus()
+
+    expect(result.network.status).toBe('warning')
+    expect(result.network.issueCode).toBe('scan_adapter_missing')
+    expect(result.network.scanAdapterPresent).toBe(false)
+    expect(result.network.message).toContain('second Wi-Fi radio')
+  })
+
+  it('marks network status warning when the managed hotspot profile is missing', async () => {
+    const { service } = createService({
+      telemetryResult: {
+        telemetry: {
+          generatedAt: new Date('2026-04-01T11:59:40.000Z'),
+          issueCode: 'hotspot_profile_missing',
+          wifiConnected: true,
+          currentSsid: 'Stone Frigate',
+          hostIpAddress: '10.42.0.1',
+          hotspotProfilePresent: false,
+          hotspotAdapterApproved: true,
+          scanAdapterPresent: true,
+          hotspotDevice: 'wlxb8fbb3c4e8ae',
+          hotspotSsid: 'Stone Frigate',
+          hotspotScanDevice: 'wlp2s0',
+          hotspotSsidVisibleFromLaptop: null,
+          internetReachable: true,
+          remoteTarget: null,
+          remoteReachable: null,
+          portalRecoveryLikely: false,
+          message: 'The managed Sentinel hotspot profile is missing.',
+        },
+        error: null,
+      },
+    })
+
+    const result = await service.getSystemStatus()
+
+    expect(result.network.status).toBe('warning')
+    expect(result.network.issueCode).toBe('hotspot_profile_missing')
+    expect(result.network.hotspotProfilePresent).toBe(false)
+    expect(result.network.message).toContain('profile is missing')
   })
 
   it('uses host hotspot IP for deployment-laptop remote sessions', async () => {
@@ -190,9 +276,14 @@ describe('SystemStatusService', () => {
       telemetryResult: {
         telemetry: {
           generatedAt: new Date('2026-04-01T11:59:40.000Z'),
+          issueCode: 'none',
           wifiConnected: true,
           currentSsid: 'Stone Frigate',
           hostIpAddress: '10.42.0.1',
+          hotspotProfilePresent: true,
+          hotspotAdapterApproved: true,
+          scanAdapterPresent: true,
+          hotspotDevice: 'wlxb8fbb3c4e8ae',
           hotspotSsid: 'Stone Frigate',
           hotspotScanDevice: 'wlp2s0',
           hotspotSsidVisibleFromLaptop: true,
@@ -242,6 +333,7 @@ describe('SystemStatusService', () => {
 
     expect(result.network.telemetryAvailable).toBe(false)
     expect(result.network.status).toBe('unknown')
+    expect(result.network.issueCode).toBe('telemetry_unavailable')
     expect(result.network.message).toBe('Host telemetry unavailable')
     expect(result.overall.status).toBe('warning')
   })
@@ -260,6 +352,7 @@ describe('SystemStatusService', () => {
 
     expect(result.network.telemetryAvailable).toBe(false)
     expect(result.network.status).toBe('healthy')
+    expect(result.network.issueCode).toBe('none')
     expect(result.network.message).toContain('Local development build detected')
     expect(result.overall.status).toBe('healthy')
   })

--- a/apps/backend/src/services/system-status-service.ts
+++ b/apps/backend/src/services/system-status-service.ts
@@ -1,5 +1,9 @@
 import type { PrismaClientInstance } from '@sentinel/database'
-import type { SystemHealthStatus, SystemStatusResponse } from '@sentinel/contracts'
+import type {
+  NetworkIssueCode,
+  SystemHealthStatus,
+  SystemStatusResponse,
+} from '@sentinel/contracts'
 import { prisma as defaultPrisma } from '@sentinel/database'
 import {
   activeRemoteSessions,
@@ -40,119 +44,149 @@ function resolveDatabaseAddress(): string | null {
   }
 }
 
-function resolveNetworkStatusMessage(input: {
+function normalizeTelemetryIssueCode(value: string | null): NetworkIssueCode {
+  switch (value) {
+    case 'telemetry_unavailable':
+    case 'telemetry_stale':
+    case 'wifi_disconnected':
+    case 'unapproved_ssid':
+    case 'hotspot_profile_missing':
+    case 'approved_hotspot_adapter_missing':
+    case 'scan_adapter_missing':
+    case 'hotspot_not_visible':
+    case 'remote_reachability_failed':
+      return value
+    default:
+      return 'none'
+  }
+}
+
+function resolveNetworkIssueCode(input: {
   telemetryAvailable: boolean
   developmentBuild: boolean
-  runningInsideContainer: boolean
   telemetryAgeSeconds: number | null
-  approvedSsidsConfigured: boolean
   wifiConnected: boolean | null
   approvedSsid: boolean | null
-  hotspotSsid: string | null
-  hotspotSsidVisibleFromLaptop: boolean | null
-  internetReachable: boolean | null
+  telemetryIssueCode: string | null
   remoteTarget: string | null
   remoteReachable: boolean | null
-  portalRecoveryLikely: boolean | null
-  fallbackMessage: string | null
-}): string {
+}): NetworkIssueCode {
   if (!input.telemetryAvailable) {
-    if (input.developmentBuild) {
-      if (input.runningInsideContainer) {
-        return 'Development build running in container; host telemetry checks are optional'
-      }
-
-      return 'Local development build detected on this laptop; host telemetry checks are optional'
-    }
-
-    return 'Host telemetry unavailable'
+    return input.developmentBuild ? 'none' : 'telemetry_unavailable'
   }
 
   if (
     input.telemetryAgeSeconds !== null &&
     input.telemetryAgeSeconds > TELEMETRY_STALE_WARNING_SECONDS
   ) {
-    return 'Host telemetry is stale'
+    return 'telemetry_stale'
   }
 
   if (input.wifiConnected === false) {
-    return 'Wi-Fi disconnected'
+    return 'wifi_disconnected'
   }
 
   if (input.approvedSsid === false) {
-    return 'Connected to an unapproved Wi-Fi SSID'
+    return 'unapproved_ssid'
   }
 
-  if (input.hotspotSsidVisibleFromLaptop === false) {
-    if (input.hotspotSsid) {
-      return `Hotspot SSID "${input.hotspotSsid}" is not visible from the laptop Wi-Fi adapter`
-    }
-
-    return 'Hosted hotspot SSID is not visible from the laptop Wi-Fi adapter'
+  const telemetryIssueCode = normalizeTelemetryIssueCode(input.telemetryIssueCode)
+  if (telemetryIssueCode !== 'none') {
+    return telemetryIssueCode
   }
 
   if (input.remoteTarget && input.remoteReachable === false) {
-    return `Remote reachability check failed for ${input.remoteTarget}`
+    return 'remote_reachability_failed'
   }
 
-  if (input.fallbackMessage) {
-    return input.fallbackMessage
+  return 'none'
+}
+
+function resolveNetworkStatusMessage(input: {
+  issueCode: NetworkIssueCode
+  telemetryAvailable: boolean
+  developmentBuild: boolean
+  runningInsideContainer: boolean
+  approvedSsidsConfigured: boolean
+  wifiConnected: boolean | null
+  approvedSsid: boolean | null
+  hotspotSsid: string | null
+  remoteTarget: string | null
+  fallbackMessage: string | null
+}): string {
+  if (!input.telemetryAvailable && input.developmentBuild) {
+    if (input.runningInsideContainer) {
+      return 'Development build running in container; host telemetry checks are optional'
+    }
+
+    return 'Local development build detected on this laptop; host telemetry checks are optional'
+  }
+
+  switch (input.issueCode) {
+    case 'telemetry_unavailable':
+      return 'Host telemetry unavailable'
+    case 'telemetry_stale':
+      return 'Host telemetry is stale'
+    case 'wifi_disconnected':
+      return 'Wi-Fi disconnected'
+    case 'unapproved_ssid':
+      return 'Connected to an unapproved Wi-Fi SSID'
+    case 'hotspot_profile_missing':
+      return 'The managed Sentinel hotspot profile is missing.'
+    case 'approved_hotspot_adapter_missing':
+      return 'No approved hotspot dongle is available on this laptop.'
+    case 'scan_adapter_missing':
+      return 'A second Wi-Fi radio is unavailable for hotspot verification.'
+    case 'hotspot_not_visible':
+      if (input.hotspotSsid) {
+        return `Hotspot SSID "${input.hotspotSsid}" is not visible from the laptop Wi-Fi adapter`
+      }
+
+      return 'Hosted hotspot SSID is not visible from the laptop Wi-Fi adapter'
+    case 'remote_reachability_failed':
+      return input.remoteTarget
+        ? `Remote reachability check failed for ${input.remoteTarget}`
+        : 'Remote reachability check failed'
+    case 'none':
+    default:
+      break
   }
 
   if (input.approvedSsidsConfigured && input.approvedSsid === true) {
     return 'Connected to approved Wi-Fi network'
   }
 
+  if (input.fallbackMessage) {
+    return input.fallbackMessage
+  }
+
+  if (input.wifiConnected === true) {
+    return 'Connected to Wi-Fi network'
+  }
+
   return 'Connected to Wi-Fi network'
 }
 
 function resolveNetworkStatus(input: {
+  issueCode: NetworkIssueCode
   telemetryAvailable: boolean
   developmentBuild: boolean
-  telemetryAgeSeconds: number | null
   wifiConnected: boolean | null
-  approvedSsid: boolean | null
-  hotspotSsidVisibleFromLaptop: boolean | null
-  internetReachable: boolean | null
-  remoteTarget: string | null
-  remoteReachable: boolean | null
 }): SystemHealthStatus {
-  if (!input.telemetryAvailable) {
-    if (input.developmentBuild) {
-      return 'healthy'
-    }
-
-    return 'unknown'
-  }
-
-  if (
-    input.telemetryAgeSeconds !== null &&
-    input.telemetryAgeSeconds > TELEMETRY_STALE_WARNING_SECONDS
-  ) {
-    return 'warning'
-  }
-
-  if (input.wifiConnected === false) {
-    return 'error'
-  }
-
-  if (input.approvedSsid === false) {
-    return 'warning'
-  }
-
-  if (input.hotspotSsidVisibleFromLaptop === false) {
-    return 'warning'
-  }
-
-  if (input.remoteTarget && input.remoteReachable === false) {
-    return 'warning'
-  }
-
-  if (input.wifiConnected === true) {
+  if (!input.telemetryAvailable && input.developmentBuild) {
     return 'healthy'
   }
 
-  return 'unknown'
+  switch (input.issueCode) {
+    case 'none':
+      return input.wifiConnected === true ? 'healthy' : 'unknown'
+    case 'telemetry_unavailable':
+      return 'unknown'
+    case 'wifi_disconnected':
+      return 'error'
+    default:
+      return 'warning'
+  }
 }
 
 function resolveOverallStatus(input: {
@@ -249,16 +283,21 @@ export class SystemStatusService {
           )
         : null
 
-    const networkStatus = resolveNetworkStatus({
+    const networkIssueCode = resolveNetworkIssueCode({
       telemetryAvailable: telemetry !== null,
       developmentBuild,
       telemetryAgeSeconds,
       wifiConnected: telemetry?.wifiConnected ?? null,
       approvedSsid,
-      hotspotSsidVisibleFromLaptop: telemetry?.hotspotSsidVisibleFromLaptop ?? null,
-      internetReachable: telemetry?.internetReachable ?? null,
+      telemetryIssueCode: telemetry?.issueCode ?? null,
       remoteTarget: telemetry?.remoteTarget ?? null,
       remoteReachable: telemetry?.remoteReachable ?? null,
+    })
+    const networkStatus = resolveNetworkStatus({
+      issueCode: networkIssueCode,
+      telemetryAvailable: telemetry !== null,
+      developmentBuild,
+      wifiConnected: telemetry?.wifiConnected ?? null,
     })
 
     if (networkStatus === 'warning' || networkStatus === 'error') {
@@ -289,25 +328,26 @@ export class SystemStatusService {
         status: networkStatus,
         telemetryAvailable: telemetry !== null,
         telemetryAgeSeconds,
+        issueCode: networkIssueCode,
         message: resolveNetworkStatusMessage({
+          issueCode: networkIssueCode,
           telemetryAvailable: telemetry !== null,
           developmentBuild,
           runningInsideContainer,
-          telemetryAgeSeconds,
           approvedSsidsConfigured: approvedSsids.length > 0,
           wifiConnected: telemetry?.wifiConnected ?? null,
           approvedSsid,
           hotspotSsid: telemetry?.hotspotSsid ?? null,
-          hotspotSsidVisibleFromLaptop: telemetry?.hotspotSsidVisibleFromLaptop ?? null,
-          internetReachable: telemetry?.internetReachable ?? null,
           remoteTarget: telemetry?.remoteTarget ?? null,
-          remoteReachable: telemetry?.remoteReachable ?? null,
-          portalRecoveryLikely: telemetry?.portalRecoveryLikely ?? null,
           fallbackMessage: telemetry?.message ?? null,
         }),
         wifiConnected: telemetry?.wifiConnected ?? null,
         currentSsid: telemetry?.currentSsid ?? null,
         hostIpAddress: telemetry?.hostIpAddress ?? null,
+        hotspotProfilePresent: telemetry?.hotspotProfilePresent ?? null,
+        hotspotAdapterApproved: telemetry?.hotspotAdapterApproved ?? null,
+        scanAdapterPresent: telemetry?.scanAdapterPresent ?? null,
+        hotspotDevice: telemetry?.hotspotDevice ?? null,
         hotspotSsid: telemetry?.hotspotSsid ?? null,
         hotspotScanDevice: telemetry?.hotspotScanDevice ?? null,
         hotspotSsidVisibleFromLaptop: telemetry?.hotspotSsidVisibleFromLaptop ?? null,

--- a/apps/backend/src/services/system-update-status-service.test.ts
+++ b/apps/backend/src/services/system-update-status-service.test.ts
@@ -1,0 +1,97 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SystemUpdateStatusService } from './system-update-status-service.js'
+
+describe('SystemUpdateStatusService', () => {
+  const tempDirs: string[] = []
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-23T15:35:00.000Z'))
+  })
+
+  afterEach(async () => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+
+    await Promise.all(tempDirs.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+  })
+
+  async function createService() {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'sentinel-system-update-status-'))
+    tempDirs.push(stateRoot)
+
+    return new SystemUpdateStatusService({
+      stateRoot,
+      applianceStatePath: join(stateRoot, 'missing-appliance-state.json'),
+      releaseRepository: 'DeadshotOMEGA/sentinel',
+      latestReleaseCacheTtlMs: 5 * 60 * 1000,
+      latestReleaseErrorCacheTtlMs: 60 * 1000,
+    })
+  }
+
+  it('caches successful latest release lookups between status polls', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new globalThis.Response(
+        JSON.stringify({
+          tag_name: 'v2.6.7',
+          html_url: 'https://github.com/DeadshotOMEGA/sentinel/releases/tag/v2.6.7',
+        }),
+        {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+        }
+      )
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const service = await createService()
+
+    const firstStatus = await service.getStatus()
+    const secondStatus = await service.getStatus()
+
+    expect(firstStatus.latestVersion).toBe('v2.6.7')
+    expect(secondStatus.latestVersion).toBe('v2.6.7')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1)
+    await service.getStatus()
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('caches rate-limited latest release failures until the GitHub reset window passes', async () => {
+    const rateLimitResetSeconds = Math.floor(Date.now() / 1000) + 120
+    const fetchMock = vi.fn().mockResolvedValue(
+      new globalThis.Response('API rate limit exceeded', {
+        status: 403,
+        headers: {
+          'x-ratelimit-remaining': '0',
+          'x-ratelimit-reset': String(rateLimitResetSeconds),
+        },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const service = await createService()
+
+    const firstStatus = await service.getStatus()
+    const secondStatus = await service.getStatus()
+
+    expect(firstStatus.latestVersion).toBeNull()
+    expect(secondStatus.latestVersion).toBeNull()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(60 * 1000)
+    await service.getStatus()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(61 * 1000)
+    await service.getStatus()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/backend/src/services/system-update-status-service.ts
+++ b/apps/backend/src/services/system-update-status-service.ts
@@ -12,10 +12,18 @@ import { isSystemUpdateJobTerminal, sanitizeSystemUpdateJob } from '../lib/syste
 const DEFAULT_STATE_ROOT = '/var/lib/sentinel/updater'
 const DEFAULT_APPLIANCE_STATE_PATH = '/var/lib/sentinel/appliance/state.json'
 const DEFAULT_RELEASE_API_BASE = 'https://api.github.com/repos'
+const DEFAULT_RELEASE_LOOKUP_CACHE_TTL_MS = 5 * 60 * 1000
+const DEFAULT_RELEASE_LOOKUP_ERROR_CACHE_TTL_MS = 60 * 1000
+const MAX_RELEASE_LOOKUP_ERROR_CACHE_TTL_MS = 60 * 60 * 1000
 
 interface LatestReleaseSummary {
   latestVersion: string | null
   latestReleaseUrl: string | null
+}
+
+interface LatestReleaseCacheEntry {
+  summary: LatestReleaseSummary
+  expiresAt: number
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -27,12 +35,18 @@ export class SystemUpdateStatusService {
   private readonly applianceStatePath: string
   private readonly releaseRepository: string
   private readonly releaseApiBase: string
+  private readonly latestReleaseCacheTtlMs: number
+  private readonly latestReleaseErrorCacheTtlMs: number
+  private latestReleaseCache: LatestReleaseCacheEntry | null = null
+  private latestReleaseRequest: Promise<LatestReleaseSummary> | null = null
 
   constructor(options?: {
     stateRoot?: string
     applianceStatePath?: string
     releaseRepository?: string
     releaseApiBase?: string
+    latestReleaseCacheTtlMs?: number
+    latestReleaseErrorCacheTtlMs?: number
   }) {
     this.stateRoot =
       options?.stateRoot ?? process.env.SYSTEM_UPDATE_STATE_ROOT ?? DEFAULT_STATE_ROOT
@@ -48,6 +62,10 @@ export class SystemUpdateStatusService {
       options?.releaseApiBase ??
       process.env.SYSTEM_UPDATE_RELEASE_API_BASE ??
       DEFAULT_RELEASE_API_BASE
+    this.latestReleaseCacheTtlMs =
+      options?.latestReleaseCacheTtlMs ?? DEFAULT_RELEASE_LOOKUP_CACHE_TTL_MS
+    this.latestReleaseErrorCacheTtlMs =
+      options?.latestReleaseErrorCacheTtlMs ?? DEFAULT_RELEASE_LOOKUP_ERROR_CACHE_TTL_MS
   }
 
   async getStatus(): Promise<SystemUpdateStatusResponse> {
@@ -158,6 +176,34 @@ export class SystemUpdateStatusService {
       }
     }
 
+    const cachedEntry = this.latestReleaseCache
+    if (cachedEntry && cachedEntry.expiresAt > Date.now()) {
+      return cachedEntry.summary
+    }
+
+    if (this.latestReleaseRequest) {
+      return this.latestReleaseRequest
+    }
+
+    this.latestReleaseRequest = this.fetchLatestReleaseSummaryUncached(repository)
+      .then(({ summary, cacheTtlMs }) => {
+        this.latestReleaseCache = {
+          summary,
+          expiresAt: Date.now() + cacheTtlMs,
+        }
+
+        return summary
+      })
+      .finally(() => {
+        this.latestReleaseRequest = null
+      })
+
+    return this.latestReleaseRequest
+  }
+
+  private async fetchLatestReleaseSummaryUncached(
+    repository: string
+  ): Promise<{ summary: LatestReleaseSummary; cacheTtlMs: number }> {
     try {
       const response = await globalThis.fetch(
         `${this.releaseApiBase.replace(/\/+$/, '')}/${repository}/releases/latest`,
@@ -177,16 +223,22 @@ export class SystemUpdateStatusService {
         })
 
         return {
-          latestVersion: null,
-          latestReleaseUrl: null,
+          summary: {
+            latestVersion: null,
+            latestReleaseUrl: null,
+          },
+          cacheTtlMs: this.getReleaseLookupErrorCacheTtl(response),
         }
       }
 
       const payload: unknown = await response.json()
       if (!isRecord(payload)) {
         return {
-          latestVersion: null,
-          latestReleaseUrl: null,
+          summary: {
+            latestVersion: null,
+            latestReleaseUrl: null,
+          },
+          cacheTtlMs: this.latestReleaseCacheTtlMs,
         }
       }
 
@@ -195,8 +247,11 @@ export class SystemUpdateStatusService {
       const latestReleaseUrl = typeof payload.html_url === 'string' ? payload.html_url : null
 
       return {
-        latestVersion,
-        latestReleaseUrl,
+        summary: {
+          latestVersion,
+          latestReleaseUrl,
+        },
+        cacheTtlMs: this.latestReleaseCacheTtlMs,
       }
     } catch (error) {
       serviceLogger.warn('Latest Sentinel release lookup raised an error', {
@@ -205,10 +260,35 @@ export class SystemUpdateStatusService {
       })
 
       return {
-        latestVersion: null,
-        latestReleaseUrl: null,
+        summary: {
+          latestVersion: null,
+          latestReleaseUrl: null,
+        },
+        cacheTtlMs: this.latestReleaseErrorCacheTtlMs,
       }
     }
+  }
+
+  private getReleaseLookupErrorCacheTtl(response: globalThis.Response): number {
+    if (response.status !== 403 || response.headers.get('x-ratelimit-remaining') !== '0') {
+      return this.latestReleaseErrorCacheTtlMs
+    }
+
+    const resetRaw = response.headers.get('x-ratelimit-reset')
+    const resetSeconds = Number.parseInt(resetRaw ?? '', 10)
+    if (Number.isNaN(resetSeconds)) {
+      return this.latestReleaseErrorCacheTtlMs
+    }
+
+    const resetDelayMs = resetSeconds * 1000 - Date.now()
+    if (resetDelayMs <= 0) {
+      return this.latestReleaseErrorCacheTtlMs
+    }
+
+    return Math.max(
+      this.latestReleaseErrorCacheTtlMs,
+      Math.min(resetDelayMs, MAX_RELEASE_LOOKUP_ERROR_CACHE_TTL_MS)
+    )
   }
 
   private async readApplianceCurrentVersion(): Promise<string | null> {

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "2.6.7",
+  "version": "2.7.0",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/components/layout/app-navbar.logic.test.ts
+++ b/apps/frontend-admin/src/components/layout/app-navbar.logic.test.ts
@@ -24,9 +24,14 @@ function createSystemStatus(overrides?: Partial<SystemStatusResponse>): SystemSt
       telemetryAvailable: true,
       telemetryAgeSeconds: 5,
       message: 'Connected to approved Wi-Fi network',
+      issueCode: 'none',
       wifiConnected: true,
       currentSsid: 'Stone Frigate',
       hostIpAddress: '192.168.8.1',
+      hotspotProfilePresent: true,
+      hotspotAdapterApproved: true,
+      scanAdapterPresent: true,
+      hotspotDevice: 'wlxb8fbb3c4e8ae',
       hotspotSsid: 'Stone Frigate',
       hotspotScanDevice: 'wlp2s0',
       hotspotSsidVisibleFromLaptop: true,
@@ -73,6 +78,7 @@ describe('app-navbar logic', () => {
         network: {
           ...createSystemStatus().network,
           status: 'error',
+          issueCode: 'wifi_disconnected',
           wifiConnected: false,
         },
       }),
@@ -82,9 +88,7 @@ describe('app-navbar logic', () => {
     })
 
     expect(result.showConnectLaptop).toBe(true)
-    expect(result.connectLaptopHref).toBe(
-      'sentinel-hotspot://connect?ssid=Stone%20Frigate'
-    )
+    expect(result.connectLaptopHref).toBe('sentinel-hotspot://connect?ssid=Stone%20Frigate')
   })
 
   it('gates host hotspot repair to admin-capable users', () => {
@@ -112,6 +116,7 @@ describe('app-navbar logic', () => {
       systemStatus: createSystemStatus({
         network: {
           ...createSystemStatus().network,
+          issueCode: 'hotspot_not_visible',
           hotspotSsidVisibleFromLaptop: false,
         },
       }),

--- a/apps/frontend-admin/src/components/layout/app-navbar.logic.ts
+++ b/apps/frontend-admin/src/components/layout/app-navbar.logic.ts
@@ -6,6 +6,7 @@ export interface WirelessRecoveryState {
   connectLaptopHref: string | null
   showRepairHostHotspot: boolean
   primaryApprovedSsid: string | null
+  issueCode: SystemStatusResponse['network']['issueCode'] | null
 }
 
 export function getWirelessRecoveryState(input: {
@@ -16,11 +17,12 @@ export function getWirelessRecoveryState(input: {
 }): WirelessRecoveryState {
   const { systemStatus, isLoading, isError, hasAdminAccess } = input
   const primaryApprovedSsid = systemStatus?.network.approvedSsids[0] ?? null
+  const issueCode = systemStatus?.network.issueCode ?? null
   const showConnectLaptop =
     !isLoading &&
     !isError &&
     systemStatus !== null &&
-    (systemStatus.network.wifiConnected === false || systemStatus.network.approvedSsid === false)
+    (issueCode === 'wifi_disconnected' || issueCode === 'unapproved_ssid')
   const connectLaptopHref =
     showConnectLaptop && primaryApprovedSsid
       ? `sentinel-hotspot://connect?ssid=${encodeURIComponent(primaryApprovedSsid)}`
@@ -30,7 +32,11 @@ export function getWirelessRecoveryState(input: {
     !isLoading &&
     !isError &&
     systemStatus !== null &&
-    systemStatus.network.hotspotSsidVisibleFromLaptop === false
+    (issueCode === 'hotspot_not_visible' ||
+      issueCode === 'hotspot_profile_missing' ||
+      issueCode === 'approved_hotspot_adapter_missing' ||
+      issueCode === 'scan_adapter_missing' ||
+      issueCode === 'telemetry_unavailable')
 
   return {
     showSection: showConnectLaptop || showRepairHostHotspot || hotspotVisibilityIssue,
@@ -38,5 +44,6 @@ export function getWirelessRecoveryState(input: {
     connectLaptopHref,
     showRepairHostHotspot,
     primaryApprovedSsid,
+    issueCode,
   }
 }

--- a/apps/frontend-admin/src/components/layout/app-navbar.tsx
+++ b/apps/frontend-admin/src/components/layout/app-navbar.tsx
@@ -40,7 +40,6 @@ interface AppNavbarProps {
 
 const WIKI_LAN_FALLBACK_PORT = '3020'
 const WIKI_LOCAL_DEV_PORT = '3002'
-const NETWORK_TELEMETRY_STALE_WARNING_SECONDS = 120
 const DEPLOYMENT_REMOTE_SYSTEM_CODE = 'deployment_laptop'
 
 export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
@@ -305,6 +304,12 @@ export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
                 <p className="mt-1 text-xs leading-relaxed">{networkMessage}</p>
                 <dl className="mt-2 space-y-1 text-[11px] text-current/80">
                   <div className="flex items-center justify-between gap-2">
+                    <dt>Issue</dt>
+                    <dd className="font-mono text-right">
+                      {formatNetworkIssueLabel(systemStatus?.network.issueCode ?? null)}
+                    </dd>
+                  </div>
+                  <div className="flex items-center justify-between gap-2">
                     <dt>Host IP</dt>
                     <dd className="font-mono text-right">
                       {systemStatus?.network.hostIpAddress ?? 'Unavailable'}
@@ -315,6 +320,20 @@ export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
                     <dd className="font-mono text-right">
                       {systemStatus?.network.approvedSsids[0] ?? 'Not configured'}
                     </dd>
+                  </div>
+                  <div className="flex items-center justify-between gap-2">
+                    <dt>AP profile</dt>
+                    <dd className="font-mono text-right">
+                      {formatHotspotProfilePresence(systemStatus)}
+                    </dd>
+                  </div>
+                  <div className="flex items-center justify-between gap-2">
+                    <dt>AP adapter</dt>
+                    <dd className="font-mono text-right">{formatHotspotAdapter(systemStatus)}</dd>
+                  </div>
+                  <div className="flex items-center justify-between gap-2">
+                    <dt>Scan radio</dt>
+                    <dd className="font-mono text-right">{formatScanRadio(systemStatus)}</dd>
                   </div>
                   <div className="flex items-center justify-between gap-2">
                     <dt>AP visibility</dt>
@@ -380,8 +399,12 @@ export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
                 >
                   <p className="text-xs font-semibold uppercase tracking-wide">Wireless Recovery</p>
                   <p className="mt-1 text-xs leading-relaxed">
-                    Reconnect this laptop to the approved hotspot SSID, or ask the host server to
-                    requeue a hotspot repair.
+                    {getWirelessRecoveryCopy(
+                      systemStatus,
+                      isStatusLoading,
+                      systemStatusQuery.isError,
+                      wirelessRecovery.primaryApprovedSsid
+                    )}
                   </p>
                   <div className="mt-2 flex flex-wrap gap-(--space-2)">
                     {wirelessRecovery.connectLaptopHref ? (
@@ -493,7 +516,89 @@ function formatUptime(uptimeSeconds: number | undefined): string {
   return `${minutes}m`
 }
 
+function formatNetworkIssueLabel(
+  issueCode: SystemStatusResponse['network']['issueCode'] | null
+): string {
+  switch (issueCode) {
+    case 'telemetry_unavailable':
+      return 'Telemetry unavailable'
+    case 'telemetry_stale':
+      return 'Telemetry stale'
+    case 'wifi_disconnected':
+      return 'Wi-Fi disconnected'
+    case 'unapproved_ssid':
+      return 'Wrong SSID'
+    case 'hotspot_profile_missing':
+      return 'Profile missing'
+    case 'approved_hotspot_adapter_missing':
+      return 'AP dongle missing'
+    case 'scan_adapter_missing':
+      return 'Scan radio missing'
+    case 'hotspot_not_visible':
+      return 'AP not visible'
+    case 'remote_reachability_failed':
+      return 'Remote check failed'
+    case 'none':
+      return 'None'
+    default:
+      return 'Unknown'
+  }
+}
+
+function formatHotspotProfilePresence(systemStatus: SystemStatusResponse | null): string {
+  const value = systemStatus?.network.hotspotProfilePresent ?? null
+  if (value === true) {
+    return 'Present'
+  }
+  if (value === false) {
+    return 'Missing'
+  }
+  return 'Unknown'
+}
+
+function formatHotspotAdapter(systemStatus: SystemStatusResponse | null): string {
+  const network = systemStatus?.network
+  if (!network) {
+    return 'Unknown'
+  }
+
+  if (network.hotspotAdapterApproved === true) {
+    return network.hotspotDevice ?? 'Approved'
+  }
+
+  if (network.hotspotDevice) {
+    return `${network.hotspotDevice} (unapproved)`
+  }
+
+  if (network.hotspotAdapterApproved === false) {
+    return 'Unavailable'
+  }
+
+  return 'Unknown'
+}
+
+function formatScanRadio(systemStatus: SystemStatusResponse | null): string {
+  const network = systemStatus?.network
+  if (!network) {
+    return 'Unknown'
+  }
+
+  if (network.scanAdapterPresent === true) {
+    return network.hotspotScanDevice ?? 'Available'
+  }
+
+  if (network.scanAdapterPresent === false) {
+    return 'Unavailable'
+  }
+
+  return 'Unknown'
+}
+
 function formatHotspotVisibility(systemStatus: SystemStatusResponse | null): string {
+  if (systemStatus?.network.scanAdapterPresent === false) {
+    return 'Check unavailable'
+  }
+
   const visibility = systemStatus?.network.hotspotSsidVisibleFromLaptop ?? null
   if (visibility === true) {
     return 'Visible'
@@ -502,6 +607,42 @@ function formatHotspotVisibility(systemStatus: SystemStatusResponse | null): str
     return 'Not visible'
   }
   return 'Check unavailable'
+}
+
+function getWirelessRecoveryCopy(
+  systemStatus: SystemStatusResponse | null,
+  isLoading: boolean,
+  isError: boolean,
+  primaryApprovedSsid: string | null
+): string {
+  if (isLoading) {
+    return 'Checking host hotspot telemetry and verification state.'
+  }
+
+  if (isError || !systemStatus) {
+    return 'Unable to load the current host hotspot state right now.'
+  }
+
+  const approvedSsidLabel =
+    primaryApprovedSsid ?? systemStatus.network.hotspotSsid ?? 'the approved hotspot'
+  switch (systemStatus.network.issueCode) {
+    case 'wifi_disconnected':
+      return `Reconnect this laptop to ${approvedSsidLabel}, then requeue a host repair if the hotspot still needs attention.`
+    case 'unapproved_ssid':
+      return `This laptop is on the wrong SSID. Reconnect it to ${approvedSsidLabel}, or requeue a host repair if the hotspot needs to be rebuilt.`
+    case 'hotspot_profile_missing':
+      return 'The host server is missing the managed hotspot profile. Requeue a host repair to recreate it.'
+    case 'approved_hotspot_adapter_missing':
+      return 'The host server cannot find an approved AP dongle. Re-seat the external adapter, then requeue a host repair.'
+    case 'scan_adapter_missing':
+      return 'Hotspot hosting is configured, but Sentinel cannot verify visibility because no second Wi-Fi radio is available.'
+    case 'hotspot_not_visible':
+      return `Sentinel cannot see ${approvedSsidLabel} from the scan radio yet. Requeue a host repair after checking the AP dongle seating.`
+    case 'telemetry_unavailable':
+      return 'The host telemetry snapshot is unavailable. Requeue a host repair to reprovision the hotspot and refresh telemetry.'
+    default:
+      return 'Reconnect this laptop to the approved hotspot SSID, or ask the host server to requeue a hotspot repair.'
+  }
 }
 
 function resolveRemoteSystemIpAddress(
@@ -838,25 +979,49 @@ function getNetworkTooltip(
 
   let reason = `Yellow because ${network.message}.`
 
-  if (!network.telemetryAvailable) {
-    reason = isDevelopmentEnvironment
-      ? 'Green because this is a development build and host telemetry is optional.'
-      : 'Yellow because host telemetry is unavailable.'
-  } else if (
-    network.telemetryAgeSeconds !== null &&
-    network.telemetryAgeSeconds > NETWORK_TELEMETRY_STALE_WARNING_SECONDS
+  switch (network.issueCode) {
+    case 'telemetry_unavailable':
+      reason = isDevelopmentEnvironment
+        ? 'Green because this is a development build and host telemetry is optional.'
+        : 'Yellow because host telemetry is unavailable.'
+      break
+    case 'telemetry_stale':
+      reason = `Yellow because the host network snapshot is stale (${formatTelemetryAge(network.telemetryAgeSeconds)}).`
+      break
+    case 'wifi_disconnected':
+      reason = 'Red because Wi-Fi is disconnected.'
+      break
+    case 'unapproved_ssid':
+      reason = `Yellow because "${currentSsid}" is not in the approved Wi-Fi allowlist.`
+      break
+    case 'hotspot_profile_missing':
+      reason = 'Yellow because the managed host hotspot profile is missing.'
+      break
+    case 'approved_hotspot_adapter_missing':
+      reason = 'Yellow because no approved AP dongle is available for the hosted hotspot.'
+      break
+    case 'scan_adapter_missing':
+      reason =
+        'Yellow because Sentinel cannot find a second Wi-Fi radio to verify hotspot visibility.'
+      break
+    case 'hotspot_not_visible': {
+      const hotspotSsidLabel = network.hotspotSsid ?? 'approved hotspot'
+      reason = `Yellow because "${hotspotSsidLabel}" is not visible from the laptop Wi-Fi adapter.`
+      break
+    }
+    case 'remote_reachability_failed':
+      reason = `Yellow because the remote reachability check to ${network.remoteTarget} failed.`
+      break
+    case 'none':
+    default:
+      break
+  }
+
+  if (
+    network.issueCode === 'none' &&
+    network.telemetryAvailable &&
+    network.wifiConnected === true
   ) {
-    reason = `Yellow because the host network snapshot is stale (${formatTelemetryAge(network.telemetryAgeSeconds)}).`
-  } else if (network.wifiConnected === false) {
-    reason = 'Red because Wi-Fi is disconnected.'
-  } else if (network.approvedSsid === false) {
-    reason = `Yellow because "${currentSsid}" is not in the approved Wi-Fi allowlist.`
-  } else if (network.hotspotSsidVisibleFromLaptop === false) {
-    const hotspotSsidLabel = network.hotspotSsid ?? 'approved hotspot'
-    reason = `Yellow because "${hotspotSsidLabel}" is not visible from the laptop Wi-Fi adapter.`
-  } else if (network.remoteTarget && network.remoteReachable === false) {
-    reason = `Yellow because the remote reachability check to ${network.remoteTarget} failed.`
-  } else if (network.telemetryAvailable && network.wifiConnected === true) {
     if (network.approvedSsids.length === 0) {
       reason = 'Green because Wi-Fi is connected and no approved SSID allowlist is configured.'
     } else if (network.approvedSsid === true) {
@@ -869,8 +1034,12 @@ function getNetworkTooltip(
   return joinTooltipLines([
     reason,
     `Detail: ${network.message}`,
+    `Issue: ${formatNetworkIssueLabel(network.issueCode)}`,
     `SSID: ${currentSsid}`,
     `Approved SSIDs: ${approvedSsids}`,
+    `AP profile: ${formatHotspotProfilePresence(systemStatus)}`,
+    `AP adapter: ${formatHotspotAdapter(systemStatus)}`,
+    `Scan radio: ${formatScanRadio(systemStatus)}`,
     `AP visibility: ${formatBooleanLabel(network.hotspotSsidVisibleFromLaptop)}`,
     `Remote target: ${remoteTarget}`,
     `Remote reachable: ${formatBooleanLabel(network.remoteReachable)}`,

--- a/apps/frontend-admin/src/components/settings/system-update-panel.logic.test.ts
+++ b/apps/frontend-admin/src/components/settings/system-update-panel.logic.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import type { SystemUpdateJob, SystemUpdateStatusResponse } from '@sentinel/contracts'
+import {
+  getPreferredUpdateTargetVersion,
+  getRetryableTargetVersion,
+} from './system-update-panel.logic'
+
+function createJob(overrides?: Partial<SystemUpdateJob>): SystemUpdateJob {
+  return {
+    jobId: 'system-update-1776956219166-5526cce8-8dc0-4e25-b3d3-15fc7edf398c',
+    status: 'failed',
+    step: 'failed',
+    message: 'Update failed',
+    requestedAt: '2026-04-23T10:33:21Z',
+    startedAt: '2026-04-23T10:33:25Z',
+    finishedAt: '2026-04-23T10:33:40Z',
+    currentVersion: 'v2.6.6',
+    latestVersion: null,
+    targetVersion: 'v2.6.7',
+    failureSummary: 'Release metadata request failed with HTTP 403',
+    rollbackAttempted: false,
+    requestedBy: {
+      memberId: 'member-1',
+      memberName: 'MS Courtney Sauk',
+      accountLevel: 5,
+      fromIp: '127.0.0.1',
+    },
+    ...overrides,
+  }
+}
+
+function createStatus(
+  overrides?: Partial<Pick<SystemUpdateStatusResponse, 'currentVersion' | 'latestVersion'>>
+): Pick<SystemUpdateStatusResponse, 'currentVersion' | 'latestVersion'> {
+  return {
+    currentVersion: 'v2.6.6',
+    latestVersion: 'v2.6.8',
+    ...overrides,
+  }
+}
+
+describe('system-update-panel logic', () => {
+  it('prefers the latest known release when it is available', () => {
+    const targetVersion = getPreferredUpdateTargetVersion(createStatus(), createJob())
+
+    expect(targetVersion).toBe('v2.6.8')
+  })
+
+  it('retries the last failed target when latest lookup is unavailable', () => {
+    const targetVersion = getPreferredUpdateTargetVersion(
+      createStatus({ latestVersion: null }),
+      createJob()
+    )
+
+    expect(targetVersion).toBe('v2.6.7')
+  })
+
+  it('does not retry a failed target that is not newer than the installed version', () => {
+    const targetVersion = getRetryableTargetVersion(
+      createJob({ targetVersion: 'v2.6.6' }),
+      'v2.6.6'
+    )
+
+    expect(targetVersion).toBeNull()
+  })
+})

--- a/apps/frontend-admin/src/components/settings/system-update-panel.logic.ts
+++ b/apps/frontend-admin/src/components/settings/system-update-panel.logic.ts
@@ -1,0 +1,66 @@
+import type { SystemUpdateJob, SystemUpdateStatusResponse } from '@sentinel/contracts'
+
+const RETRYABLE_STATUSES = new Set<SystemUpdateJob['status']>([
+  'failed',
+  'rollback_attempted',
+  'rolled_back',
+])
+
+function compareVersionTags(left: string, right: string): number {
+  const parse = (tag: string): [number, number, number] => {
+    const cleaned = tag.startsWith('v') ? tag.slice(1) : tag
+    const [majorRaw, minorRaw, patchRaw] = cleaned.split('.')
+
+    const major = Number.parseInt(majorRaw ?? '0', 10)
+    const minor = Number.parseInt(minorRaw ?? '0', 10)
+    const patch = Number.parseInt(patchRaw ?? '0', 10)
+
+    return [
+      Number.isNaN(major) ? 0 : major,
+      Number.isNaN(minor) ? 0 : minor,
+      Number.isNaN(patch) ? 0 : patch,
+    ]
+  }
+
+  const leftParts = parse(left)
+  const rightParts = parse(right)
+
+  for (let index = 0; index < leftParts.length; index += 1) {
+    const leftPart = leftParts[index]
+    const rightPart = rightParts[index]
+    if (leftPart === undefined || rightPart === undefined) {
+      continue
+    }
+
+    const delta = leftPart - rightPart
+    if (delta !== 0) {
+      return delta
+    }
+  }
+
+  return 0
+}
+
+export function getRetryableTargetVersion(
+  currentJob: SystemUpdateJob | null,
+  currentVersion: string | null
+): string | null {
+  if (!currentJob || !RETRYABLE_STATUSES.has(currentJob.status)) {
+    return null
+  }
+
+  if (!currentVersion) {
+    return currentJob.targetVersion
+  }
+
+  return compareVersionTags(currentJob.targetVersion, currentVersion) > 0
+    ? currentJob.targetVersion
+    : null
+}
+
+export function getPreferredUpdateTargetVersion(
+  status: Pick<SystemUpdateStatusResponse, 'currentVersion' | 'latestVersion'>,
+  currentJob: SystemUpdateJob | null
+): string | null {
+  return status.latestVersion ?? getRetryableTargetVersion(currentJob, status.currentVersion)
+}

--- a/apps/frontend-admin/src/components/settings/system-update-panel.tsx
+++ b/apps/frontend-admin/src/components/settings/system-update-panel.tsx
@@ -30,6 +30,7 @@ import {
 } from '@/hooks/use-system-update'
 import { TID } from '@/lib/test-ids'
 import { AccountLevel, useAuthStore } from '@/store/auth-store'
+import { getPreferredUpdateTargetVersion } from './system-update-panel.logic'
 
 const PRIMARY_FLOW: readonly SystemUpdateJobStatus[] = [
   'requested',
@@ -256,10 +257,24 @@ export function SystemUpdatePanel() {
   const currentJob = status?.currentJob ?? null
   const hasActiveJob = currentJob ? !isTerminalStatus(currentJob.status) : false
   const autoOpenTraceLog = shouldAutoOpenTraceLog(currentJob)
+  const preferredTargetVersion = status ? getPreferredUpdateTargetVersion(status, currentJob) : null
+  const retryingLastTarget =
+    status !== null && status.latestVersion === null && preferredTargetVersion !== null
+  const startActionLabel =
+    preferredTargetVersion === null
+      ? 'Update to latest'
+      : retryingLastTarget
+        ? `Retry ${preferredTargetVersion}`
+        : `Update to ${preferredTargetVersion}`
+  const confirmActionLabel =
+    preferredTargetVersion === null
+      ? 'Start update'
+      : retryingLastTarget
+        ? `Retry ${preferredTargetVersion}`
+        : `Start update to ${preferredTargetVersion}`
   const canStartNow =
     canStartUpdates &&
-    status?.updateAvailable === true &&
-    status.latestVersion !== null &&
+    preferredTargetVersion !== null &&
     !hasActiveJob &&
     !startSystemUpdate.isPending
   const traceQuery = useSystemUpdateTrace({
@@ -287,13 +302,13 @@ export function SystemUpdatePanel() {
   }
 
   const handleStartUpdate = async () => {
-    if (!status?.latestVersion) {
+    if (!preferredTargetVersion) {
       return
     }
 
     try {
       const result = await startSystemUpdate.mutateAsync({
-        targetVersion: status.latestVersion,
+        targetVersion: preferredTargetVersion,
       })
       setConfirmOpen(false)
       toast.success(result.message)
@@ -376,7 +391,7 @@ export function SystemUpdatePanel() {
                 disabled={!canStartNow}
                 data-testid={TID.settings.updates.start}
               >
-                Update to {status.latestVersion ?? 'latest'}
+                {startActionLabel}
               </button>
             </div>
           </div>
@@ -395,6 +410,13 @@ export function SystemUpdatePanel() {
             <AppAlert tone="warning" heading="Admin or Developer access required">
               You can view update status here, but only Admin or Developer accounts can start a new
               Sentinel update.
+            </AppAlert>
+          )}
+
+          {retryingLastTarget && currentJob && (
+            <AppAlert tone="info" heading="Retry target is still available">
+              Latest release lookup is temporarily unavailable, but you can retry the last requested
+              target {currentJob.targetVersion} from this page.
             </AppAlert>
           )}
 
@@ -784,8 +806,8 @@ export function SystemUpdatePanel() {
             <DialogTitle>Start Sentinel update</DialogTitle>
             <DialogDescription>
               This will ask the host appliance updater to install{' '}
-              {status.latestVersion ?? 'the latest stable release'}. The UI may reconnect while
-              services restart, but the update will keep running on the appliance.
+              {preferredTargetVersion ?? 'the selected Sentinel release'}. The UI may reconnect
+              while services restart, but the update will keep running on the appliance.
             </DialogDescription>
           </DialogHeader>
 
@@ -800,7 +822,7 @@ export function SystemUpdatePanel() {
               <div className="text-xs font-semibold uppercase tracking-wide text-base-content/60">
                 Target version
               </div>
-              <div className="mt-1 font-mono">{status.latestVersion ?? 'Unknown'}</div>
+              <div className="mt-1 font-mono">{preferredTargetVersion ?? 'Unknown'}</div>
             </div>
             <AppAlert tone="info">
               No root or sudo password should be requested here. Sentinel will hand the request to
@@ -831,7 +853,7 @@ export function SystemUpdatePanel() {
                   Starting...
                 </>
               ) : (
-                `Start update to ${status.latestVersion ?? 'latest'}`
+                confirmActionLabel
               )}
             </button>
           </DialogFooter>

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -61,6 +61,9 @@ SENTINEL_AUTO_SEED_RETRY_DELAY_MS=3000
 
 # Hotspot/runtime helpers
 HOTSPOT_CONNECTION_NAME=Sentinel Hotspot
+HOTSPOT_SSID=Stone Frigate
+HOTSPOT_PSK=replace-this-fixed-hotspot-password
+HOTSPOT_APPROVED_DONGLES_FILE=hardware/approved-hotspot-dongles.json
 NETWORK_REACHABILITY_CHECK_URL=https://connectivitycheck.gstatic.com/generate_204
 # Optional: set a host or URL to require in addition to general internet access.
 # Examples:

--- a/deploy/README_DEPLOY.md
+++ b/deploy/README_DEPLOY.md
@@ -61,7 +61,7 @@ sentinel-install-update
 1. Open the `deploy` folder in Files.
 2. Double-click `Sentinel Install and Update.desktop`.
 3. If Ubuntu prompts, choose **Allow Launching**.
-4. A terminal window opens and prompts for the version number to install or update (example: `1.1.8`).
+4. A guided Zenity wizard asks whether you are installing or updating, confirms the target release, and runs hotspot preflight before Sentinel starts the long-running install/update work in the terminal.
 
 ### Terminal fallback
 
@@ -112,6 +112,9 @@ Port defaults in `.env`:
 - `KROKI_SERVER_URL=http://kroki:8000` (internal Wiki.js renderer target)
 - `WIKI_LAN_PORT=3020` (only used if `--allow-wiki-lan`)
 - `HOTSPOT_CONNECTION_NAME=Sentinel Hotspot` (NetworkManager profile name for the hosted hotspot)
+- `HOTSPOT_SSID=Stone Frigate` (canonical hosted SSID Sentinel will create/repair)
+- `HOTSPOT_PSK=...` (fixed hotspot password supplied by the release package or operator-managed `.env`)
+- `HOTSPOT_APPROVED_DONGLES_FILE=hardware/approved-hotspot-dongles.json` (approved external AP dongle allowlist)
 - `NETWORK_REACHABILITY_CHECK_URL=https://connectivitycheck.gstatic.com/generate_204` (host-level internet probe)
 - `NETWORK_REMOTE_REACHABILITY_TARGET=` optional extra reachability target, such as a Tailscale IP or HTTPS health URL
 - `NETWORK_STATUS_SNAPSHOT_INTERVAL_SECONDS=30` (how often the Ubuntu host writes Wi-Fi/internet telemetry for Sentinel)
@@ -152,6 +155,8 @@ If install reports GHCR unreachable:
 
 Install/update now provisions hotspot and update helpers:
 
+- supported hotspot hosting expects exactly one approved external AP dongle plus a second Wi-Fi radio for verification
+- a canonical `ensure-host-hotspot-profile.sh` helper that detects approved AP dongles, creates or repairs the managed `Sentinel Hotspot` profile, and keeps the profile bound to the correct adapter
 - a local `sentinel-hotspot://connect?ssid=<approved-ssid>` URL handler that tries to reconnect the current laptop to the approved hotspot, then falls back to Wi-Fi settings
 - a host-side recovery queue watched by systemd so the webapp can ask the deployment server to repair the hosted hotspot without interactive root access
 - a managed sudoers entry for the desktop operator account so hotspot recovery commands can be run non-interactively (no password prompt) when needed
@@ -160,6 +165,7 @@ Install/update now provisions hotspot and update helpers:
 Relevant runtime paths:
 
 - local reconnect handler: `/opt/sentinel/deploy/sentinel-hotspot-connect.sh`
+- canonical hotspot helper: `/opt/sentinel/deploy/ensure-host-hotspot-profile.sh`
 - queued recovery requests: `/opt/sentinel/deploy/runtime/hotspot-recovery/requests`
 - processed requests: `/opt/sentinel/deploy/runtime/hotspot-recovery/processed`
 - failed requests: `/opt/sentinel/deploy/runtime/hotspot-recovery/failed`
@@ -183,6 +189,10 @@ What it checks:
 - whether Wi-Fi is connected
 - the current SSID
 - the host IP address that operators can use on the local hotspot/LAN
+- whether the managed hotspot profile exists
+- whether an approved AP dongle is present
+- whether a second Wi-Fi radio is available for hotspot verification
+- which hotspot adapter and scan adapter Sentinel selected
 - whether the configured Sentinel hotspot SSID is visible from the laptop's non-host Wi-Fi adapter (when available)
 - whether the configured internet reachability URL succeeds
 - whether the optional `NETWORK_REMOTE_REACHABILITY_TARGET` is reachable
@@ -207,7 +217,7 @@ systemd units installed during install/update/rollback:
 
 1. Open `/opt/sentinel/deploy` in Files.
 2. Double-click `Sentinel Install and Update.desktop`.
-3. Enter the target Sentinel version when prompted in the terminal.
+3. Follow the guided wizard for release selection, hotspot preflight, and recovery choices before Sentinel starts the terminal-driven install/update run.
 
 ### Terminal fallback
 
@@ -218,10 +228,11 @@ cd /opt/sentinel/deploy
 
 This guided flow handles both install and update:
 
-- prompts for the release version,
+- prompts for the workflow and release version,
+- runs hotspot provisioning/recovery preflight with explicit retry/continue/cancel choices,
 - downloads the matching Debian package from GitHub Releases,
 - installs the package,
-- runs `/opt/sentinel/deploy/update.sh --version vX.Y.Z`.
+- runs `/opt/sentinel/deploy/update.sh --version vX.Y.Z`, including shared hotspot recovery.
 - `--no-firewall`
 
 ## Automatic upgrade helper

--- a/deploy/Sentinel Install and Update.desktop
+++ b/deploy/Sentinel Install and Update.desktop
@@ -2,7 +2,7 @@
 Version=1.0
 Type=Application
 Name=Sentinel Install and Update
-Comment=Install or update Sentinel with a guided terminal prompt
+Comment=Install or update Sentinel with a guided hotspot and release wizard
 Exec=sh -c 'cd "$(dirname "%k")" && ./sentinel-install-update-launcher.sh'
 Icon=sentinel-appliance
 Terminal=true

--- a/deploy/_common.sh
+++ b/deploy/_common.sh
@@ -449,6 +449,18 @@ bootstrap_env_defaults() {
     upsert_env "HOTSPOT_CONNECTION_NAME" "Sentinel Hotspot"
   fi
 
+  if is_placeholder_env_value "$(env_value HOTSPOT_SSID)"; then
+    upsert_env "HOTSPOT_SSID" "Stone Frigate"
+  fi
+
+  if is_placeholder_env_value "$(env_value HOTSPOT_PSK)"; then
+    upsert_env "HOTSPOT_PSK" "replace-this-fixed-hotspot-password"
+  fi
+
+  if is_placeholder_env_value "$(env_value HOTSPOT_APPROVED_DONGLES_FILE)"; then
+    upsert_env "HOTSPOT_APPROVED_DONGLES_FILE" "hardware/approved-hotspot-dongles.json"
+  fi
+
   if is_placeholder_env_value "$(env_value NETWORK_REACHABILITY_CHECK_URL)"; then
     upsert_env "NETWORK_REACHABILITY_CHECK_URL" "https://connectivitycheck.gstatic.com/generate_204"
   fi
@@ -1341,6 +1353,7 @@ DESKTOP
     "${DEPLOY_DIR}/runtime/system-update/processed" \
     "${DEPLOY_DIR}/runtime/system-update/failed"
   run_root chmod 755 \
+    "${DEPLOY_DIR}/ensure-host-hotspot-profile.sh" \
     "${DEPLOY_DIR}/recover-host-hotspot.sh" \
     "${DEPLOY_DIR}/process-host-hotspot-recovery-requests.sh" \
     "${DEPLOY_DIR}/process-system-update-requests.sh" \
@@ -1412,6 +1425,67 @@ UNIT
   log "System update request watcher enabled."
 }
 
+run_host_hotspot_recovery_nonblocking() {
+  local recovery_script report_script connection_name recovery_rc report_json report_issue report_message
+  recovery_script="${DEPLOY_DIR}/recover-host-hotspot.sh"
+  report_script="${DEPLOY_DIR}/ensure-host-hotspot-profile.sh"
+  connection_name="$(env_value HOTSPOT_CONNECTION_NAME 'Sentinel Hotspot')"
+
+  if [[ ! -x "${recovery_script}" ]]; then
+    warn "Hotspot recovery script not found or not executable: ${recovery_script}"
+    return 0
+  fi
+
+  log "Running shared hotspot recovery for connection: ${connection_name}"
+  if run_root "${recovery_script}" "${connection_name}"; then
+    log "Shared hotspot recovery completed."
+    recovery_rc=0
+  else
+    recovery_rc=$?
+  fi
+
+  report_issue="none"
+  report_message=""
+  if [[ -x "${report_script}" && -n "$(command -v python3 || true)" ]]; then
+    report_json="$("${report_script}" --report-json 2>/dev/null || true)"
+    if [[ -n "${report_json}" ]]; then
+      report_issue="$(
+        printf '%s' "${report_json}" |
+          python3 -c 'import json,sys; payload=json.load(sys.stdin); print(payload.get("issueCode", "none"))'
+      )"
+      report_message="$(
+        printf '%s' "${report_json}" |
+          python3 -c 'import json,sys; payload=json.load(sys.stdin); print(payload.get("message", ""))'
+      )"
+    fi
+  fi
+
+  if [[ "${recovery_rc}" -eq 0 && "${report_issue}" == "none" ]]; then
+    return 0
+  fi
+
+  if [[ "${recovery_rc}" -eq 0 && "${report_issue}" != "none" && -n "${report_message}" ]]; then
+    warn "Shared hotspot recovery completed with degraded verification: ${report_message}"
+    return 0
+  fi
+
+  if [[ "${recovery_rc}" -eq 2 ]]; then
+    if [[ -n "${report_message}" ]]; then
+      warn "Shared hotspot recovery completed with degraded verification: ${report_message}"
+    else
+      warn "Shared hotspot recovery completed with degraded verification. Sentinel will keep the update and surface the networking issue in the UI."
+    fi
+    return 0
+  fi
+
+  if [[ -n "${report_message}" ]]; then
+    warn "Shared hotspot recovery failed: ${report_message}"
+  else
+    warn "Shared hotspot recovery failed. Sentinel will keep the current install/update state and surface the networking issue in the UI."
+  fi
+  return 0
+}
+
 configure_network_status_telemetry() {
   local interval_seconds runtime_dir
 
@@ -1428,6 +1502,10 @@ configure_network_status_telemetry() {
   runtime_dir="${DEPLOY_DIR}/runtime/network-status"
   run_root install -d -m 755 "${runtime_dir}"
   run_root chmod 755 "${NETWORK_STATUS_SCRIPT}" >/dev/null 2>&1 || true
+  if getent group sentinel-backend >/dev/null 2>&1; then
+    run_root chgrp sentinel-backend "${runtime_dir}" >/dev/null 2>&1 || true
+    run_root chmod 2755 "${runtime_dir}" >/dev/null 2>&1 || true
+  fi
 
   run_root tee /etc/systemd/system/sentinel-network-status.service >/dev/null <<UNIT
 [Unit]

--- a/deploy/deb/assets/usr/lib/sentinel/sentinel-updater
+++ b/deploy/deb/assets/usr/lib/sentinel/sentinel-updater
@@ -162,8 +162,8 @@ def compare_version_tags(left: str, right: str) -> int:
     return 0
 
 
-def github_request(path: str) -> dict[str, Any]:
-    trace("info", f"Fetching GitHub release metadata from {path}.")
+def github_request(path: str, *, purpose: str = "release metadata") -> dict[str, Any]:
+    trace("info", f"Fetching GitHub {purpose} from {path}.")
     request = urllib.request.Request(
         f"{RELEASE_API_BASE.rstrip('/')}/{resolve_release_repository()}{path}",
         headers={
@@ -184,15 +184,20 @@ def github_request(path: str) -> dict[str, Any]:
     return payload
 
 
-def fetch_release(tag: str) -> dict[str, Any]:
-    return github_request(f"/releases/tags/{tag}")
+def fetch_release(tag: str, *, purpose: str = "release metadata") -> dict[str, Any]:
+    return github_request(f"/releases/tags/{tag}", purpose=purpose)
 
 
 def fetch_latest_release() -> dict[str, Any]:
-    return github_request("/releases/latest")
+    return github_request("/releases/latest", purpose="latest release metadata")
 
 
-def select_release_asset(release: dict[str, Any], version_tag: str) -> tuple[dict[str, Any], dict[str, Any]]:
+def select_release_asset(
+    release: dict[str, Any],
+    version_tag: str,
+    *,
+    purpose: str = "release",
+) -> tuple[dict[str, Any], dict[str, Any]]:
     version = version_tag.removeprefix("v")
     expected_name = f"sentinel_{version}_all.deb"
     assets = release.get("assets")
@@ -217,7 +222,7 @@ def select_release_asset(release: dict[str, Any], version_tag: str) -> tuple[dic
         raise UpdaterError("verifying", f"Release {version_tag} did not contain a checksum asset.")
     trace(
         "info",
-        "Selected release assets for "
+        f"Selected {purpose} assets for "
         f"{version_tag}: package={deb_asset.get('name', expected_name)}, checksum={checksum_asset.get('name', 'unknown')}.",
     )
     return deb_asset, checksum_asset
@@ -270,28 +275,34 @@ def cached_paths(version_tag: str) -> tuple[Path, Path]:
     return DOWNLOADS_DIR / f"sentinel_{version}_all.deb", DOWNLOADS_DIR / f"SHA256SUMS-{version}.txt"
 
 
-def cache_verified_release(version_tag: str, job_logger: JobLogger) -> dict[str, str]:
-    release = fetch_release(version_tag)
+def cache_verified_release(
+    version_tag: str,
+    job_logger: JobLogger,
+    *,
+    purpose: str,
+) -> dict[str, str]:
+    trace("info", f"Preparing {purpose} artifacts for {version_tag}.")
+    release = fetch_release(version_tag, purpose=f"{purpose} metadata")
     release_tag = str(release.get("tag_name", "")).strip()
     if release_tag != version_tag:
         raise UpdaterError("verifying", f"Release metadata tag mismatch for {version_tag}.")
 
-    deb_asset, checksum_asset = select_release_asset(release, version_tag)
+    deb_asset, checksum_asset = select_release_asset(release, version_tag, purpose=purpose)
     deb_path, checksum_path = cached_paths(version_tag)
 
     if not deb_path.exists():
-        update_line = f"Downloading {deb_asset['name']} to {deb_path}"
+        update_line = f"Downloading {purpose} package {deb_asset['name']} to {deb_path}"
         job_logger.write_line(update_line)
         download_asset(str(deb_asset["browser_download_url"]), deb_path)
     if not checksum_path.exists():
-        job_logger.write_line(f"Downloading {checksum_asset['name']} to {checksum_path}")
+        job_logger.write_line(f"Downloading {purpose} checksum {checksum_asset['name']} to {checksum_path}")
         download_asset(str(checksum_asset["browser_download_url"]), checksum_path)
 
     expected_hash = checksum_from_file(checksum_path, deb_path.name)
     actual_hash = sha256sum(deb_path)
     if actual_hash != expected_hash:
         raise UpdaterError("verifying", f"Checksum mismatch for {deb_path.name}.")
-    trace("info", f"Verified checksum for {deb_path.name}: {actual_hash}.")
+    trace("info", f"Verified {purpose} checksum for {deb_path.name}: {actual_hash}.")
 
     return {
         "version": version_tag,
@@ -334,16 +345,23 @@ def run_command(
             job_logger.write_line(f"  {line}")
             trace("info", f"stdout: {line}")
     if stderr:
+        stderr_level = "warning" if result.returncode != 0 else "info"
         job_logger.write_line("stderr:")
-        trace("warning", f"Command produced stderr for step {step}.")
+        trace(stderr_level, f"Command produced stderr for step {step}.")
         for line in stderr.splitlines():
             job_logger.write_line(f"  {line}")
-            trace("warning", f"stderr: {line}")
+            trace(stderr_level, f"stderr: {line}")
     trace(
         "info" if result.returncode == 0 else "warning",
         f"Command for step {step} exited with status {result.returncode}.",
     )
     return result
+
+
+def refreshed_appliance_env() -> dict[str, str]:
+    env = dict(os.environ)
+    env.update(read_env_file(APPLIANCE_ENV_PATH))
+    return env
 
 
 def install_deb(deb_path: Path, job_logger: JobLogger) -> None:
@@ -469,7 +487,7 @@ def prepare_backup(job: dict[str, Any], job_logger: JobLogger) -> dict[str, Any]
         job_logger=job_logger,
         timeout=COMMAND_TIMEOUT_SECONDS,
         step="staging",
-        env=dict(os.environ),
+        env=refreshed_appliance_env(),
     )
     if result.returncode != 0:
         raise UpdaterError("staging", "Pre-update backup failed.")
@@ -483,10 +501,12 @@ def prepare_backup(job: dict[str, Any], job_logger: JobLogger) -> dict[str, Any]
 def update_runtime_version(target_version: str) -> None:
     trace("info", f"Updating SENTINEL_VERSION in {APPLIANCE_ENV_PATH} to {target_version}.")
     upsert_env_value(APPLIANCE_ENV_PATH, "SENTINEL_VERSION", target_version)
+    os.environ["SENTINEL_VERSION"] = target_version
 
 
 def run_backend_post_update(state: dict[str, Any], job_logger: JobLogger) -> None:
     trace("info", "Running backend post-update database and bootstrap commands.")
+    command_env = refreshed_appliance_env()
     commands = [
         compose_command(
             state,
@@ -531,6 +551,7 @@ def run_backend_post_update(state: dict[str, Any], job_logger: JobLogger) -> Non
             job_logger=job_logger,
             timeout=COMMAND_TIMEOUT_SECONDS,
             step="health_check",
+            env=command_env,
         )
         if result.returncode != 0:
             raise UpdaterError("health_check", f"Backend post-update command failed: {' '.join(command)}")
@@ -539,11 +560,13 @@ def run_backend_post_update(state: dict[str, Any], job_logger: JobLogger) -> Non
 
 def restart_stack(state: dict[str, Any], job_logger: JobLogger) -> None:
     trace("info", "Pulling fresh container images for the Sentinel stack.")
+    command_env = refreshed_appliance_env()
     pull_result = run_command(
         compose_command(state, "pull"),
         job_logger=job_logger,
         timeout=COMMAND_TIMEOUT_SECONDS,
         step="post_install",
+        env=command_env,
     )
     if pull_result.returncode != 0:
         raise UpdaterError("post_install", "docker compose pull failed.")
@@ -554,10 +577,72 @@ def restart_stack(state: dict[str, Any], job_logger: JobLogger) -> None:
         job_logger=job_logger,
         timeout=COMMAND_TIMEOUT_SECONDS,
         step="restarting",
+        env=command_env,
     )
     if up_result.returncode != 0:
         raise UpdaterError("restarting", "docker compose up -d failed.")
     trace("info", "Sentinel stack restart completed.")
+
+
+def read_hotspot_report(job_logger: JobLogger) -> dict[str, Any] | None:
+    ensure_script = DEPLOY_DIR / "ensure-host-hotspot-profile.sh"
+    if not ensure_script.exists():
+        return None
+
+    report_result = run_command(
+        [str(ensure_script), "--report-json"],
+        job_logger=job_logger,
+        timeout=COMMAND_TIMEOUT_SECONDS,
+        step="health_check",
+        env=refreshed_appliance_env(),
+    )
+    report_raw = report_result.stdout.strip()
+    if not report_raw:
+        return None
+
+    try:
+        payload = json.loads(report_raw)
+    except json.JSONDecodeError:
+        trace("warning", "Shared hotspot report returned invalid JSON after an update step.")
+        return None
+
+    return payload if isinstance(payload, dict) else None
+
+
+def run_shared_hotspot_recovery(job_logger: JobLogger, *, context: str) -> str | None:
+    recovery_script = DEPLOY_DIR / "recover-host-hotspot.sh"
+    if not recovery_script.exists():
+        trace("warning", f"Shared hotspot recovery script is missing after {context}.")
+        return "Shared hotspot recovery script is missing."
+
+    trace("info", f"Running shared hotspot recovery after {context}.")
+    result = run_command(
+        [str(recovery_script)],
+        job_logger=job_logger,
+        timeout=COMMAND_TIMEOUT_SECONDS,
+        step="health_check",
+        env=refreshed_appliance_env(),
+    )
+
+    degraded_message: str | None = None
+    if result.returncode not in {0, 2}:
+        degraded_message = f"Shared hotspot recovery failed with exit code {result.returncode}."
+    elif result.returncode == 2:
+        degraded_message = "Shared hotspot recovery completed, but hotspot visibility verification still needs attention."
+
+    report = read_hotspot_report(job_logger)
+    if isinstance(report, dict):
+        issue_code = report.get("issueCode")
+        report_message = report.get("message")
+        if issue_code != "none" and isinstance(report_message, str) and report_message.strip():
+            degraded_message = report_message.strip()
+
+    if degraded_message is None:
+        trace("info", f"Shared hotspot recovery completed cleanly after {context}.")
+    else:
+        trace("warning", f"Shared hotspot recovery is degraded after {context}: {degraded_message}")
+
+    return degraded_message
 
 
 def rollback(job: dict[str, Any], previous_artifact: dict[str, str], job_logger: JobLogger) -> None:
@@ -579,12 +664,23 @@ def rollback(job: dict[str, Any], previous_artifact: dict[str, str], job_logger:
     install_deb(Path(previous_artifact["debPath"]), job_logger)
     restart_stack(previous_state, job_logger)
     wait_for_health(job_logger, expected_version=previous_artifact["version"])
+    hotspot_warning = run_shared_hotspot_recovery(
+        job_logger,
+        context=f"rollback to {previous_artifact['version']}",
+    )
 
     job["currentVersion"] = previous_artifact["version"]
     update_job(
         job,
         status="rolled_back",
-        message=f"Rollback completed to {previous_artifact['version']}.",
+        message=(
+            f"Rollback completed to {previous_artifact['version']}."
+            if hotspot_warning is None
+            else (
+                f"Rollback completed to {previous_artifact['version']}. "
+                f"Host hotspot still needs attention: {hotspot_warning}"
+            )
+        ),
         job_logger=job_logger,
         finished=True,
     )
@@ -610,9 +706,23 @@ def execute_update(job: dict[str, Any], job_logger: JobLogger) -> None:
             f"Target version {target_version} is not newer than the current version {current_version}.",
         )
 
-    latest_release = fetch_latest_release()
     job["currentVersion"] = current_version
-    job["latestVersion"] = normalize_version_tag(str(latest_release.get("tag_name", "")).strip())
+    job["latestVersion"] = None
+
+    try:
+        latest_release = fetch_latest_release()
+    except UpdaterError as error:
+        job_logger.write_line(
+            "Latest release metadata lookup failed while authorizing the update. "
+            f"Continuing with the explicit target {target_version}: {error}"
+        )
+        trace(
+            "warning",
+            "Latest release metadata lookup failed while authorizing "
+            f"{target_version}; continuing with the explicit target. Reason: {error}",
+        )
+    else:
+        job["latestVersion"] = normalize_version_tag(str(latest_release.get("tag_name", "")).strip())
 
     update_job(
         job,
@@ -626,7 +736,7 @@ def execute_update(job: dict[str, Any], job_logger: JobLogger) -> None:
 
     previous_artifact: dict[str, str] | None = None
     try:
-        previous_artifact = cache_verified_release(current_version, job_logger)
+        previous_artifact = cache_verified_release(current_version, job_logger, purpose="rollback")
     except UpdaterError as error:
         # Older published releases may not have shipped rollback metadata such as
         # a checksum asset yet. Record that explicitly, but keep validating the
@@ -642,7 +752,7 @@ def execute_update(job: dict[str, Any], job_logger: JobLogger) -> None:
         )
 
     update_job(job, status="downloading", message=f"Downloading Sentinel release {target_version}.", job_logger=job_logger)
-    target_artifact = cache_verified_release(target_version, job_logger)
+    target_artifact = cache_verified_release(target_version, job_logger, purpose="target release")
 
     update_job(job, status="verifying", message=f"Verifying release artifacts for {target_version}.", job_logger=job_logger)
     job["artifacts"] = {
@@ -671,12 +781,23 @@ def execute_update(job: dict[str, Any], job_logger: JobLogger) -> None:
     update_job(job, status="health_check", message="Running post-update verification.", job_logger=job_logger)
     run_backend_post_update(state, job_logger)
     wait_for_health(job_logger, expected_version=target_version)
+    hotspot_warning = run_shared_hotspot_recovery(
+        job_logger,
+        context=f"update to {target_version}",
+    )
 
     job["currentVersion"] = target_version
     update_job(
         job,
         status="completed",
-        message=f"Sentinel updated successfully to {target_version}.",
+        message=(
+            f"Sentinel updated successfully to {target_version}."
+            if hotspot_warning is None
+            else (
+                f"Sentinel updated successfully to {target_version}. "
+                f"Host hotspot still needs attention: {hotspot_warning}"
+            )
+        ),
         job_logger=job_logger,
         finished=True,
     )

--- a/deploy/deb/assets/usr/share/applications/sentinel-install-update.desktop
+++ b/deploy/deb/assets/usr/share/applications/sentinel-install-update.desktop
@@ -2,7 +2,7 @@
 Version=1.0
 Type=Application
 Name=Sentinel Install and Update
-Comment=Install or update Sentinel with a guided terminal prompt
+Comment=Install or update Sentinel with a guided hotspot and release wizard
 Exec=/usr/local/bin/sentinel-install-update
 Icon=sentinel-appliance
 Terminal=true

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -68,6 +68,7 @@ services:
       SENTINEL_AUTO_SEED_ENUMS: ${SENTINEL_AUTO_SEED_ENUMS:-true}
       SENTINEL_AUTO_SEED_ATTEMPTS: ${SENTINEL_AUTO_SEED_ATTEMPTS:-3}
       SENTINEL_AUTO_SEED_RETRY_DELAY_MS: ${SENTINEL_AUTO_SEED_RETRY_DELAY_MS:-3000}
+      HOTSPOT_SSID: ${HOTSPOT_SSID:-Stone Frigate}
       NETWORK_STATUS_FILE_PATH: /var/run/sentinel/network-status/network-status.json
       HOST_HOTSPOT_RECOVERY_REQUEST_DIR: /var/run/sentinel/hotspot-recovery/requests
       SYSTEM_UPDATE_BRIDGE_SOCKET_PATH: /run/sentinel/update-bridge.sock

--- a/deploy/ensure-host-hotspot-profile.sh
+++ b/deploy/ensure-host-hotspot-profile.sh
@@ -1,0 +1,550 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/_common.sh"
+
+HOTSPOT_CONFIG_CONNECTION_NAME=""
+HOTSPOT_CONFIG_SSID=""
+HOTSPOT_CONFIG_PSK=""
+HOTSPOT_CONFIG_BAND=""
+HOTSPOT_CONFIG_CHANNEL=""
+HOTSPOT_CONFIG_MANIFEST_PATH=""
+
+HOTSPOT_STATE_ISSUE_CODE="none"
+HOTSPOT_STATE_MESSAGE=""
+HOTSPOT_STATE_PROFILE_PRESENT="false"
+HOTSPOT_STATE_HOTSPOT_ADAPTER_APPROVED="false"
+HOTSPOT_STATE_SCAN_ADAPTER_PRESENT="false"
+HOTSPOT_STATE_HOTSPOT_DEVICE=""
+HOTSPOT_STATE_HOTSPOT_SCAN_DEVICE=""
+HOTSPOT_STATE_HOTSPOT_SSID=""
+HOTSPOT_STATE_HOTSPOT_VISIBILITY="null"
+HOTSPOT_STATE_APPROVED_ADAPTER_COUNT="0"
+HOTSPOT_STATE_ENV_PSK_CONFIGURED="false"
+
+hotspot_log() {
+  printf '[host-hotspot-profile] %s\n' "$*"
+}
+
+hotspot_warn() {
+  printf '[host-hotspot-profile] %s\n' "$*" >&2
+}
+
+hotspot_refresh_config() {
+  HOTSPOT_CONFIG_CONNECTION_NAME="${HOTSPOT_CONNECTION_NAME_OVERRIDE:-$(env_value HOTSPOT_CONNECTION_NAME 'Sentinel Hotspot')}"
+  HOTSPOT_CONFIG_SSID="${HOTSPOT_SSID_OVERRIDE:-$(env_value HOTSPOT_SSID 'Stone Frigate')}"
+  HOTSPOT_CONFIG_PSK="${HOTSPOT_PSK_OVERRIDE:-$(env_value HOTSPOT_PSK '')}"
+  HOTSPOT_CONFIG_BAND="${HOTSPOT_BAND_OVERRIDE:-$(env_value HOTSPOT_BAND 'bg')}"
+  HOTSPOT_CONFIG_CHANNEL="${HOTSPOT_CHANNEL_OVERRIDE:-$(env_value HOTSPOT_CHANNEL '1')}"
+  HOTSPOT_CONFIG_MANIFEST_PATH="${HOTSPOT_APPROVED_DONGLES_FILE_OVERRIDE:-$(env_value HOTSPOT_APPROVED_DONGLES_FILE "${SCRIPT_DIR}/hardware/approved-hotspot-dongles.json")}"
+
+  if [[ "${HOTSPOT_CONFIG_MANIFEST_PATH}" != /* ]]; then
+    HOTSPOT_CONFIG_MANIFEST_PATH="${SCRIPT_DIR}/${HOTSPOT_CONFIG_MANIFEST_PATH}"
+  fi
+}
+
+hotspot_json_string_or_null() {
+  local value="${1:-}"
+  if [[ -z "${value}" ]]; then
+    printf 'null'
+    return 0
+  fi
+
+  printf '"%s"' "$(json_escape "${value}")"
+}
+
+hotspot_have_command() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+hotspot_connection_exists() {
+  nmcli -t -f NAME connection show 2>/dev/null | grep -Fxq "${HOTSPOT_CONFIG_CONNECTION_NAME}"
+}
+
+hotspot_connection_type() {
+  nmcli -g connection.type connection show "${HOTSPOT_CONFIG_CONNECTION_NAME}" 2>/dev/null | head -n1
+}
+
+hotspot_connection_device() {
+  local active_device configured_device
+
+  active_device="$(
+    nmcli -t -f NAME,TYPE,DEVICE connection show --active 2>/dev/null |
+      awk -F: -v conn="${HOTSPOT_CONFIG_CONNECTION_NAME}" '$1 == conn && ($2 == "wifi" || $2 == "802-11-wireless") { print $3; exit }'
+  )"
+  if [[ -n "${active_device}" ]]; then
+    printf '%s\n' "${active_device}"
+    return 0
+  fi
+
+  configured_device="$(
+    nmcli -g connection.interface-name connection show "${HOTSPOT_CONFIG_CONNECTION_NAME}" 2>/dev/null |
+      head -n1
+  )"
+  if [[ -n "${configured_device}" ]]; then
+    printf '%s\n' "${configured_device}"
+  fi
+}
+
+hotspot_connection_ssid() {
+  local configured_ssid
+  configured_ssid="$(
+    nmcli -g 802-11-wireless.ssid connection show "${HOTSPOT_CONFIG_CONNECTION_NAME}" 2>/dev/null |
+      head -n1
+  )"
+  if [[ -n "${configured_ssid}" ]]; then
+    printf '%s\n' "${configured_ssid}"
+    return 0
+  fi
+
+  printf '%s\n' "${HOTSPOT_CONFIG_SSID}"
+}
+
+hotspot_device_property() {
+  local device="${1:-}" key="${2:-}"
+  [[ -n "${device}" && -n "${key}" ]] || return 1
+  [[ -e "/sys/class/net/${device}" ]] || return 1
+  hotspot_have_command udevadm || return 1
+
+  udevadm info --query=property --path="/sys/class/net/${device}" 2>/dev/null |
+    awk -F= -v wanted="${key}" '$1 == wanted { print substr($0, index($0, $2)); exit }'
+}
+
+hotspot_device_bus() {
+  hotspot_device_property "${1:-}" ID_BUS
+}
+
+hotspot_device_driver() {
+  local driver
+  driver="$(hotspot_device_property "${1:-}" ID_USB_DRIVER || true)"
+  if [[ -n "${driver}" ]]; then
+    printf '%s\n' "${driver}"
+    return 0
+  fi
+
+  hotspot_device_property "${1:-}" ID_NET_DRIVER || true
+}
+
+hotspot_device_vid_pid() {
+  local device="${1:-}" vendor_id product_id
+  vendor_id="$(hotspot_device_property "${device}" ID_VENDOR_ID || true)"
+  product_id="$(hotspot_device_property "${device}" ID_MODEL_ID || true)"
+  if [[ -z "${vendor_id}" || -z "${product_id}" ]]; then
+    return 1
+  fi
+
+  printf '%s:%s\n' "${vendor_id,,}" "${product_id,,}"
+}
+
+hotspot_device_label() {
+  local device="${1:-}" vendor model
+  vendor="$(hotspot_device_property "${device}" ID_VENDOR_FROM_DATABASE || true)"
+  if [[ -z "${vendor}" ]]; then
+    vendor="$(hotspot_device_property "${device}" ID_VENDOR || true)"
+  fi
+
+  model="$(hotspot_device_property "${device}" ID_MODEL_FROM_DATABASE || true)"
+  if [[ -z "${model}" ]]; then
+    model="$(hotspot_device_property "${device}" ID_USB_MODEL || true)"
+  fi
+  if [[ -z "${model}" ]]; then
+    model="$(hotspot_device_property "${device}" ID_MODEL || true)"
+  fi
+
+  if [[ -n "${vendor}" && -n "${model}" ]]; then
+    printf '%s %s\n' "${vendor}" "${model}"
+    return 0
+  fi
+  if [[ -n "${vendor}" ]]; then
+    printf '%s\n' "${vendor}"
+    return 0
+  fi
+  if [[ -n "${model}" ]]; then
+    printf '%s\n' "${model}"
+    return 0
+  fi
+
+  printf '%s\n' "${device}"
+}
+
+hotspot_manifest_exists() {
+  [[ -f "${HOTSPOT_CONFIG_MANIFEST_PATH}" ]]
+}
+
+hotspot_adapter_matches_manifest() {
+  local device="${1:-}" vid_pid driver vendor_id product_id
+  [[ -n "${device}" ]] || return 1
+  hotspot_manifest_exists || return 1
+  hotspot_have_command python3 || return 1
+
+  vid_pid="$(hotspot_device_vid_pid "${device}" || true)"
+  [[ -n "${vid_pid}" ]] || return 1
+  vendor_id="${vid_pid%%:*}"
+  product_id="${vid_pid##*:}"
+  driver="$(hotspot_device_driver "${device}" || true)"
+
+  python3 - "${HOTSPOT_CONFIG_MANIFEST_PATH}" "${vendor_id}" "${product_id}" "${driver,,}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest_path = Path(sys.argv[1])
+vendor_id = sys.argv[2].lower()
+product_id = sys.argv[3].lower()
+driver = sys.argv[4].lower()
+
+try:
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+except Exception:
+    raise SystemExit(1)
+
+entries = payload.get("dongles", []) if isinstance(payload, dict) else payload
+if not isinstance(entries, list):
+    raise SystemExit(1)
+
+for entry in entries:
+    if not isinstance(entry, dict):
+        continue
+    entry_vendor = str(entry.get("vendorId", "")).lower()
+    entry_product = str(entry.get("productId", "")).lower()
+    entry_driver = str(entry.get("driver", "")).lower()
+    if entry_vendor != vendor_id or entry_product != product_id:
+        continue
+    if entry_driver and entry_driver != driver:
+        continue
+    raise SystemExit(0)
+
+raise SystemExit(1)
+PY
+}
+
+hotspot_wifi_devices() {
+  nmcli -t -f DEVICE,TYPE device status 2>/dev/null |
+    awk -F: '$2 == "wifi" { print $1 }'
+}
+
+hotspot_find_approved_adapters() {
+  local device
+  while IFS= read -r device; do
+    [[ -n "${device}" ]] || continue
+    if [[ "$(hotspot_device_bus "${device}" || true)" != "usb" ]]; then
+      continue
+    fi
+    if hotspot_adapter_matches_manifest "${device}"; then
+      printf '%s\n' "${device}"
+    fi
+  done < <(hotspot_wifi_devices)
+}
+
+hotspot_pick_scan_device() {
+  local hotspot_device="${1:-}" preferred_device fallback_device line device type state
+  [[ -n "${hotspot_device}" ]] || return 0
+
+  while IFS= read -r line; do
+    [[ -n "${line}" ]] || continue
+    IFS=':' read -r device type state <<<"${line}"
+    if [[ "${type}" == "wifi" && "${device}" != "${hotspot_device}" && "${state}" == "connected" ]]; then
+      preferred_device="${device}"
+      break
+    fi
+  done < <(nmcli -t -f DEVICE,TYPE,STATE device status 2>/dev/null || true)
+
+  if [[ -n "${preferred_device}" ]]; then
+    printf '%s\n' "${preferred_device}"
+    return 0
+  fi
+
+  while IFS= read -r line; do
+    [[ -n "${line}" ]] || continue
+    IFS=':' read -r device type _ <<<"${line}"
+    if [[ "${type}" == "wifi" && "${device}" != "${hotspot_device}" ]]; then
+      fallback_device="${device}"
+      break
+    fi
+  done < <(nmcli -t -f DEVICE,TYPE,STATE device status 2>/dev/null || true)
+
+  if [[ -n "${fallback_device}" ]]; then
+    printf '%s\n' "${fallback_device}"
+  fi
+}
+
+hotspot_is_ssid_visible_on_device() {
+  local scan_device="${1:-}" ssid="${2:-}"
+  [[ -n "${scan_device}" && -n "${ssid}" ]] || return 2
+
+  if nmcli -t -f SSID,CHAN,SECURITY device wifi list ifname "${scan_device}" 2>/dev/null |
+    awk -F: -v wanted="${ssid}" '$1 == wanted { found = 1 } END { exit found ? 0 : 1 }'; then
+    return 0
+  fi
+
+  nmcli device wifi rescan ifname "${scan_device}" >/dev/null 2>&1 || true
+  nmcli -t -f SSID,CHAN,SECURITY device wifi list ifname "${scan_device}" 2>/dev/null |
+    awk -F: -v wanted="${ssid}" '$1 == wanted { found = 1 } END { exit found ? 0 : 1 }'
+}
+
+hotspot_has_configured_psk() {
+  hotspot_refresh_config
+  if is_placeholder_env_value "${HOTSPOT_CONFIG_PSK}"; then
+    return 1
+  fi
+  return 0
+}
+
+hotspot_reset_state() {
+  HOTSPOT_STATE_ISSUE_CODE="none"
+  HOTSPOT_STATE_MESSAGE="Hotspot profile and adapters are ready."
+  HOTSPOT_STATE_PROFILE_PRESENT="false"
+  HOTSPOT_STATE_HOTSPOT_ADAPTER_APPROVED="false"
+  HOTSPOT_STATE_SCAN_ADAPTER_PRESENT="false"
+  HOTSPOT_STATE_HOTSPOT_DEVICE=""
+  HOTSPOT_STATE_HOTSPOT_SCAN_DEVICE=""
+  HOTSPOT_STATE_HOTSPOT_SSID="${HOTSPOT_CONFIG_SSID}"
+  HOTSPOT_STATE_HOTSPOT_VISIBILITY="null"
+  HOTSPOT_STATE_APPROVED_ADAPTER_COUNT="0"
+  HOTSPOT_STATE_ENV_PSK_CONFIGURED="false"
+}
+
+hotspot_collect_runtime_state() {
+  local profile_device profile_ssid approved_devices approved_count visibility_rc
+
+  hotspot_refresh_config
+  hotspot_reset_state
+
+  if ! hotspot_have_command nmcli; then
+    HOTSPOT_STATE_ISSUE_CODE="hotspot_profile_missing"
+    HOTSPOT_STATE_MESSAGE="NetworkManager is unavailable on this host."
+    return 0
+  fi
+
+  if hotspot_connection_exists; then
+    HOTSPOT_STATE_PROFILE_PRESENT="true"
+  fi
+
+  profile_device="$(hotspot_connection_device || true)"
+  profile_ssid="$(hotspot_connection_ssid || true)"
+  if [[ -n "${profile_ssid}" ]]; then
+    HOTSPOT_STATE_HOTSPOT_SSID="${profile_ssid}"
+  fi
+
+  mapfile -t approved_devices < <(hotspot_find_approved_adapters)
+  approved_count="${#approved_devices[@]}"
+  HOTSPOT_STATE_APPROVED_ADAPTER_COUNT="${approved_count}"
+
+  if hotspot_has_configured_psk; then
+    HOTSPOT_STATE_ENV_PSK_CONFIGURED="true"
+  fi
+
+  if (( approved_count == 1 )); then
+    HOTSPOT_STATE_HOTSPOT_ADAPTER_APPROVED="true"
+    HOTSPOT_STATE_HOTSPOT_DEVICE="${approved_devices[0]}"
+  elif [[ -n "${profile_device}" ]]; then
+    HOTSPOT_STATE_HOTSPOT_DEVICE="${profile_device}"
+  fi
+
+  HOTSPOT_STATE_HOTSPOT_SCAN_DEVICE="$(hotspot_pick_scan_device "${HOTSPOT_STATE_HOTSPOT_DEVICE}")"
+  if [[ -n "${HOTSPOT_STATE_HOTSPOT_SCAN_DEVICE}" ]]; then
+    HOTSPOT_STATE_SCAN_ADAPTER_PRESENT="true"
+  fi
+
+  if hotspot_is_ssid_visible_on_device "${HOTSPOT_STATE_HOTSPOT_SCAN_DEVICE}" "${HOTSPOT_STATE_HOTSPOT_SSID}"; then
+    HOTSPOT_STATE_HOTSPOT_VISIBILITY="true"
+  else
+    visibility_rc=$?
+    if [[ "${visibility_rc}" -eq 1 ]]; then
+      HOTSPOT_STATE_HOTSPOT_VISIBILITY="false"
+    fi
+  fi
+
+  if ! hotspot_manifest_exists; then
+    HOTSPOT_STATE_ISSUE_CODE="approved_hotspot_adapter_missing"
+    HOTSPOT_STATE_MESSAGE="Approved hotspot hardware manifest is missing."
+    return 0
+  fi
+
+  if (( approved_count == 0 )); then
+    HOTSPOT_STATE_ISSUE_CODE="approved_hotspot_adapter_missing"
+    if [[ -n "${profile_device}" ]]; then
+      HOTSPOT_STATE_MESSAGE="No approved hotspot dongle is detected. The current profile is bound to ${profile_device}."
+    else
+      HOTSPOT_STATE_MESSAGE="No approved hotspot dongle is detected on this laptop."
+    fi
+    return 0
+  fi
+
+  if (( approved_count > 1 )); then
+    HOTSPOT_STATE_ISSUE_CODE="approved_hotspot_adapter_missing"
+    HOTSPOT_STATE_MESSAGE="Multiple approved hotspot dongles are connected. Unplug extras and retry."
+    return 0
+  fi
+
+  if [[ "${HOTSPOT_STATE_PROFILE_PRESENT}" != "true" ]]; then
+    HOTSPOT_STATE_ISSUE_CODE="hotspot_profile_missing"
+    if [[ "${HOTSPOT_STATE_ENV_PSK_CONFIGURED}" != "true" ]]; then
+      HOTSPOT_STATE_MESSAGE="The hotspot password is not configured, so Sentinel cannot create the hosted profile automatically."
+    else
+      HOTSPOT_STATE_MESSAGE="The managed Sentinel hotspot profile is missing."
+    fi
+    return 0
+  fi
+
+  if [[ "${HOTSPOT_STATE_SCAN_ADAPTER_PRESENT}" != "true" ]]; then
+    HOTSPOT_STATE_ISSUE_CODE="scan_adapter_missing"
+    HOTSPOT_STATE_MESSAGE="A second Wi-Fi radio is unavailable for hotspot verification."
+    return 0
+  fi
+
+  if [[ "${HOTSPOT_STATE_HOTSPOT_VISIBILITY}" == "false" ]]; then
+    HOTSPOT_STATE_ISSUE_CODE="hotspot_not_visible"
+    HOTSPOT_STATE_MESSAGE="Hotspot SSID \"${HOTSPOT_STATE_HOTSPOT_SSID}\" is not visible from ${HOTSPOT_STATE_HOTSPOT_SCAN_DEVICE}."
+    return 0
+  fi
+
+  HOTSPOT_STATE_ISSUE_CODE="none"
+  HOTSPOT_STATE_MESSAGE="Hotspot profile and adapters are ready."
+}
+
+hotspot_state_exit_code() {
+  case "${HOTSPOT_STATE_ISSUE_CODE}" in
+    none)
+      return 0
+      ;;
+    scan_adapter_missing|hotspot_not_visible)
+      return 2
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+emit_hotspot_state_json() {
+  cat <<JSON
+{
+  "issueCode": "$(json_escape "${HOTSPOT_STATE_ISSUE_CODE}")",
+  "message": "$(json_escape "${HOTSPOT_STATE_MESSAGE}")",
+  "hotspotProfilePresent": $(json_bool "${HOTSPOT_STATE_PROFILE_PRESENT}"),
+  "hotspotAdapterApproved": $(json_bool "${HOTSPOT_STATE_HOTSPOT_ADAPTER_APPROVED}"),
+  "scanAdapterPresent": $(json_bool "${HOTSPOT_STATE_SCAN_ADAPTER_PRESENT}"),
+  "hotspotDevice": $(hotspot_json_string_or_null "${HOTSPOT_STATE_HOTSPOT_DEVICE}"),
+  "scanDevice": $(hotspot_json_string_or_null "${HOTSPOT_STATE_HOTSPOT_SCAN_DEVICE}"),
+  "hotspotSsid": $(hotspot_json_string_or_null "${HOTSPOT_STATE_HOTSPOT_SSID}"),
+  "hotspotVisibility": ${HOTSPOT_STATE_HOTSPOT_VISIBILITY},
+  "approvedAdapterCount": ${HOTSPOT_STATE_APPROVED_ADAPTER_COUNT},
+  "hotspotPskConfigured": $(json_bool "${HOTSPOT_STATE_ENV_PSK_CONFIGURED}")
+}
+JSON
+}
+
+recreate_hotspot_profile_if_needed() {
+  local device="${1:-}" profile_type
+  [[ -n "${device}" ]] || return 1
+
+  if hotspot_connection_exists; then
+    profile_type="$(hotspot_connection_type || true)"
+    if [[ "${profile_type}" != "wifi" && "${profile_type}" != "802-11-wireless" ]]; then
+      hotspot_log "Recreating non-Wi-Fi NetworkManager profile ${HOTSPOT_CONFIG_CONNECTION_NAME}"
+      nmcli connection delete "${HOTSPOT_CONFIG_CONNECTION_NAME}" >/dev/null
+    fi
+  fi
+
+  if ! hotspot_connection_exists; then
+    hotspot_log "Creating hotspot profile ${HOTSPOT_CONFIG_CONNECTION_NAME} on ${device}"
+    nmcli connection add type wifi ifname "${device}" con-name "${HOTSPOT_CONFIG_CONNECTION_NAME}" ssid "${HOTSPOT_CONFIG_SSID}" autoconnect yes >/dev/null
+  fi
+}
+
+apply_hotspot_profile_settings() {
+  local device="${1:-}"
+  [[ -n "${device}" ]] || return 1
+
+  hotspot_log "Applying canonical hotspot settings to ${HOTSPOT_CONFIG_CONNECTION_NAME}"
+  nmcli connection modify "${HOTSPOT_CONFIG_CONNECTION_NAME}" \
+    connection.interface-name "${device}" \
+    connection.autoconnect yes \
+    connection.autoconnect-priority 100 \
+    802-11-wireless.mode ap \
+    802-11-wireless.ssid "${HOTSPOT_CONFIG_SSID}" \
+    802-11-wireless.band "${HOTSPOT_CONFIG_BAND}" \
+    802-11-wireless.channel "${HOTSPOT_CONFIG_CHANNEL}" \
+    802-11-wireless.hidden no \
+    802-11-wireless.powersave 2 \
+    ipv4.method shared \
+    ipv6.method ignore \
+    802-11-wireless-security.key-mgmt wpa-psk \
+    802-11-wireless-security.psk "${HOTSPOT_CONFIG_PSK}" >/dev/null
+}
+
+ensure_host_hotspot_profile() {
+  hotspot_collect_runtime_state
+
+  if [[ "${HOTSPOT_STATE_HOTSPOT_ADAPTER_APPROVED}" != "true" ]]; then
+    hotspot_warn "${HOTSPOT_STATE_MESSAGE}"
+    return 1
+  fi
+
+  if [[ "${HOTSPOT_STATE_ENV_PSK_CONFIGURED}" != "true" ]]; then
+    hotspot_warn "HOTSPOT_PSK is not configured; Sentinel cannot create or repair the hosted hotspot profile."
+    return 1
+  fi
+
+  recreate_hotspot_profile_if_needed "${HOTSPOT_STATE_HOTSPOT_DEVICE}"
+  apply_hotspot_profile_settings "${HOTSPOT_STATE_HOTSPOT_DEVICE}"
+
+  hotspot_collect_runtime_state
+  if [[ "${HOTSPOT_STATE_SCAN_ADAPTER_PRESENT}" != "true" ]]; then
+    hotspot_warn "${HOTSPOT_STATE_MESSAGE}"
+    return 2
+  fi
+
+  hotspot_log "Hotspot profile ${HOTSPOT_CONFIG_CONNECTION_NAME} is configured on ${HOTSPOT_STATE_HOTSPOT_DEVICE}"
+  return 0
+}
+
+usage() {
+  cat <<USAGE
+Usage: ./ensure-host-hotspot-profile.sh [--report-json]
+
+Options:
+  --report-json   Print the detected hotspot/profile state as JSON and exit.
+  -h, --help      Show this help text.
+USAGE
+}
+
+main() {
+  local report_json="false"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --report-json)
+        report_json="true"
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        hotspot_warn "Unknown option: $1"
+        usage
+        exit 1
+        ;;
+    esac
+  done
+
+  hotspot_refresh_config
+
+  if [[ "${report_json}" == "true" ]]; then
+    hotspot_collect_runtime_state
+    emit_hotspot_state_json
+    hotspot_state_exit_code
+    return $?
+  fi
+
+  ensure_host_hotspot_profile
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/deploy/hardware/approved-hotspot-dongles.json
+++ b/deploy/hardware/approved-hotspot-dongles.json
@@ -1,0 +1,10 @@
+{
+  "dongles": [
+    {
+      "vendorId": "2357",
+      "productId": "0138",
+      "driver": "rtw88_8822bu",
+      "label": "TP-Link 802.11ac NIC"
+    }
+  ]
+}

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -224,6 +224,7 @@ fi
 ensure_mdns_hostname
 ensure_local_wiki_host_alias
 configure_hotspot_connectivity_helpers
+run_host_hotspot_recovery_nonblocking
 MDNS_HOSTNAME="$(env_value MDNS_HOSTNAME sentinel)"
 WIKI_DOMAIN="$(env_value WIKI_DOMAIN docs.sentinel.local)"
 

--- a/deploy/recover-host-hotspot.sh
+++ b/deploy/recover-host-hotspot.sh
@@ -2,12 +2,17 @@
 
 set -euo pipefail
 
-CONNECTION_NAME="${1:-${HOTSPOT_CONNECTION_NAME:-Sentinel Hotspot}}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/ensure-host-hotspot-profile.sh"
+
+CONNECTION_NAME="${1:-$(env_value HOTSPOT_CONNECTION_NAME 'Sentinel Hotspot')}"
 SSID_WAIT_TIMEOUT="${SSID_WAIT_TIMEOUT:-20}"
 SSID_POLL_INTERVAL="${SSID_POLL_INTERVAL:-2}"
-HOTSPOT_BAND="${HOTSPOT_BAND:-bg}"
-HOTSPOT_CHANNEL="${HOTSPOT_CHANNEL:-1}"
+HOTSPOT_BAND="$(env_value HOTSPOT_BAND 'bg')"
+HOTSPOT_CHANNEL="$(env_value HOTSPOT_CHANNEL '1')"
 LOCK_FILE="${LOCK_FILE:-/run/lock/sentinel-host-hotspot-recover.lock}"
+export HOTSPOT_CONNECTION_NAME_OVERRIDE="${CONNECTION_NAME}"
 
 log() {
   printf '[host-hotspot-recover] %s\n' "$*"
@@ -29,6 +34,21 @@ wait_for_path() {
 
   while (( SECONDS < end )); do
     if [[ -e "${path}" ]]; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  return 1
+}
+
+wait_for_nm_device() {
+  local device="$1"
+  local timeout="${2:-20}"
+  local end=$((SECONDS + timeout))
+
+  while (( SECONDS < end )); do
+    if nmcli -t -f DEVICE device status | grep -Fxq "${device}"; then
       return 0
     fi
     sleep 1
@@ -63,6 +83,14 @@ stop_hotspot() {
 }
 
 start_hotspot() {
+  local device="${1:-}"
+
+  if [[ -n "${device}" ]]; then
+    log "Bringing hotspot connection up on ${device}"
+    nmcli -w 30 connection up "${CONNECTION_NAME}" ifname "${device}" >/dev/null
+    return 0
+  fi
+
   log "Bringing hotspot connection up"
   nmcli -w 30 connection up "${CONNECTION_NAME}" >/dev/null
 }
@@ -121,16 +149,29 @@ if ! flock -n 9; then
   die "Host hotspot recovery is already running"
 fi
 
-if ! nmcli -t -f NAME connection show | grep -Fxq "${CONNECTION_NAME}"; then
+skip_visibility_check="false"
+if ensure_host_hotspot_profile; then
+  :
+else
+  ensure_rc=$?
+  if [[ "${ensure_rc}" -eq 2 ]]; then
+    skip_visibility_check="true"
+    log "Hotspot profile is configured, but no second Wi-Fi radio is available for visibility verification."
+  else
+    die "Unable to ensure the canonical hotspot profile for \"${CONNECTION_NAME}\""
+  fi
+fi
+
+if ! hotspot_connection_exists; then
   die "NetworkManager connection \"${CONNECTION_NAME}\" was not found"
 fi
 
-SSID="$(nmcli -g 802-11-wireless.ssid connection show "${CONNECTION_NAME}" | head -n1)"
-DEVICE="$(nmcli -g connection.interface-name connection show "${CONNECTION_NAME}" | head -n1)"
+SSID="$(hotspot_connection_ssid || true)"
+DEVICE="$(hotspot_connection_device || true)"
 KEY_MGMT="$(nmcli -g 802-11-wireless-security.key-mgmt connection show "${CONNECTION_NAME}" | head -n1)"
 
 if [[ -z "${DEVICE}" ]]; then
-  DEVICE="$(nmcli -t -f NAME,TYPE,DEVICE connection show --active | awk -F: -v conn="${CONNECTION_NAME}" '$1 == conn && ($2 == "wifi" || $2 == "802-11-wireless") { print $3; exit }')"
+  DEVICE="${HOTSPOT_STATE_HOTSPOT_DEVICE:-}"
 fi
 
 [[ -n "${DEVICE}" ]] || die "Could not determine the hotspot interface for \"${CONNECTION_NAME}\""
@@ -150,7 +191,10 @@ USB_AUTHORIZED="/sys/bus/usb/devices/${USB_DEVICE_NAME}/authorized"
 USB_UNBIND="/sys/bus/usb/drivers/usb/unbind"
 USB_BIND="/sys/bus/usb/drivers/usb/bind"
 
-SCAN_DEVICE="$(nmcli -t -f DEVICE,TYPE device status | awk -F: -v dev="${DEVICE}" '$2 == "wifi" && $1 != dev { print $1; exit }')"
+SCAN_DEVICE="${HOTSPOT_STATE_HOTSPOT_SCAN_DEVICE:-}"
+if [[ -z "${SCAN_DEVICE}" ]]; then
+  SCAN_DEVICE="$(hotspot_pick_scan_device "${DEVICE}")"
+fi
 
 log "Connection: ${CONNECTION_NAME}"
 log "SSID: ${SSID:-unknown}"
@@ -182,8 +226,9 @@ if have_command udevadm; then
 fi
 
 wait_for_path "/sys/class/net/${DEVICE}" 20 || die "Interface ${DEVICE} did not come back after reset"
+wait_for_nm_device "${DEVICE}" 20 || die "NetworkManager did not rediscover ${DEVICE} after reset"
 
-start_hotspot
+start_hotspot "${DEVICE}"
 
 if have_command iw; then
   iw dev "${DEVICE}" set power_save off >/dev/null 2>&1 || true
@@ -191,6 +236,11 @@ fi
 
 if have_command iwconfig; then
   iwconfig "${DEVICE}" power off >/dev/null 2>&1 || true
+fi
+
+if [[ "${skip_visibility_check}" == "true" || -z "${SCAN_DEVICE}" || -z "${SSID}" ]]; then
+  log "Host hotspot recovery complete without a scan-radio visibility check"
+  exit 0
 fi
 
 if [[ -n "${SCAN_DEVICE}" && -n "${SSID}" ]]; then

--- a/deploy/rollback.sh
+++ b/deploy/rollback.sh
@@ -99,6 +99,7 @@ if command -v systemctl >/dev/null 2>&1; then
 fi
 
 configure_hotspot_connectivity_helpers
+run_host_hotspot_recovery_nonblocking
 
 log "Rollback complete. Current version: ${CURRENT_VERSION}"
 warn "If database schema changed incompatibly, use restore.sh with a pre-update backup."

--- a/deploy/sentinel-install-update-launcher.sh
+++ b/deploy/sentinel-install-update-launcher.sh
@@ -2,22 +2,328 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${SCRIPT_DIR}/.env"
+APPLIANCE_STATE_FILE="/var/lib/sentinel/appliance/state.json"
 
-set +e
-cd "${SCRIPT_DIR}"
-bash "${SCRIPT_DIR}/sentinel_update_quiet.sh" "$@"
-exit_code=$?
-set -e
-
-if [[ -t 0 ]]; then
-  echo
-  if [[ "${exit_code}" -eq 0 ]]; then
-    echo "[sentinel] Completed successfully."
-  else
-    echo "[sentinel] Failed with exit code ${exit_code}."
+read_env_value() {
+  local key="${1:-}"
+  [[ -n "${key}" ]] || return 0
+  if [[ -f "${ENV_FILE}" ]]; then
+    grep -E "^${key}=" "${ENV_FILE}" | cut -d= -f2- || true
   fi
-  echo "[sentinel] Press Enter to close."
-  read -r _
-fi
+}
 
-exit "${exit_code}"
+normalize_version_tag() {
+  local raw="${1:-}"
+  raw="${raw%%#*}"
+  raw="$(printf '%s' "${raw}" | tr -d '\r' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+  raw="${raw#v}"
+  if [[ ! "${raw}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    return 1
+  fi
+
+  printf 'v%s\n' "${raw}"
+}
+
+fetch_latest_release_version() {
+  local owner="${1:-deadshotomega}"
+  curl -fsSL --max-time 8 "https://api.github.com/repos/${owner}/sentinel/releases/latest" |
+    sed -n 's/.*"tag_name":[[:space:]]*"\(v[^"]*\)".*/\1/p' |
+    head -n1
+}
+
+can_use_zenity() {
+  command -v zenity >/dev/null 2>&1 && [[ -n "${DISPLAY:-}${WAYLAND_DISPLAY:-}" ]]
+}
+
+existing_install_detected() {
+  if [[ -f "${APPLIANCE_STATE_FILE}" ]]; then
+    return 0
+  fi
+
+  dpkg-query -W -f='${Status}\n' sentinel 2>/dev/null | grep -Fq 'install ok installed'
+}
+
+prompt_action_zenity() {
+  local install_selected update_selected
+  if existing_install_detected; then
+    update_selected="TRUE"
+    install_selected="FALSE"
+  else
+    update_selected="FALSE"
+    install_selected="TRUE"
+  fi
+
+  zenity --list \
+    --radiolist \
+    --title="Sentinel install and update" \
+    --text="Choose the guided workflow for this laptop." \
+    --width=520 \
+    --height=260 \
+    --column="" \
+    --column="Workflow" \
+    "${install_selected}" "Install Sentinel on this laptop" \
+    "${update_selected}" "Update existing Sentinel appliance"
+}
+
+prompt_action_terminal() {
+  local prompt
+  if existing_install_detected; then
+    prompt="Update existing Sentinel appliance"
+  else
+    prompt="Install Sentinel on this laptop"
+  fi
+
+  printf '\nSentinel install and update\n'
+  printf 'Recommended workflow: %s\n' "${prompt}"
+  printf '1) Install Sentinel on this laptop\n'
+  printf '2) Update existing Sentinel appliance\n'
+  read -r -p 'Choose a workflow [1/2]: ' selection
+  case "${selection}" in
+    1) printf 'Install Sentinel on this laptop\n' ;;
+    2) printf 'Update existing Sentinel appliance\n' ;;
+    *)
+      printf 'Invalid workflow selection.\n' >&2
+      exit 1
+      ;;
+  esac
+}
+
+prompt_version_zenity() {
+  local default_version="${1:-v1.0.0}" action_label="${2:-install}"
+  zenity --entry \
+    --title="Sentinel ${action_label}" \
+    --text="Enter the Sentinel release version to ${action_label} on this laptop." \
+    --entry-text="${default_version}"
+}
+
+prompt_version_terminal() {
+  local default_version="${1:-v1.0.0}" action_label="${2:-install}" version=""
+  printf '\nEnter the Sentinel release version to %s (example: v2.6.7)\n' "${action_label}"
+  read -r -p "Version [${default_version}]: " version
+  if [[ -z "${version}" ]]; then
+    version="${default_version}"
+  fi
+  printf '%s\n' "${version}"
+}
+
+confirm_continue_zenity() {
+  local title="${1:-Continue}" message="${2:-Continue?}"
+  zenity --question \
+    --title="${title}" \
+    --text="${message}" \
+    --ok-label="Continue" \
+    --cancel-label="Cancel"
+}
+
+confirm_continue_terminal() {
+  local message="${1:-Continue? [y/N]: }" reply
+  read -r -p "${message}" reply
+  [[ "${reply}" =~ ^[Yy]([Ee][Ss])?$ ]]
+}
+
+run_environment_preflight() {
+  local owner="${1:-deadshotomega}" action_label="${2:-install}"
+  local message
+
+  if curl -fsSL --max-time 10 "https://api.github.com/repos/${owner}/sentinel/releases/latest" >/dev/null; then
+    return 0
+  fi
+
+  message="Sentinel could not reach GitHub release metadata during preflight. ${action_label^} may still fail later if internet access is not restored."
+  if can_use_zenity; then
+    confirm_continue_zenity "Network preflight" "${message}"
+    return $?
+  fi
+
+  printf '[sentinel] %s\n' "${message}" >&2
+  confirm_continue_terminal "Continue anyway? [y/N]: "
+}
+
+read_hotspot_report_json() {
+  if [[ ! -x "${SCRIPT_DIR}/ensure-host-hotspot-profile.sh" ]]; then
+    return 0
+  fi
+
+  "${SCRIPT_DIR}/ensure-host-hotspot-profile.sh" --report-json 2>/dev/null || true
+}
+
+hotspot_report_field() {
+  local field="${1:-}" report_json="${2:-}"
+  [[ -n "${field}" && -n "${report_json}" ]] || return 0
+  command -v python3 >/dev/null 2>&1 || return 0
+  printf '%s' "${report_json}" |
+    python3 -c "import json, sys; payload = json.load(sys.stdin); print(payload.get('${field}', ''))"
+}
+
+prompt_hotspot_choice_zenity() {
+  local action_label="${1:-install}" message="${2:-Hotspot setup needs attention.}"
+  zenity --list \
+    --radiolist \
+    --title="Wireless recovery" \
+    --text="${message}" \
+    --width=560 \
+    --height=280 \
+    --column="" \
+    --column="Action" \
+    TRUE "Retry hotspot setup" \
+    FALSE "Continue without hotspot" \
+    FALSE "Cancel ${action_label}"
+}
+
+prompt_hotspot_choice_terminal() {
+  local action_label="${1:-install}" message="${2:-Hotspot setup needs attention.}" selection
+  printf '\n%s\n' "${message}"
+  printf '1) Retry hotspot setup\n'
+  printf '2) Continue without hotspot\n'
+  printf '3) Cancel %s\n' "${action_label}"
+  read -r -p 'Choose an action [1/2/3]: ' selection
+  case "${selection}" in
+    1) printf 'Retry hotspot setup\n' ;;
+    2) printf 'Continue without hotspot\n' ;;
+    3) printf 'Cancel %s\n' "${action_label}" ;;
+    *)
+      printf 'Invalid hotspot choice.\n' >&2
+      exit 1
+      ;;
+  esac
+}
+
+run_hotspot_wizard_gate() {
+  local action_label="${1:-install}" recovery_rc report_json report_issue report_message choice
+
+  while true; do
+    set +e
+    sudo bash "${SCRIPT_DIR}/recover-host-hotspot.sh"
+    recovery_rc=$?
+    set -e
+
+    report_json="$(read_hotspot_report_json)"
+    report_issue="$(hotspot_report_field issueCode "${report_json}")"
+    report_message="$(hotspot_report_field message "${report_json}")"
+
+    if [[ "${report_issue:-none}" == "none" && "${recovery_rc}" -eq 0 ]]; then
+      return 0
+    fi
+
+    if [[ -z "${report_message}" ]]; then
+      if [[ "${recovery_rc}" -eq 0 ]]; then
+        report_message="Hotspot setup finished, but Sentinel still could not verify the hosted AP cleanly."
+      else
+        report_message="Hotspot setup could not finish cleanly on the host laptop."
+      fi
+    fi
+
+    if can_use_zenity; then
+      choice="$(prompt_hotspot_choice_zenity "${action_label}" "${report_message}")" || exit 1
+    else
+      choice="$(prompt_hotspot_choice_terminal "${action_label}" "${report_message}")"
+    fi
+
+    case "${choice}" in
+      "Retry hotspot setup")
+        continue
+        ;;
+      "Continue without hotspot")
+        if can_use_zenity; then
+          zenity --warning \
+            --title="Continuing in degraded mode" \
+            --text="Sentinel will continue without a verified hotspot. The web app will keep showing the networking issue until the host hotspot is repaired."
+        else
+          printf '[sentinel] Continuing without a verified hotspot. Sentinel will remain in degraded networking mode.\n'
+        fi
+        return 0
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+  done
+}
+
+show_final_summary() {
+  local exit_code="${1:-0}" action_label="${2:-install}"
+  local summary
+  if [[ "${exit_code}" -eq 0 ]]; then
+    summary="Sentinel ${action_label} finished successfully."
+    if can_use_zenity; then
+      zenity --info --title="Sentinel ${action_label}" --text="${summary}"
+    fi
+  else
+    summary="Sentinel ${action_label} failed with exit code ${exit_code}. Review the terminal log for details."
+    if can_use_zenity; then
+      zenity --error --title="Sentinel ${action_label}" --text="${summary}"
+    fi
+  fi
+
+  if [[ -t 0 ]]; then
+    echo
+    echo "[sentinel] ${summary}"
+    echo "[sentinel] Press Enter to close."
+    read -r _
+  fi
+}
+
+main() {
+  local gh_owner default_version workflow action_label raw_version version_tag exit_code
+
+  gh_owner="$(read_env_value GHCR_OWNER)"
+  if [[ -z "${gh_owner}" ]]; then
+    gh_owner="deadshotomega"
+  fi
+
+  default_version="$(read_env_value SENTINEL_VERSION)"
+  if ! default_version="$(normalize_version_tag "${default_version}")"; then
+    default_version="$(fetch_latest_release_version "${gh_owner}" || true)"
+  fi
+  if ! default_version="$(normalize_version_tag "${default_version}")"; then
+    default_version="v1.0.0"
+  fi
+
+  if can_use_zenity; then
+    workflow="$(prompt_action_zenity)" || exit 1
+  else
+    workflow="$(prompt_action_terminal)"
+  fi
+
+  case "${workflow}" in
+    "Install Sentinel on this laptop")
+      action_label="install"
+      ;;
+    "Update existing Sentinel appliance")
+      action_label="update"
+      ;;
+    *)
+      printf 'Unknown workflow selection: %s\n' "${workflow}" >&2
+      exit 1
+      ;;
+  esac
+
+  if can_use_zenity; then
+    raw_version="$(prompt_version_zenity "${default_version}" "${action_label}")" || exit 1
+  else
+    raw_version="$(prompt_version_terminal "${default_version}" "${action_label}")"
+  fi
+  version_tag="$(normalize_version_tag "${raw_version}")" || {
+    printf 'Invalid version: %s\n' "${raw_version}" >&2
+    exit 1
+  }
+
+  run_environment_preflight "${gh_owner}" "${action_label}" || exit 1
+  run_hotspot_wizard_gate "${action_label}"
+
+  set +e
+  if [[ "${action_label}" == "install" ]]; then
+    bash "${SCRIPT_DIR}/install.sh" --version "${version_tag}"
+    exit_code=$?
+  else
+    SENTINEL_TARGET_VERSION="${version_tag}" bash "${SCRIPT_DIR}/sentinel_update_quiet.sh"
+    exit_code=$?
+  fi
+  set -e
+
+  show_final_summary "${exit_code}" "${action_label}"
+  exit "${exit_code}"
+}
+
+main "$@"

--- a/deploy/sentinel_update_quiet.sh
+++ b/deploy/sentinel_update_quiet.sh
@@ -13,9 +13,8 @@ set -Eeuo pipefail
 #   6) Verifies GitHub CLI authentication
 #   7) Downloads the matching .deb from GitHub Releases
 #   8) Installs the .deb
-#   9) Runs /opt/sentinel/deploy/update.sh --version v#.#.#
-#  10) Runs host hotspot recovery after a successful update
-#  11) Logs everything and reports errors clearly
+#   9) Runs /opt/sentinel/deploy/update.sh --version v#.#.#, including shared hotspot recovery
+#  10) Logs everything and reports errors clearly
 #
 # Notes:
 #   - The captive portal automation is best-effort and is most reliable on X11.
@@ -29,6 +28,7 @@ set -Eeuo pipefail
 # Optional environment overrides:
 #   SSID=MySSID CAPTIVE_URL=http://neverssl.com bash ./sentinel_update_quiet.sh
 #   SENTINEL_SHOW_PROGRESS=1 bash ./sentinel_update_quiet.sh   # show full update.sh output
+#   SENTINEL_TARGET_VERSION=v2.6.8 bash ./sentinel_update_quiet.sh
 
 #######################################
 # Configuration
@@ -40,7 +40,7 @@ DOWNLOAD_DIR="${DOWNLOAD_DIR:-${DEPLOY_DIR}/runtime/downloads}"
 CAPTIVE_URL="${CAPTIVE_URL:-http://neverssl.com}"
 CONNECTIVITY_TEST_URL="${CONNECTIVITY_TEST_URL:-http://connectivitycheck.gstatic.com/generate_204}"
 FALLBACK_TEST_URL="${FALLBACK_TEST_URL:-https://github.com}"
-HOTSPOT_CONNECTION_NAME="${HOTSPOT_CONNECTION_NAME:-Sentinel Hotspot}"
+SENTINEL_TARGET_VERSION="${SENTINEL_TARGET_VERSION:-}"
 
 LOG_DIR="${LOG_DIR:-/tmp}"
 TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
@@ -149,6 +149,19 @@ pick_browser() {
 
 prompt_version() {
   local version
+  if [[ -n "${SENTINEL_TARGET_VERSION}" ]]; then
+    version="${SENTINEL_TARGET_VERSION#v}"
+    if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      VERSION="$version"
+      TAG="v${VERSION}"
+      DEB_FILE="sentinel_${VERSION}_all.deb"
+      log "Using version from SENTINEL_TARGET_VERSION: ${VERSION}"
+      return 0
+    fi
+
+    die "Invalid SENTINEL_TARGET_VERSION value: ${SENTINEL_TARGET_VERSION}. Expected v#.#.# or #.#.#"
+  fi
+
   while true; do
     read -r -p "Enter Sentinel version (#.#.#, example 2.1.2): " version
     if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -524,24 +537,6 @@ run_update() {
   return "$update_rc"
 }
 
-run_post_update_hotspot_recovery() {
-  local recovery_script="${DEPLOY_DIR}/recover-host-hotspot.sh"
-
-  if [[ ! -x "${recovery_script}" ]]; then
-    warn "Hotspot recovery script not found or not executable: ${recovery_script}"
-    return 0
-  fi
-
-  log "Running post-update hotspot recovery for connection: ${HOTSPOT_CONNECTION_NAME}"
-  if sudo "${recovery_script}" "${HOTSPOT_CONNECTION_NAME}"; then
-    log "Post-update hotspot recovery completed."
-    return 0
-  fi
-
-  warn "Post-update hotspot recovery failed. Review logs above."
-  return 0
-}
-
 #######################################
 # Main
 #######################################
@@ -606,7 +601,6 @@ main() {
   download_release_deb
   install_deb
   run_update
-  run_post_update_hotspot_recovery
 
   log "Sentinel update completed successfully."
   log "Log saved to: ${LOG_FILE}"

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -308,6 +308,7 @@ fi
 
 ensure_mdns_hostname
 ensure_local_wiki_host_alias
+run_host_hotspot_recovery_nonblocking
 MDNS_HOSTNAME="$(env_value MDNS_HOSTNAME sentinel)"
 WIKI_DOMAIN="$(env_value WIKI_DOMAIN docs.sentinel.local)"
 

--- a/deploy/write-network-status.sh
+++ b/deploy/write-network-status.sh
@@ -10,6 +10,7 @@ OUTPUT_FILE="${OUTPUT_DIR}/network-status.json"
 CHECK_URL="$(env_value NETWORK_REACHABILITY_CHECK_URL "$(env_value CAPTIVE_PORTAL_RECOVERY_CHECK_URL https://connectivitycheck.gstatic.com/generate_204)")"
 REMOTE_TARGET="$(env_value NETWORK_REMOTE_REACHABILITY_TARGET "$(env_value CAPTIVE_PORTAL_TAILSCALE_TARGET)")"
 HOTSPOT_CONNECTION_NAME="$(env_value HOTSPOT_CONNECTION_NAME 'Sentinel Hotspot')"
+BACKEND_READER_GROUP="${BACKEND_READER_GROUP:-sentinel-backend}"
 
 json_escape() {
   printf '%s' "${1:-}" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
@@ -177,6 +178,25 @@ check_target() {
   esac
 }
 
+set_output_permissions() {
+  local path="$1"
+
+  if [[ -z "${path}" || ! -e "${path}" ]]; then
+    return 0
+  fi
+
+  if getent group "${BACKEND_READER_GROUP}" >/dev/null 2>&1; then
+    chgrp "${BACKEND_READER_GROUP}" "${path}" >/dev/null 2>&1 || true
+    chmod 640 "${path}" >/dev/null 2>&1 || true
+    return 0
+  fi
+
+  chmod 644 "${path}" >/dev/null 2>&1 || true
+}
+
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/ensure-host-hotspot-profile.sh"
+
 mkdir -p "${OUTPUT_DIR}"
 
 generated_at="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
@@ -187,11 +207,28 @@ internet_reachable_value="null"
 remote_reachable_value="null"
 portal_recovery_likely_value="null"
 message_value="Telemetry snapshot captured"
-hotspot_device_value="$(hotspot_connection_device || true)"
-hotspot_ssid_value="$(hotspot_connection_ssid || true)"
-hotspot_scan_device_value="$(resolve_hotspot_scan_device "${hotspot_device_value}")"
+hotspot_issue_code_value="none"
+hotspot_profile_present_value="false"
+hotspot_adapter_approved_value="false"
+scan_adapter_present_value="false"
+hotspot_device_value=""
+hotspot_ssid_value="$(env_value HOTSPOT_SSID 'Stone Frigate')"
+hotspot_scan_device_value=""
 hotspot_ssid_visible_from_laptop_value="null"
+hotspot_collect_runtime_state || true
+hotspot_issue_code_value="${HOTSPOT_STATE_ISSUE_CODE:-none}"
+hotspot_profile_present_value="${HOTSPOT_STATE_PROFILE_PRESENT:-false}"
+hotspot_adapter_approved_value="${HOTSPOT_STATE_HOTSPOT_ADAPTER_APPROVED:-false}"
+scan_adapter_present_value="${HOTSPOT_STATE_SCAN_ADAPTER_PRESENT:-false}"
+hotspot_device_value="${HOTSPOT_STATE_HOTSPOT_DEVICE:-}"
+hotspot_ssid_value="${HOTSPOT_STATE_HOTSPOT_SSID:-${hotspot_ssid_value}}"
+hotspot_scan_device_value="${HOTSPOT_STATE_HOTSPOT_SCAN_DEVICE:-}"
+hotspot_ssid_visible_from_laptop_value="${HOTSPOT_STATE_HOTSPOT_VISIBILITY:-null}"
 host_ip_address_value="$(resolve_host_ip_address "${hotspot_device_value}")"
+
+if [[ "${hotspot_issue_code_value}" != "none" && -n "${HOTSPOT_STATE_MESSAGE:-}" ]]; then
+  message_value="${HOTSPOT_STATE_MESSAGE}"
+fi
 
 if wifi_connected; then
   wifi_connected_value="true"
@@ -202,20 +239,14 @@ fi
 
 current_ssid_value="$(current_ssid || true)"
 
-if is_ssid_visible_on_device "${hotspot_scan_device_value}" "${hotspot_ssid_value}"; then
-  hotspot_ssid_visible_from_laptop_value="true"
-elif [[ $? -eq 1 ]]; then
-  hotspot_ssid_visible_from_laptop_value="false"
-fi
-
 if check_url "${CHECK_URL}"; then
   internet_reachable_value="true"
 elif command -v curl >/dev/null 2>&1; then
   internet_reachable_value="false"
-  if [[ "${wifi_connected_value}" == "true" ]]; then
+  if [[ "${wifi_connected_value}" == "true" && "${hotspot_issue_code_value}" == "none" ]]; then
     portal_recovery_likely_value="true"
     message_value="Internet reachability failed while Wi-Fi is connected"
-  else
+  elif [[ "${hotspot_issue_code_value}" == "none" ]]; then
     message_value="Internet reachability failed"
   fi
 fi
@@ -225,13 +256,13 @@ if [[ -n "${REMOTE_TARGET}" ]]; then
     remote_reachable_value="true"
   else
     remote_reachable_value="false"
-    if [[ "${internet_reachable_value}" == "true" ]]; then
+    if [[ "${internet_reachable_value}" == "true" && "${hotspot_issue_code_value}" == "none" ]]; then
       message_value="Remote reachability failed for ${REMOTE_TARGET}"
     fi
   fi
 fi
 
-if [[ "${wifi_connected_value}" == "true" && "${internet_reachable_value}" == "true" ]]; then
+if [[ "${wifi_connected_value}" == "true" && "${internet_reachable_value}" == "true" && "${hotspot_issue_code_value}" == "none" ]]; then
   message_value="Connected to Wi-Fi and internet is reachable"
 fi
 
@@ -239,9 +270,14 @@ tmp_file="$(mktemp "${OUTPUT_DIR}/network-status.XXXXXX")"
 cat >"${tmp_file}" <<JSON
 {
   "generatedAt": "${generated_at}",
+  "issueCode": "$(json_escape "${hotspot_issue_code_value}")",
   "wifiConnected": ${wifi_connected_value},
   "currentSsid": $(json_string_or_null "${current_ssid_value}"),
   "hostIpAddress": $(json_string_or_null "${host_ip_address_value}"),
+  "hotspotProfilePresent": $(json_bool "${hotspot_profile_present_value}"),
+  "hotspotAdapterApproved": $(json_bool "${hotspot_adapter_approved_value}"),
+  "scanAdapterPresent": $(json_bool "${scan_adapter_present_value}"),
+  "hotspotDevice": $(json_string_or_null "${hotspot_device_value}"),
   "hotspotSsid": $(json_string_or_null "${hotspot_ssid_value}"),
   "hotspotScanDevice": $(json_string_or_null "${hotspot_scan_device_value}"),
   "hotspotSsidVisibleFromLaptop": ${hotspot_ssid_visible_from_laptop_value},
@@ -252,4 +288,5 @@ cat >"${tmp_file}" <<JSON
   "message": $(json_string_or_null "${message_value}")
 }
 JSON
+set_output_permissions "${tmp_file}"
 mv "${tmp_file}" "${OUTPUT_FILE}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "2.6.7",
+  "version": "2.7.0",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "2.6.7",
+  "version": "2.7.0",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/contracts/src/schemas/system-status.schema.ts
+++ b/packages/contracts/src/schemas/system-status.schema.ts
@@ -18,14 +18,35 @@ export const DatabaseHealthSchema = v.object({
   address: v.nullable(v.string()),
 })
 
+export const NetworkIssueCodeSchema = v.picklist(
+  [
+    'none',
+    'telemetry_unavailable',
+    'telemetry_stale',
+    'wifi_disconnected',
+    'unapproved_ssid',
+    'hotspot_profile_missing',
+    'approved_hotspot_adapter_missing',
+    'scan_adapter_missing',
+    'hotspot_not_visible',
+    'remote_reachability_failed',
+  ],
+  'Choose a valid network issue code'
+)
+
 export const NetworkFactsSchema = v.object({
   status: SystemHealthStatusSchema,
   telemetryAvailable: v.boolean(),
   telemetryAgeSeconds: v.nullable(v.number()),
   message: v.string(),
+  issueCode: NetworkIssueCodeSchema,
   wifiConnected: v.nullable(v.boolean()),
   currentSsid: v.nullable(v.string()),
   hostIpAddress: v.nullable(v.string()),
+  hotspotProfilePresent: v.nullable(v.boolean()),
+  hotspotAdapterApproved: v.nullable(v.boolean()),
+  scanAdapterPresent: v.nullable(v.boolean()),
+  hotspotDevice: v.nullable(v.string()),
   hotspotSsid: v.nullable(v.string()),
   hotspotScanDevice: v.nullable(v.string()),
   hotspotSsidVisibleFromLaptop: v.nullable(v.boolean()),
@@ -75,6 +96,7 @@ export const SystemStatusResponseSchema = v.object({
 export type SystemHealthStatus = v.InferOutput<typeof SystemHealthStatusSchema>
 export type BackendHealth = v.InferOutput<typeof BackendHealthSchema>
 export type DatabaseHealth = v.InferOutput<typeof DatabaseHealthSchema>
+export type NetworkIssueCode = v.InferOutput<typeof NetworkIssueCodeSchema>
 export type NetworkFacts = v.InferOutput<typeof NetworkFactsSchema>
 export type ActiveRemoteSession = v.InferOutput<typeof ActiveRemoteSessionSchema>
 export type ActiveRemoteSystemsSummary = v.InferOutput<typeof ActiveRemoteSystemsSummarySchema>

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "2.6.7",
+  "version": "2.7.0",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "2.6.7",
+  "version": "2.7.0",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## What changed
- prepares the full current worktree for the `v2.7.0` release on top of the existing `v2.6.7` mainline
- includes the host hotspot recovery and network-status UX/backend work already present in the tree
- includes the system updater hardening, GitHub release lookup caching, and update-screen retry improvements
- bumps the workspace version set from `2.6.7` to `2.7.0`

## Why it changed
- this batches the current appliance, backend, and frontend improvements into a single release-prep branch
- it fixes the updater path that could keep using a stale `SENTINEL_VERSION` and fail explicit updates
- it reduces GitHub API pressure from the update status polling path and improves retry behavior when latest-release lookup is temporarily unavailable

## Impact
- host appliances get stronger hotspot/profile recovery and clearer update behavior
- the admin UI can retry the last failed update target even if latest-release lookup is temporarily unknown
- backend update status polling is less likely to trigger GitHub unauthenticated rate limits

## Validation
- `pnpm version:check`
- `pnpm typecheck`
- `apps/frontend-admin/node_modules/.bin/vitest run apps/backend/src/services/system-update-status-service.test.ts apps/backend/src/routes/system-update.test.ts apps/frontend-admin/src/components/settings/system-update-panel.logic.test.ts apps/frontend-admin/src/components/layout/app-navbar.logic.test.ts`
- `python3 -m py_compile deploy/deb/assets/usr/lib/sentinel/sentinel-updater deploy/deb/assets/usr/lib/sentinel/sentinel_update_common.py`
