### PR TITLE
feat(release): prepare v2.7.1

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/app/dashboard/page.tsx
+++ b/apps/frontend-admin/src/app/dashboard/page.tsx
@@ -22,11 +22,11 @@ export default function DashboardPage() {
         <section aria-label="Dashboard update verification tools">
           <AppAlert
             tone="info"
-            heading="Update verification shortcuts"
-            description="Jump straight into the new update flow or open the host-side trace log from the dashboard."
+            heading="Update readiness shortcuts"
+            description="Launch the update flow or inspect the host trace log without leaving the dashboard."
             meta={
               <AppBadge status="info" size="sm">
-                Update test
+                Release prep
               </AppBadge>
             }
             actions={
@@ -36,14 +36,14 @@ export default function DashboardPage() {
                   className="btn btn-sm btn-outline"
                   data-testid={TID.dashboard.updateBanner.updatesLink}
                 >
-                  Open updates
+                  Open update flow
                 </Link>
                 <Link
                   href="/settings?tab=updates&trace=open"
                   className="btn btn-sm btn-primary"
                   data-testid={TID.dashboard.updateBanner.traceLink}
                 >
-                  Open update log
+                  Open trace log
                 </Link>
               </div>
             }
@@ -51,8 +51,8 @@ export default function DashboardPage() {
             data-testid={TID.dashboard.updateBanner.panel}
           >
             <p className="text-sm text-base-content/80">
-              Use these shortcuts to validate both the update request flow and the update log viewer
-              without leaving the dashboard first.
+              Use these shortcuts during release checks to confirm the operator flow and the
+              host-side trace output stay aligned in one pass.
             </p>
           </AppAlert>
         </section>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary
- refresh the dashboard update banner copy for release-prep clarity
- bump the monorepo and workspace package versions to 2.7.1

## Validation
- pnpm version:check
- pnpm --filter frontend-admin typecheck
- pnpm --filter frontend-admin lint (repo has pre-existing warnings only)
- Playwright verification skipped per request