### PR TITLE
feat(update): surface structured progress checkpoints

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/lib/system-update-state.ts
+++ b/apps/backend/src/lib/system-update-state.ts
@@ -1,6 +1,8 @@
 import type {
+  SystemUpdateCheckpoint,
   SystemUpdateJob,
   SystemUpdateJobStatus,
+  SystemUpdatePhase,
   SystemUpdateVersion,
 } from '@sentinel/contracts'
 import { AccountLevel } from '../middleware/roles.js'
@@ -30,6 +32,130 @@ const TERMINAL_JOB_STATUSES = new Set<SystemUpdateJobStatus>([
   'rollback_attempted',
   'rolled_back',
 ])
+const PRIMARY_PHASES = [
+  {
+    key: 'prepare_update',
+    label: 'Prepare update',
+    description: 'Confirm the requested release and gather trusted metadata.',
+    kind: 'primary',
+    order: 1,
+    total: 5,
+  },
+  {
+    key: 'protect_current_system',
+    label: 'Protect current system',
+    description: 'Create recovery assets before applying the new release.',
+    kind: 'primary',
+    order: 2,
+    total: 5,
+  },
+  {
+    key: 'install_release',
+    label: 'Install release',
+    description: 'Download, verify, and install the requested Sentinel package.',
+    kind: 'primary',
+    order: 3,
+    total: 5,
+  },
+  {
+    key: 'bring_services_back',
+    label: 'Bring services back',
+    description: 'Pull updated images and restart the Sentinel stack.',
+    kind: 'primary',
+    order: 4,
+    total: 5,
+  },
+  {
+    key: 'verify_and_finalize',
+    label: 'Verify and finalize',
+    description: 'Run health checks and final appliance recovery tasks.',
+    kind: 'primary',
+    order: 5,
+    total: 5,
+  },
+  {
+    key: 'recovery',
+    label: 'Recovery',
+    description: 'Attempt rollback or point the operator to restore guidance.',
+    kind: 'recovery',
+    order: 5,
+    total: 5,
+  },
+] as const satisfies readonly SystemUpdatePhase[]
+const PHASE_BY_KEY = new Map(PRIMARY_PHASES.map((phase) => [phase.key, phase]))
+
+const CHECKPOINT_BY_STATUS: Record<SystemUpdateJobStatus, SystemUpdateCheckpoint> = {
+  idle: {
+    key: 'request_accepted',
+    label: 'Update request accepted',
+    detail: 'The updater has accepted the update request and is waiting to continue.',
+  },
+  requested: {
+    key: 'request_accepted',
+    label: 'Update request accepted',
+    detail: 'The updater has accepted the update request and is waiting to continue.',
+  },
+  authorized: {
+    key: 'request_authorized',
+    label: 'Request authorized',
+    detail: 'The requested Sentinel release was validated and authorized to continue.',
+  },
+  staging: {
+    key: 'creating_pre_update_backup',
+    label: 'Creating pre-update backup',
+    detail: 'Creating Sentinel and Wiki.js backups before any changes are applied.',
+  },
+  downloading: {
+    key: 'downloading_release',
+    label: 'Downloading release',
+    detail: 'Downloading the requested Sentinel package and release metadata.',
+  },
+  verifying: {
+    key: 'verifying_release_artifacts',
+    label: 'Verifying release artifacts',
+    detail: 'Checking release checksums and manifests before installation.',
+  },
+  installing: {
+    key: 'installing_package',
+    label: 'Installing package',
+    detail: 'Installing the requested Sentinel package on the host appliance.',
+  },
+  post_install: {
+    key: 'pulling_container_images',
+    label: 'Pulling container images',
+    detail: 'Pulling the updated container images for the Sentinel stack.',
+  },
+  restarting: {
+    key: 'restarting_services',
+    label: 'Restarting services',
+    detail: 'Recreating the Sentinel stack and waiting for containers to report healthy.',
+  },
+  health_check: {
+    key: 'waiting_for_health_endpoint',
+    label: 'Waiting for health checks',
+    detail: 'Waiting for Sentinel to report healthy at the local health endpoint.',
+  },
+  completed: {
+    key: 'update_completed',
+    label: 'Update completed',
+    detail: 'Sentinel finished the update and returned to steady state.',
+  },
+  failed: {
+    key: 'update_failed',
+    label: 'Update failed',
+    detail: 'The update stopped and needs operator attention before retrying.',
+  },
+  rollback_attempted: {
+    key: 'attempting_rollback',
+    label: 'Attempting rollback',
+    detail: 'Rolling back to the last known good Sentinel release.',
+  },
+  rolled_back: {
+    key: 'rollback_completed',
+    label: 'Rollback completed',
+    detail: 'Sentinel rolled back to the previous known good release.',
+  },
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
@@ -107,12 +233,116 @@ function parseNullableVersion(value: unknown, fieldName: string): SystemUpdateVe
   return version
 }
 
+function derivePhase(status: SystemUpdateJobStatus): SystemUpdatePhase {
+  switch (status) {
+    case 'requested':
+    case 'authorized':
+    case 'idle':
+      return PHASE_BY_KEY.get('prepare_update')!
+    case 'staging':
+      return PHASE_BY_KEY.get('protect_current_system')!
+    case 'downloading':
+    case 'verifying':
+    case 'installing':
+      return PHASE_BY_KEY.get('install_release')!
+    case 'post_install':
+    case 'restarting':
+      return PHASE_BY_KEY.get('bring_services_back')!
+    case 'health_check':
+    case 'completed':
+      return PHASE_BY_KEY.get('verify_and_finalize')!
+    case 'failed':
+    case 'rollback_attempted':
+    case 'rolled_back':
+      return PHASE_BY_KEY.get('recovery')!
+  }
+}
+
+function parsePhase(value: unknown, status: SystemUpdateJobStatus): SystemUpdatePhase {
+  if (!isRecord(value)) {
+    return derivePhase(status)
+  }
+
+  const key = typeof value.key === 'string' ? value.key.trim() : ''
+  const fallback = derivePhase(status)
+  const definition = PHASE_BY_KEY.get(key as (typeof PRIMARY_PHASES)[number]['key']) ?? fallback
+
+  const description =
+    value.description === null
+      ? null
+      : typeof value.description === 'string' && value.description.trim().length > 0
+        ? value.description.trim()
+        : definition.description
+
+  const kind =
+    typeof value.kind === 'string' && value.kind.trim().length > 0
+      ? value.kind.trim()
+      : definition.kind
+
+  const order =
+    typeof value.order === 'number' && Number.isInteger(value.order) && value.order > 0
+      ? value.order
+      : definition.order
+
+  const total =
+    typeof value.total === 'number' && Number.isInteger(value.total) && value.total > 0
+      ? value.total
+      : definition.total
+
+  return {
+    key: definition.key,
+    label:
+      typeof value.label === 'string' && value.label.trim().length > 0
+        ? value.label.trim()
+        : definition.label,
+    description,
+    kind,
+    order,
+    total,
+  }
+}
+
+function parseCheckpoint(
+  value: unknown,
+  status: SystemUpdateJobStatus,
+  message: string
+): SystemUpdateCheckpoint {
+  const fallback = CHECKPOINT_BY_STATUS[status]
+
+  if (!isRecord(value)) {
+    return {
+      ...fallback,
+      detail: message.trim().length > 0 ? message : fallback.detail,
+    }
+  }
+
+  const key =
+    typeof value.key === 'string' && value.key.trim().length > 0 ? value.key.trim() : fallback.key
+  const label =
+    typeof value.label === 'string' && value.label.trim().length > 0
+      ? value.label.trim()
+      : fallback.label
+  const detail =
+    typeof value.detail === 'string' && value.detail.trim().length > 0
+      ? value.detail.trim()
+      : message.trim().length > 0
+        ? message
+        : fallback.detail
+
+  return {
+    key,
+    label,
+    detail,
+  }
+}
+
 export function sanitizeSystemUpdateJob(payload: unknown): SystemUpdateJob {
   if (!isRecord(payload)) {
     throw new Error('Updater job payload must be an object.')
   }
 
   const status = parseJobStatus(payload.status)
+  const message = requireString(payload.message, 'message')
   const requestedBy = payload.requestedBy
 
   if (!isRecord(requestedBy)) {
@@ -123,13 +353,15 @@ export function sanitizeSystemUpdateJob(payload: unknown): SystemUpdateJob {
     jobId: parseJobId(payload.jobId),
     status,
     step: status,
-    message: requireString(payload.message, 'message'),
+    message,
     requestedAt: requireString(payload.requestedAt, 'requestedAt'),
     startedAt: parseNullableString(payload.startedAt, 'startedAt'),
     finishedAt: parseNullableString(payload.finishedAt, 'finishedAt'),
     currentVersion: parseNullableVersion(payload.currentVersion, 'currentVersion'),
     latestVersion: parseNullableVersion(payload.latestVersion, 'latestVersion'),
     targetVersion: parseVersion(payload.targetVersion, 'targetVersion'),
+    phase: parsePhase(payload.phase, status),
+    checkpoint: parseCheckpoint(payload.checkpoint, status, message),
     failureSummary: parseNullableString(payload.failureSummary, 'failureSummary'),
     rollbackAttempted: Boolean(payload.rollbackAttempted),
     requestedBy: {
@@ -143,6 +375,20 @@ export function sanitizeSystemUpdateJob(payload: unknown): SystemUpdateJob {
 
 export function isSystemUpdateJobTerminal(status: SystemUpdateJobStatus): boolean {
   return TERMINAL_JOB_STATUSES.has(status)
+}
+
+export function isSystemUpdateJobFinished(
+  job: Pick<SystemUpdateJob, 'status' | 'finishedAt'> | null | undefined
+): boolean {
+  if (!job) {
+    return true
+  }
+
+  if (job.status === 'rollback_attempted') {
+    return job.finishedAt !== null
+  }
+
+  return TERMINAL_JOB_STATUSES.has(job.status)
 }
 
 export function hasSystemUpdatePermission(accountLevel: number | null | undefined): boolean {

--- a/apps/backend/src/routes/system-update.test.ts
+++ b/apps/backend/src/routes/system-update.test.ts
@@ -56,6 +56,19 @@ function createJob(overrides?: Partial<Record<string, unknown>>) {
     currentVersion: 'v2.6.1',
     latestVersion: 'v2.6.2',
     targetVersion: 'v2.6.2',
+    phase: {
+      key: 'prepare_update',
+      label: 'Prepare update',
+      description: 'Confirm the requested release and gather trusted metadata.',
+      kind: 'primary',
+      order: 1,
+      total: 5,
+    },
+    checkpoint: {
+      key: 'request_accepted',
+      label: 'Update request accepted',
+      detail: 'Queued for update.',
+    },
     failureSummary: null,
     rollbackAttempted: false,
     requestedBy: {
@@ -260,6 +273,92 @@ describe('systemUpdateRouter', () => {
       expect(response.status).toBe(409)
       expect(response.body).toMatchObject({
         error: 'CONFLICT',
+      })
+    } finally {
+      await rm(stateRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('treats an unfinished rollback as an active update job', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'sentinel-system-update-state-'))
+    await mkdir(join(stateRoot, 'jobs'), { recursive: true })
+    await writeJson(
+      join(stateRoot, 'current-job.json'),
+      createJob({
+        status: 'rollback_attempted',
+        finishedAt: null,
+        message: 'Attempting rollback to v2.6.1.',
+        phase: {
+          key: 'recovery',
+          label: 'Recovery',
+          description: 'Attempt rollback or point the operator to restore guidance.',
+          kind: 'recovery',
+          order: 5,
+          total: 5,
+        },
+        checkpoint: {
+          key: 'attempting_rollback',
+          label: 'Attempting rollback',
+          detail: 'Rolling back to the last known good Sentinel release.',
+        },
+      })
+    )
+
+    process.env.APP_VERSION = 'v2.6.1'
+    process.env.SYSTEM_UPDATE_STATE_ROOT = stateRoot
+    process.env.SENTINEL_APPLIANCE_STATE = join(stateRoot, 'missing-appliance-state.json')
+    process.env.SYSTEM_UPDATE_RELEASE_REPOSITORY = ''
+
+    try {
+      const app = createTestApp(5)
+      const response = await request(app)
+        .post('/api/admin/system/update')
+        .send({ targetVersion: 'v2.6.2' })
+
+      expect(response.status).toBe(409)
+      expect(response.body).toMatchObject({
+        error: 'CONFLICT',
+      })
+    } finally {
+      await rm(stateRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('derives phase and checkpoint fields for legacy updater job payloads', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'sentinel-system-update-state-'))
+    await mkdir(join(stateRoot, 'jobs'), { recursive: true })
+
+    const legacyJob = createJob({
+      status: 'health_check',
+      finishedAt: null,
+      message: 'Waiting for Sentinel health checks to pass.',
+    }) as Record<string, unknown>
+    delete legacyJob.phase
+    delete legacyJob.checkpoint
+
+    await writeJson(join(stateRoot, 'current-job.json'), legacyJob)
+
+    process.env.APP_VERSION = 'v2.6.1'
+    process.env.SYSTEM_UPDATE_STATE_ROOT = stateRoot
+    process.env.SENTINEL_APPLIANCE_STATE = join(stateRoot, 'missing-appliance-state.json')
+    process.env.SYSTEM_UPDATE_RELEASE_REPOSITORY = ''
+
+    try {
+      const app = createTestApp(5)
+      const response = await request(app).get('/api/admin/system/update')
+
+      expect(response.status).toBe(200)
+      expect(response.body).toMatchObject({
+        currentJob: {
+          status: 'health_check',
+          phase: {
+            key: 'verify_and_finalize',
+          },
+          checkpoint: {
+            key: 'waiting_for_health_endpoint',
+            detail: 'Waiting for Sentinel health checks to pass.',
+          },
+        },
       })
     } finally {
       await rm(stateRoot, { recursive: true, force: true })

--- a/apps/backend/src/routes/system-update.ts
+++ b/apps/backend/src/routes/system-update.ts
@@ -3,7 +3,7 @@ import { initServer } from '@ts-rest/express'
 import type { Request } from 'express'
 import { systemUpdateContract } from '@sentinel/contracts'
 import { compareVersionTags } from '../lib/service-version.js'
-import { hasSystemUpdatePermission, isSystemUpdateJobTerminal } from '../lib/system-update-state.js'
+import { hasSystemUpdatePermission, isSystemUpdateJobFinished } from '../lib/system-update-state.js'
 import { getRequestClientIp } from '../lib/runtime-context.js'
 import {
   SystemUpdateBridgeClient,
@@ -99,7 +99,7 @@ export function createSystemUpdateRouter(options?: {
       try {
         const status = await statusService.getStatus()
 
-        if (status.currentJob && !isSystemUpdateJobTerminal(status.currentJob.status)) {
+        if (status.currentJob && !isSystemUpdateJobFinished(status.currentJob)) {
           return {
             status: 409 as const,
             body: {

--- a/apps/backend/src/services/system-update-status-service.ts
+++ b/apps/backend/src/services/system-update-status-service.ts
@@ -7,7 +7,7 @@ import {
   isStableVersionTag,
   resolveServiceVersionTag,
 } from '../lib/service-version.js'
-import { isSystemUpdateJobTerminal, sanitizeSystemUpdateJob } from '../lib/system-update-state.js'
+import { isSystemUpdateJobFinished, sanitizeSystemUpdateJob } from '../lib/system-update-state.js'
 
 const DEFAULT_STATE_ROOT = '/var/lib/sentinel/updater'
 const DEFAULT_APPLIANCE_STATE_PATH = '/var/lib/sentinel/appliance/state.json'
@@ -76,7 +76,7 @@ export class SystemUpdateStatusService {
     )
     const releaseSummary = await this.fetchLatestReleaseSummary()
     const completedJobVersion =
-      currentJob && isSystemUpdateJobTerminal(currentJob.status) ? currentJob.currentVersion : null
+      currentJob && isSystemUpdateJobFinished(currentJob) ? currentJob.currentVersion : null
     const currentVersion =
       applianceStateVersion ??
       completedJobVersion ??
@@ -101,7 +101,7 @@ export class SystemUpdateStatusService {
     currentJob: SystemUpdateJob | null,
     applianceStateVersion: string | null
   ): SystemUpdateJob | null {
-    if (!currentJob || !applianceStateVersion || !isSystemUpdateJobTerminal(currentJob.status)) {
+    if (!currentJob || !applianceStateVersion || !isSystemUpdateJobFinished(currentJob)) {
       return currentJob
     }
 

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/components/layout/app-navbar.tsx
+++ b/apps/frontend-admin/src/components/layout/app-navbar.tsx
@@ -7,6 +7,7 @@ import { useSyncExternalStore } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import type {
   SystemHealthStatus,
+  SystemUpdateJob,
   SystemStatusResponse,
   SystemUpdateJobStatus,
 } from '@sentinel/contracts'
@@ -137,7 +138,7 @@ export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
   const updateAvailable = systemUpdateStatus?.updateAvailable ?? false
   const currentSystemUpdateJob = systemUpdateStatus?.currentJob ?? null
   const hasActiveSystemUpdate =
-    currentSystemUpdateJob !== null && !isSystemUpdateJobTerminal(currentSystemUpdateJob.status)
+    currentSystemUpdateJob !== null && !isSystemUpdateJobTerminal(currentSystemUpdateJob)
 
   const handleHostHotspotRecovery = async () => {
     try {
@@ -1130,13 +1131,18 @@ function safeParseUrl(value: string) {
   }
 }
 
-function isSystemUpdateJobTerminal(status: SystemUpdateJobStatus): boolean {
-  return (
-    status === 'completed' ||
-    status === 'failed' ||
-    status === 'rollback_attempted' ||
-    status === 'rolled_back'
-  )
+function isSystemUpdateJobTerminal(
+  job: Pick<SystemUpdateJob, 'status' | 'finishedAt'> | null
+): boolean {
+  if (!job) {
+    return true
+  }
+
+  if (job.status === 'rollback_attempted') {
+    return job.finishedAt !== null
+  }
+
+  return job.status === 'completed' || job.status === 'failed' || job.status === 'rolled_back'
 }
 
 function formatSystemUpdateStatus(status: SystemUpdateJobStatus): string {

--- a/apps/frontend-admin/src/components/settings/system-update-panel.logic.test.ts
+++ b/apps/frontend-admin/src/components/settings/system-update-panel.logic.test.ts
@@ -3,6 +3,8 @@ import type { SystemUpdateJob, SystemUpdateStatusResponse } from '@sentinel/cont
 import {
   getPreferredUpdateTargetVersion,
   getRetryableTargetVersion,
+  getSystemUpdatePhaseProgress,
+  isSystemUpdateJobTerminal,
 } from './system-update-panel.logic'
 
 function createJob(overrides?: Partial<SystemUpdateJob>): SystemUpdateJob {
@@ -17,6 +19,19 @@ function createJob(overrides?: Partial<SystemUpdateJob>): SystemUpdateJob {
     currentVersion: 'v2.6.6',
     latestVersion: null,
     targetVersion: 'v2.6.7',
+    phase: {
+      key: 'recovery',
+      label: 'Recovery',
+      description: 'Attempt rollback or point the operator to restore guidance.',
+      kind: 'recovery',
+      order: 5,
+      total: 5,
+    },
+    checkpoint: {
+      key: 'update_failed',
+      label: 'Update failed',
+      detail: 'The update stopped and needs operator attention before retrying.',
+    },
     failureSummary: 'Release metadata request failed with HTTP 403',
     rollbackAttempted: false,
     requestedBy: {
@@ -62,5 +77,59 @@ describe('system-update-panel logic', () => {
     )
 
     expect(targetVersion).toBeNull()
+  })
+
+  it('marks rollback_attempted as active until it has a finished timestamp', () => {
+    expect(
+      isSystemUpdateJobTerminal(
+        createJob({
+          status: 'rollback_attempted',
+          step: 'rollback_attempted',
+          finishedAt: null,
+        })
+      )
+    ).toBe(false)
+
+    expect(
+      isSystemUpdateJobTerminal(
+        createJob({
+          status: 'rollback_attempted',
+          step: 'rollback_attempted',
+          finishedAt: '2026-04-23T10:33:40Z',
+        })
+      )
+    ).toBe(true)
+  })
+
+  it('builds phase progress from updater-owned phase and checkpoint fields', () => {
+    const phases = getSystemUpdatePhaseProgress(
+      createJob({
+        status: 'health_check',
+        step: 'health_check',
+        finishedAt: null,
+        phase: {
+          key: 'verify_and_finalize',
+          label: 'Verify and finalize',
+          description: 'Run health checks and final appliance recovery tasks.',
+          kind: 'primary',
+          order: 5,
+          total: 5,
+        },
+        checkpoint: {
+          key: 'recovering_hotspot',
+          label: 'Checking hotspot recovery',
+          detail: 'Checking hosted hotspot recovery.',
+        },
+      })
+    )
+
+    expect(phases.map((phase) => phase.state)).toEqual([
+      'complete',
+      'complete',
+      'complete',
+      'complete',
+      'active',
+    ])
+    expect(phases[4]?.caption).toBe('Checking hosted hotspot recovery.')
   })
 })

--- a/apps/frontend-admin/src/components/settings/system-update-panel.logic.ts
+++ b/apps/frontend-admin/src/components/settings/system-update-panel.logic.ts
@@ -1,10 +1,64 @@
-import type { SystemUpdateJob, SystemUpdateStatusResponse } from '@sentinel/contracts'
+import type {
+  SystemUpdateCheckpoint,
+  SystemUpdateJob,
+  SystemUpdateStatusResponse,
+} from '@sentinel/contracts'
 
 const RETRYABLE_STATUSES = new Set<SystemUpdateJob['status']>([
   'failed',
   'rollback_attempted',
   'rolled_back',
 ])
+
+type PrimaryPhaseKey =
+  | 'prepare_update'
+  | 'protect_current_system'
+  | 'install_release'
+  | 'bring_services_back'
+  | 'verify_and_finalize'
+
+interface PrimaryPhaseDefinition {
+  key: PrimaryPhaseKey
+  label: string
+  description: string
+}
+
+const PRIMARY_PHASES: readonly PrimaryPhaseDefinition[] = [
+  {
+    key: 'prepare_update',
+    label: 'Prepare update',
+    description: 'Confirm the requested release and gather trusted metadata.',
+  },
+  {
+    key: 'protect_current_system',
+    label: 'Protect current system',
+    description: 'Create recovery assets before applying the new release.',
+  },
+  {
+    key: 'install_release',
+    label: 'Install release',
+    description: 'Download, verify, and install the requested Sentinel package.',
+  },
+  {
+    key: 'bring_services_back',
+    label: 'Bring services back',
+    description: 'Pull updated images and restart the Sentinel stack.',
+  },
+  {
+    key: 'verify_and_finalize',
+    label: 'Verify and finalize',
+    description: 'Run health checks and final appliance recovery tasks.',
+  },
+] as const
+export type SystemUpdatePhaseViewState = 'complete' | 'active' | 'pending'
+
+export interface SystemUpdatePhaseView {
+  key: PrimaryPhaseKey
+  label: string
+  description: string
+  state: SystemUpdatePhaseViewState
+  caption: string
+}
 
 function compareVersionTags(left: string, right: string): number {
   const parse = (tag: string): [number, number, number] => {
@@ -39,6 +93,91 @@ function compareVersionTags(left: string, right: string): number {
   }
 
   return 0
+}
+
+export function formatSystemUpdateStatusLabel(status: SystemUpdateJob['status']): string {
+  return status.replace(/_/g, ' ').replace(/\b\w/g, (character) => character.toUpperCase())
+}
+
+export function isSystemUpdateJobTerminal(job: SystemUpdateJob | null): boolean {
+  if (!job) {
+    return true
+  }
+
+  if (job.status === 'rollback_attempted') {
+    return job.finishedAt !== null
+  }
+
+  return job.status === 'completed' || job.status === 'failed' || job.status === 'rolled_back'
+}
+
+export function isSystemUpdateJobFailure(job: SystemUpdateJob | null): boolean {
+  if (!job) {
+    return false
+  }
+
+  return (
+    job.status === 'failed' || job.status === 'rollback_attempted' || job.status === 'rolled_back'
+  )
+}
+
+function findPrimaryPhaseIndex(job: SystemUpdateJob | null): number {
+  if (!job) {
+    return -1
+  }
+
+  if (job.phase.kind === 'primary') {
+    return PRIMARY_PHASES.findIndex((phase) => phase.key === job.phase.key)
+  }
+
+  if (
+    job.status === 'completed' ||
+    job.status === 'rollback_attempted' ||
+    job.status === 'rolled_back'
+  ) {
+    return PRIMARY_PHASES.length - 1
+  }
+
+  return -1
+}
+
+export function getSystemUpdatePhaseProgress(job: SystemUpdateJob | null): SystemUpdatePhaseView[] {
+  const activeIndex = findPrimaryPhaseIndex(job)
+  const isTerminal = isSystemUpdateJobTerminal(job)
+
+  return PRIMARY_PHASES.map((phase, index) => {
+    const isActive =
+      job !== null && !isTerminal && job.phase.kind === 'primary' && phase.key === job.phase.key
+
+    const isComplete =
+      job !== null &&
+      (job.status === 'completed'
+        ? index <= activeIndex
+        : job.phase.kind === 'recovery'
+          ? index <= activeIndex
+          : index < activeIndex)
+
+    let caption = phase.description
+    if (isActive) {
+      caption = job.checkpoint.detail
+    } else if (isComplete) {
+      caption = 'Completed'
+    }
+
+    return {
+      key: phase.key,
+      label: phase.label,
+      description: phase.description,
+      state: isActive ? 'active' : isComplete ? 'complete' : 'pending',
+      caption,
+    }
+  })
+}
+
+export function getSystemUpdateActiveCheckpoint(
+  job: SystemUpdateJob | null
+): SystemUpdateCheckpoint | null {
+  return job?.checkpoint ?? null
 }
 
 export function getRetryableTargetVersion(

--- a/apps/frontend-admin/src/components/settings/system-update-panel.tsx
+++ b/apps/frontend-admin/src/components/settings/system-update-panel.tsx
@@ -30,43 +30,20 @@ import {
 } from '@/hooks/use-system-update'
 import { TID } from '@/lib/test-ids'
 import { AccountLevel, useAuthStore } from '@/store/auth-store'
-import { getPreferredUpdateTargetVersion } from './system-update-panel.logic'
-
-const PRIMARY_FLOW: readonly SystemUpdateJobStatus[] = [
-  'requested',
-  'authorized',
-  'staging',
-  'downloading',
-  'verifying',
-  'installing',
-  'post_install',
-  'restarting',
-  'health_check',
-  'completed',
-]
+import {
+  formatSystemUpdateStatusLabel,
+  getPreferredUpdateTargetVersion,
+  getSystemUpdateActiveCheckpoint,
+  getSystemUpdatePhaseProgress,
+  isSystemUpdateJobFailure,
+  isSystemUpdateJobTerminal,
+} from './system-update-panel.logic'
 
 const FAILURE_FLOW: readonly SystemUpdateJobStatus[] = [
   'failed',
   'rollback_attempted',
   'rolled_back',
 ]
-
-function isTerminalStatus(status: SystemUpdateJobStatus): boolean {
-  return (
-    status === 'completed' ||
-    status === 'failed' ||
-    status === 'rollback_attempted' ||
-    status === 'rolled_back'
-  )
-}
-
-function isFailureStatus(status: SystemUpdateJobStatus): boolean {
-  return status === 'failed' || status === 'rollback_attempted' || status === 'rolled_back'
-}
-
-function formatStepLabel(status: SystemUpdateJobStatus): string {
-  return status.replace(/_/g, ' ').replace(/\b\w/g, (character) => character.toUpperCase())
-}
 
 function formatTimestamp(value: string | null): string {
   if (!value) {
@@ -81,40 +58,16 @@ function formatTimestamp(value: string | null): string {
   return timestamp.toLocaleString()
 }
 
-function getPrimaryStepDescription(
-  step: SystemUpdateJobStatus,
-  currentJob: SystemUpdateJob | null
-): string {
-  if (!currentJob) {
-    return step === 'completed' ? 'Sentinel returns to steady state after verification.' : 'Pending'
-  }
-
-  const currentIndex = PRIMARY_FLOW.indexOf(currentJob.status)
-  const stepIndex = PRIMARY_FLOW.indexOf(step)
-  const isActive = currentJob.status === step
-  const isCompleted = currentIndex >= 0 && stepIndex <= currentIndex
-
-  if (isActive) {
-    return currentJob.message
-  }
-
-  if (isCompleted) {
-    if (step === 'completed' && currentJob.status === 'completed') {
-      return currentJob.message
-    }
-
-    return 'Completed'
-  }
-
-  return step === 'completed' ? 'Sentinel returns to steady state after verification.' : 'Pending'
-}
-
 function getCardStatus(job: SystemUpdateJob | null, updateAvailable: boolean) {
-  if (job && isFailureStatus(job.status)) {
+  if (isSystemUpdateJobFailure(job)) {
     return 'warning' as const
   }
 
-  if (job && !isTerminalStatus(job.status)) {
+  if (job?.phase.kind === 'recovery') {
+    return 'warning' as const
+  }
+
+  if (job && !isSystemUpdateJobTerminal(job)) {
     return 'info' as const
   }
 
@@ -126,11 +79,15 @@ function getCardStatus(job: SystemUpdateJob | null, updateAvailable: boolean) {
 }
 
 function getSummaryTone(job: SystemUpdateJob | null, updateAvailable: boolean) {
-  if (job && isFailureStatus(job.status)) {
+  if (isSystemUpdateJobFailure(job)) {
     return 'warning' as const
   }
 
-  if (job && !isTerminalStatus(job.status)) {
+  if (job?.phase.kind === 'recovery') {
+    return 'warning' as const
+  }
+
+  if (job && !isSystemUpdateJobTerminal(job)) {
     return 'info' as const
   }
 
@@ -142,8 +99,12 @@ function getSummaryTone(job: SystemUpdateJob | null, updateAvailable: boolean) {
 }
 
 function getSummaryHeading(job: SystemUpdateJob | null, updateAvailable: boolean) {
-  if (job && !isTerminalStatus(job.status)) {
-    return `Update ${job.targetVersion} is ${formatStepLabel(job.status).toLowerCase()}`
+  if (job && !isSystemUpdateJobTerminal(job)) {
+    if (job.phase.kind === 'recovery') {
+      return 'Rollback in progress'
+    }
+
+    return `Updating to ${job.targetVersion}`
   }
 
   if (job?.status === 'rolled_back') {
@@ -185,6 +146,14 @@ function getTerminalJobBadgeStatus(status: SystemUpdateJobStatus) {
 
 function getUpdateStateBadge(job: SystemUpdateJob | null, updateAvailable: boolean) {
   if (job) {
+    if (!isSystemUpdateJobTerminal(job)) {
+      if (job.phase.kind === 'recovery') {
+        return { status: 'warning' as const, label: job.phase.label }
+      }
+
+      return { status: 'info' as const, label: job.phase.label }
+    }
+
     if (job.status === 'completed') {
       return { status: 'success' as const, label: 'Completed' }
     }
@@ -194,10 +163,10 @@ function getUpdateStateBadge(job: SystemUpdateJob | null, updateAvailable: boole
     }
 
     if (job.status === 'rollback_attempted' || job.status === 'rolled_back') {
-      return { status: 'warning' as const, label: formatStepLabel(job.status) }
+      return { status: 'warning' as const, label: formatSystemUpdateStatusLabel(job.status) }
     }
 
-    return { status: 'info' as const, label: formatStepLabel(job.status) }
+    return { status: 'info' as const, label: formatSystemUpdateStatusLabel(job.status) }
   }
 
   if (updateAvailable) {
@@ -208,7 +177,11 @@ function getUpdateStateBadge(job: SystemUpdateJob | null, updateAvailable: boole
 }
 
 function getNextActionGuidance(job: SystemUpdateJob | null, updateAvailable: boolean) {
-  if (job && !isTerminalStatus(job.status)) {
+  if (job?.phase.kind === 'recovery' && !isSystemUpdateJobTerminal(job)) {
+    return 'Sentinel is actively attempting recovery. Keep this page open if you want live progress.'
+  }
+
+  if (job && !isSystemUpdateJobTerminal(job)) {
     return 'The appliance updater is running on the host and will keep going if this page reconnects.'
   }
 
@@ -236,7 +209,7 @@ function shouldAutoOpenTraceLog(job: SystemUpdateJob | null): boolean {
     return false
   }
 
-  return !isTerminalStatus(job.status) || isFailureStatus(job.status)
+  return !isSystemUpdateJobTerminal(job) || isSystemUpdateJobFailure(job)
 }
 
 export function SystemUpdatePanel() {
@@ -244,20 +217,28 @@ export function SystemUpdatePanel() {
   const canStartUpdates = (member?.accountLevel ?? 0) >= AccountLevel.ADMIN
   const searchParams = useSearchParams()
   const traceRequested = searchParams.get('trace') === 'open'
+  const [isHydrated, setIsHydrated] = useState(false)
   const [confirmOpen, setConfirmOpen] = useState(false)
   const [tracePanelOpen, setTracePanelOpen] = useState(traceRequested)
 
+  useEffect(() => {
+    setIsHydrated(true)
+  }, [])
+
   const systemUpdateQuery = useSystemUpdateStatus({
-    enabled: Boolean(member),
+    enabled: isHydrated && Boolean(member),
     refetchIntervalMs: 5_000,
   })
   const startSystemUpdate = useStartSystemUpdate()
 
   const status = systemUpdateQuery.data ?? null
   const currentJob = status?.currentJob ?? null
-  const hasActiveJob = currentJob ? !isTerminalStatus(currentJob.status) : false
+  const awaitingSessionContext = !isHydrated || (!member && !status && !systemUpdateQuery.isError)
+  const hasActiveJob = currentJob ? !isSystemUpdateJobTerminal(currentJob) : false
   const autoOpenTraceLog = shouldAutoOpenTraceLog(currentJob)
   const preferredTargetVersion = status ? getPreferredUpdateTargetVersion(status, currentJob) : null
+  const phaseProgress = getSystemUpdatePhaseProgress(currentJob)
+  const activeCheckpoint = getSystemUpdateActiveCheckpoint(currentJob)
   const retryingLastTarget =
     status !== null && status.latestVersion === null && preferredTargetVersion !== null
   const startActionLabel =
@@ -278,7 +259,7 @@ export function SystemUpdatePanel() {
     !hasActiveJob &&
     !startSystemUpdate.isPending
   const traceQuery = useSystemUpdateTrace({
-    enabled: Boolean(member) && canStartUpdates && tracePanelOpen,
+    enabled: isHydrated && Boolean(member) && canStartUpdates && tracePanelOpen,
     refetchIntervalMs: tracePanelOpen && hasActiveJob ? 5_000 : false,
   })
 
@@ -326,6 +307,28 @@ export function SystemUpdatePanel() {
     )
   }
 
+  if (awaitingSessionContext) {
+    return (
+      <AppCard status="info">
+        <AppCardHeader>
+          <AppCardTitle className="flex items-center gap-(--space-2)">
+            <ServerCog className="h-5 w-5" />
+            Updates
+          </AppCardTitle>
+          <AppCardDescription>
+            Restoring your authenticated Sentinel session before loading updater status.
+          </AppCardDescription>
+        </AppCardHeader>
+        <AppCardContent>
+          <div className="flex items-center gap-(--space-3) text-sm text-base-content/70">
+            <LoadingSpinner size="sm" className="text-base-content/60" />
+            <span>Loading update progress from the appliance host.</span>
+          </div>
+        </AppCardContent>
+      </AppCard>
+    )
+  }
+
   if (systemUpdateQuery.isError || !status) {
     return (
       <AppCard status="error">
@@ -351,8 +354,12 @@ export function SystemUpdatePanel() {
 
   const summaryTone = getSummaryTone(currentJob, status.updateAvailable)
   const summaryHeading = getSummaryHeading(currentJob, status.updateAvailable)
-  const showLiveProgress = currentJob ? !isTerminalStatus(currentJob.status) : false
+  const showLiveProgress = currentJob ? !isSystemUpdateJobTerminal(currentJob) : false
   const updateStateBadge = getUpdateStateBadge(currentJob, status.updateAvailable)
+  const activeCheckpointPanelClass =
+    currentJob?.phase.kind === 'recovery'
+      ? 'border-warning/35 bg-warning-fadded text-warning-fadded-content'
+      : 'border-info/35 bg-info-fadded text-info-fadded-content'
 
   return (
     <div className="space-y-4" data-testid={TID.settings.updates.panel}>
@@ -421,9 +428,17 @@ export function SystemUpdatePanel() {
           )}
 
           {currentJob?.status === 'rollback_attempted' && (
-            <AppAlert tone="warning" heading="Rollback needs operator follow-up">
-              Sentinel attempted a rollback but did not finish cleanly. Review the updater logs and
-              appliance state before retrying another update.
+            <AppAlert
+              tone="warning"
+              heading={
+                currentJob.finishedAt === null
+                  ? 'Rollback is in progress'
+                  : 'Rollback needs operator follow-up'
+              }
+            >
+              {currentJob.finishedAt === null
+                ? 'Sentinel is actively rolling back to the last known good release.'
+                : 'Sentinel attempted a rollback but did not finish cleanly. Review the updater logs and appliance state before retrying another update.'}
             </AppAlert>
           )}
 
@@ -519,7 +534,7 @@ export function SystemUpdatePanel() {
               {currentJob && (
                 <div className="mt-4 rounded-box border border-base-300 bg-base-200 p-(--space-4)">
                   <div className="flex items-center gap-(--space-2)">
-                    {isFailureStatus(currentJob.status) ? (
+                    {isSystemUpdateJobFailure(currentJob) ? (
                       <ShieldAlert className="h-4 w-4 text-warning" />
                     ) : (
                       <ServerCog className="h-4 w-4 text-info" />
@@ -542,8 +557,18 @@ export function SystemUpdatePanel() {
                       <dd className="text-right">{formatTimestamp(currentJob.startedAt)}</dd>
                     </div>
                     <div className="flex items-start justify-between gap-(--space-3)">
+                      <dt className="text-base-content/60">Phase</dt>
+                      <dd className="text-right">{currentJob.phase.label}</dd>
+                    </div>
+                    <div className="flex items-start justify-between gap-(--space-3)">
+                      <dt className="text-base-content/60">Checkpoint</dt>
+                      <dd className="text-right">{currentJob.checkpoint.label}</dd>
+                    </div>
+                    <div className="flex items-start justify-between gap-(--space-3)">
                       <dt className="text-base-content/60">Status</dt>
-                      <dd className="text-right">{formatStepLabel(currentJob.status)}</dd>
+                      <dd className="text-right">
+                        {formatSystemUpdateStatusLabel(currentJob.status)}
+                      </dd>
                     </div>
                   </dl>
                   {currentJob.failureSummary && (
@@ -573,47 +598,71 @@ export function SystemUpdatePanel() {
 
               {showLiveProgress ? (
                 <>
-                  <ul className="steps steps-vertical mt-4 w-full">
-                    {PRIMARY_FLOW.map((step) => {
-                      const currentIndex = currentJob ? PRIMARY_FLOW.indexOf(currentJob.status) : -1
-                      const stepIndex = PRIMARY_FLOW.indexOf(step)
-                      const isActive = currentJob?.status === step
-                      const isCompleted = currentIndex >= 0 && stepIndex <= currentIndex
-
-                      return (
+                  {currentJob?.phase.kind === 'primary' && (
+                    <ul className="steps steps-vertical mt-4 w-full">
+                      {phaseProgress.map((phase) => (
                         <li
-                          key={step}
-                          className={`step ${isCompleted || isActive ? 'step-primary' : ''}`}
+                          key={phase.key}
+                          className={`step ${phase.state !== 'pending' ? 'step-primary' : ''}`}
                         >
                           <div className="text-left">
-                            <div className="font-medium">{formatStepLabel(step)}</div>
-                            <div className="text-xs text-base-content/60">
-                              {getPrimaryStepDescription(step, currentJob)}
-                            </div>
+                            <div className="font-medium">{phase.label}</div>
+                            <div className="text-xs text-base-content/60">{phase.caption}</div>
                           </div>
                         </li>
-                      )
-                    })}
-                  </ul>
+                      ))}
+                    </ul>
+                  )}
 
-                  {currentJob && isFailureStatus(currentJob.status) && (
+                  {activeCheckpoint && currentJob && (
+                    <div
+                      className={`mt-4 rounded-box border p-(--space-4) ${activeCheckpointPanelClass}`}
+                    >
+                      <div className="flex flex-wrap items-start justify-between gap-(--space-3)">
+                        <div>
+                          <p className="text-xs font-semibold uppercase tracking-wide opacity-70">
+                            Active checkpoint
+                          </p>
+                          <p className="mt-1 text-sm font-semibold">{activeCheckpoint.label}</p>
+                        </div>
+                        <AppBadge
+                          status={currentJob.phase.kind === 'recovery' ? 'warning' : 'info'}
+                          size="sm"
+                        >
+                          {currentJob.phase.label}
+                        </AppBadge>
+                      </div>
+                      <p className="mt-3 text-sm">{activeCheckpoint.detail}</p>
+                    </div>
+                  )}
+
+                  {currentJob && currentJob.phase.kind === 'recovery' && (
                     <div className="mt-4 border-t border-base-300 pt-(--space-4)">
                       <h4 className="text-sm font-semibold">Recovery states</h4>
                       <ul className="steps steps-vertical mt-3 w-full">
                         {FAILURE_FLOW.map((step) => {
                           const currentIndex = FAILURE_FLOW.indexOf(currentJob.status)
                           const stepIndex = FAILURE_FLOW.indexOf(step)
-                          const isCompleted = currentIndex >= 0 && stepIndex <= currentIndex
+                          const isActive = currentJob.status === step
+                          const isCompleted =
+                            currentIndex >= 0 &&
+                            (stepIndex < currentIndex ||
+                              (stepIndex === currentIndex && currentJob.finishedAt !== null))
 
                           return (
-                            <li key={step} className={`step ${isCompleted ? 'step-warning' : ''}`}>
+                            <li
+                              key={step}
+                              className={`step ${isCompleted || isActive ? 'step-warning' : ''}`}
+                            >
                               <div className="text-left">
                                 <div className="flex items-center gap-(--space-2)">
                                   {step === 'rolled_back' && <RotateCcw className="h-3.5 w-3.5" />}
-                                  <span className="font-medium">{formatStepLabel(step)}</span>
+                                  <span className="font-medium">
+                                    {formatSystemUpdateStatusLabel(step)}
+                                  </span>
                                 </div>
                                 <div className="text-xs text-base-content/60">
-                                  {step === currentJob.status ? currentJob.message : 'Not reached'}
+                                  {isActive ? currentJob.message : 'Not reached'}
                                 </div>
                               </div>
                             </li>
@@ -632,7 +681,7 @@ export function SystemUpdatePanel() {
                         <p className="text-sm text-base-content/70">{currentJob.message}</p>
                       </div>
                       <AppBadge status={getTerminalJobBadgeStatus(currentJob.status)} size="sm">
-                        {formatStepLabel(currentJob.status)}
+                        {formatSystemUpdateStatusLabel(currentJob.status)}
                       </AppBadge>
                     </div>
 
@@ -660,6 +709,18 @@ export function SystemUpdatePanel() {
                         <dd className="mt-1 text-base-content">
                           {currentJob.requestedBy.memberName}
                         </dd>
+                      </div>
+                      <div className="rounded-box border border-base-300 bg-base-100 p-(--space-3)">
+                        <dt className="text-xs font-semibold uppercase tracking-wide text-base-content/60">
+                          Final phase
+                        </dt>
+                        <dd className="mt-1 text-base-content">{currentJob.phase.label}</dd>
+                      </div>
+                      <div className="rounded-box border border-base-300 bg-base-100 p-(--space-3)">
+                        <dt className="text-xs font-semibold uppercase tracking-wide text-base-content/60">
+                          Final checkpoint
+                        </dt>
+                        <dd className="mt-1 text-base-content">{currentJob.checkpoint.label}</dd>
                       </div>
                       <div className="rounded-box border border-base-300 bg-base-100 p-(--space-3)">
                         <dt className="text-xs font-semibold uppercase tracking-wide text-base-content/60">

--- a/deploy/deb/assets/usr/lib/sentinel/sentinel-update-bridge
+++ b/deploy/deb/assets/usr/lib/sentinel/sentinel-update-bridge
@@ -25,9 +25,12 @@ from sentinel_update_common import (
     LOCK_PATH,
     TRACE_LOG_PATH,
     VERSION_PATTERN,
+    apply_job_progress,
+    ensure_job_progress,
     append_trace_line,
     archive_and_reset_trace,
     ensure_runtime_directories,
+    is_terminal_job,
     is_terminal_status,
     load_appliance_state,
     read_env_file,
@@ -167,9 +170,7 @@ def receive_payload(connection: socket.socket) -> dict[str, Any]:
 
 def current_job_is_active() -> bool:
     job = read_json_file(CURRENT_JOB_PATH)
-    if not isinstance(job, dict):
-        return False
-    return not is_terminal_status(str(job.get("status", "")))
+    return not is_terminal_job(job)
 
 
 def run_polkit_check() -> None:
@@ -264,6 +265,19 @@ def persist_initial_job(payload: dict[str, Any]) -> dict[str, Any]:
             "migration": {"mode": None, "status": "pending"},
             "network": {"status": "pending", "message": "Not started."},
             "warnings": [],
+            "phase": {
+                "key": "prepare_update",
+                "label": "Prepare update",
+                "description": "Confirm the requested release and gather trusted metadata.",
+                "kind": "primary",
+                "order": 1,
+                "total": 5,
+            },
+            "checkpoint": {
+                "key": "request_accepted",
+                "label": "Update request accepted",
+                "detail": "Update request accepted and waiting for the updater service.",
+            },
             "tracePath": str(TRACE_LOG_PATH),
             "jobLogPath": None,
             "logPath": None,
@@ -290,6 +304,13 @@ def mark_job_failed(job: dict[str, Any], message: str) -> dict[str, Any]:
         "failureSummary": message,
         "finishedAt": utc_now(),
     }
+    apply_job_progress(
+        failed_job,
+        phase_key="recovery",
+        checkpoint_key="update_failed",
+        checkpoint_detail=message,
+    )
+    ensure_job_progress(failed_job)
     write_json_file(JOBS_DIR / f"{job['jobId']}.json", failed_job, mode=0o644)
     write_json_file(CURRENT_JOB_PATH, failed_job, mode=0o644)
     trace("error", f"Marked update job {job['jobId']} as failed before updater handoff: {message}")

--- a/deploy/deb/assets/usr/lib/sentinel/sentinel-updater
+++ b/deploy/deb/assets/usr/lib/sentinel/sentinel-updater
@@ -38,10 +38,13 @@ from sentinel_update_common import (
     TRACE_LOG_PATH,
     TRACE_ARCHIVE_DIR,
     VERSION_PATTERN,
+    apply_job_progress,
     archive_and_reset_trace,
     append_trace_line,
     compose_command,
+    ensure_job_progress,
     ensure_runtime_directories,
+    is_terminal_job,
     is_terminal_status,
     load_appliance_state,
     load_trace_session,
@@ -230,6 +233,7 @@ def report_path_for_job(job: dict[str, Any]) -> Path:
 def update_report_metadata(job: dict[str, Any]) -> None:
     job["schemaVersion"] = REPORT_SCHEMA_VERSION
     job["tracePath"] = active_trace_path()
+    ensure_job_progress(job)
     if isinstance(job.get("jobLogPath"), str):
         job["logPath"] = job.get("jobLogPath")
     result = report_result_for_job(job)
@@ -307,12 +311,24 @@ def update_job(
     job_logger: JobLogger | None = None,
     failure_summary: str | None = None,
     finished: bool = False,
+    phase_key: str | None = None,
+    checkpoint_key: str | None = None,
+    checkpoint_detail: str | None = None,
 ) -> None:
     if status == "authorized" and not job.get("startedAt"):
         job["startedAt"] = utc_now()
     job["status"] = status
     job["message"] = message
     job["failureSummary"] = failure_summary
+    if phase_key is not None or checkpoint_key is not None:
+        apply_job_progress(
+            job,
+            phase_key=phase_key or "prepare_update",
+            checkpoint_key=checkpoint_key or "request_accepted",
+            checkpoint_detail=checkpoint_detail or message,
+        )
+    else:
+        ensure_job_progress(job)
     if finished:
         job["finishedAt"] = utc_now()
         if "durationSeconds" not in job:
@@ -353,9 +369,7 @@ def parse_release_asset_size(release_asset: dict[str, Any]) -> int:
 
 def current_job_is_active() -> bool:
     job = read_json_file(CURRENT_JOB_PATH)
-    if not isinstance(job, dict):
-        return False
-    return not is_terminal_status(str(job.get("status", "")))
+    return not is_terminal_job(job)
 
 
 def persist_initial_job(job: dict[str, Any]) -> dict[str, Any]:
@@ -855,6 +869,7 @@ def update_runtime_version(target_version: str) -> None:
 
 
 def run_backend_post_update(
+    job: dict[str, Any],
     state: dict[str, Any],
     job_logger: JobLogger,
     *,
@@ -865,44 +880,69 @@ def run_backend_post_update(
         overrides={"SENTINEL_VERSION": version_override} if version_override else None
     )
     commands = [
-        compose_command(
-            state,
-            "exec",
-            "-T",
-            "backend",
-            "sh",
-            "-lc",
-            "cd /app && pnpm --filter @sentinel/database prisma:migrate:deploy:safe",
+        (
+            "applying_database_migrations",
+            "Applying safe database migrations.",
+            compose_command(
+                state,
+                "exec",
+                "-T",
+                "backend",
+                "sh",
+                "-lc",
+                "cd /app && pnpm --filter @sentinel/database prisma:migrate:deploy:safe",
+            ),
         ),
-        compose_command(
-            state,
-            "exec",
-            "-T",
-            "backend",
-            "sh",
-            "-lc",
-            "cd /app && pnpm --filter @sentinel/database exec prisma migrate status",
+        (
+            "checking_migration_status",
+            "Checking Sentinel database migration status.",
+            compose_command(
+                state,
+                "exec",
+                "-T",
+                "backend",
+                "sh",
+                "-lc",
+                "cd /app && pnpm --filter @sentinel/database exec prisma migrate status",
+            ),
         ),
-        compose_command(
-            state,
-            "exec",
-            "-T",
-            "backend",
-            "sh",
-            "-lc",
-            "cd /app && pnpm --filter @sentinel/backend sentinel:bootstrap-account",
+        (
+            "refreshing_bootstrap_account",
+            "Refreshing the Sentinel bootstrap account.",
+            compose_command(
+                state,
+                "exec",
+                "-T",
+                "backend",
+                "sh",
+                "-lc",
+                "cd /app && pnpm --filter @sentinel/backend sentinel:bootstrap-account",
+            ),
         ),
-        compose_command(
-            state,
-            "exec",
-            "-T",
-            "backend",
-            "sh",
-            "-lc",
-            "cd /app && pnpm --filter @sentinel/backend sentinel:seed-default-enums",
+        (
+            "seeding_default_enums",
+            "Seeding default enums and appliance defaults.",
+            compose_command(
+                state,
+                "exec",
+                "-T",
+                "backend",
+                "sh",
+                "-lc",
+                "cd /app && pnpm --filter @sentinel/backend sentinel:seed-default-enums",
+            ),
         ),
     ]
-    for command in commands:
+    for checkpoint_key, message, command in commands:
+        update_job(
+            job,
+            status="health_check",
+            message=message,
+            job_logger=job_logger,
+            phase_key="verify_and_finalize",
+            checkpoint_key=checkpoint_key,
+            checkpoint_detail=message,
+        )
         result = run_command(
             command,
             job_logger=job_logger,
@@ -915,7 +955,7 @@ def run_backend_post_update(
     trace("info", "Backend post-update commands completed successfully.")
 
 
-def restart_stack(
+def pull_stack_images(
     state: dict[str, Any],
     job_logger: JobLogger,
     *,
@@ -935,7 +975,17 @@ def restart_stack(
     if pull_result.returncode != 0:
         raise UpdaterError("post_install", "docker compose pull failed.")
 
+
+def restart_stack_services(
+    state: dict[str, Any],
+    job_logger: JobLogger,
+    *,
+    version_override: str | None = None,
+) -> None:
     trace("info", "Recreating the Sentinel stack with docker compose up -d.")
+    command_env = refreshed_appliance_env(
+        overrides={"SENTINEL_VERSION": version_override} if version_override else None
+    )
     up_result = run_command(
         compose_command(state, "up", "-d"),
         job_logger=job_logger,
@@ -1125,6 +1175,19 @@ def enqueue_manual_update(args: argparse.Namespace) -> int:
         "migration": {"mode": None, "status": "pending"},
         "network": {"status": "pending", "message": "Not started."},
         "warnings": [],
+        "phase": {
+            "key": "prepare_update",
+            "label": "Prepare update",
+            "description": "Confirm the requested release and gather trusted metadata.",
+            "kind": "primary",
+            "order": 1,
+            "total": 5,
+        },
+        "checkpoint": {
+            "key": "request_accepted",
+            "label": "Update request accepted",
+            "detail": f"Manual update request accepted for {target_version}.",
+        },
         "jobLogPath": str(job_log_path),
         "logPath": str(job_log_path),
         "tracePath": active_trace_path(),
@@ -1171,11 +1234,30 @@ def rollback(job: dict[str, Any], previous_artifact: dict[str, str], job_logger:
         status="rollback_attempted",
         message=f"Attempting rollback to {previous_artifact['version']}.",
         job_logger=job_logger,
+        phase_key="recovery",
+        checkpoint_key="attempting_rollback",
     )
 
     previous_state = build_runtime_state(load_appliance_state(), job)
     install_deb(Path(previous_artifact["debPath"]), job_logger)
-    restart_stack(previous_state, job_logger, version_override=previous_artifact["version"])
+    update_job(
+        job,
+        status="rollback_attempted",
+        message="Pulling container images for rollback.",
+        job_logger=job_logger,
+        phase_key="recovery",
+        checkpoint_key="attempting_rollback",
+    )
+    pull_stack_images(previous_state, job_logger, version_override=previous_artifact["version"])
+    update_job(
+        job,
+        status="rollback_attempted",
+        message=f"Restarting Sentinel services for rollback to {previous_artifact['version']}.",
+        job_logger=job_logger,
+        phase_key="recovery",
+        checkpoint_key="attempting_rollback",
+    )
+    restart_stack_services(previous_state, job_logger, version_override=previous_artifact["version"])
     wait_for_health(job_logger, expected_version=previous_artifact["version"])
     hotspot_warning = run_shared_hotspot_recovery(
         job_logger,
@@ -1218,6 +1300,8 @@ def rollback(job: dict[str, Any], previous_artifact: dict[str, str], job_logger:
         ),
         job_logger=job_logger,
         finished=True,
+        phase_key="recovery",
+        checkpoint_key="rollback_completed",
     )
     trace("warning", f"Rollback completed successfully to {previous_artifact['version']}.")
 
@@ -1277,9 +1361,28 @@ def execute_update(job: dict[str, Any], job_logger: JobLogger) -> None:
         status="authorized",
         message=f"Update request for {target_version} was authorized.",
         job_logger=job_logger,
+        phase_key="prepare_update",
+        checkpoint_key="request_authorized",
     )
 
-    update_job(job, status="staging", message="Preparing update artifacts and rollback metadata.", job_logger=job_logger)
+    update_job(
+        job,
+        status="staging",
+        message="Creating a pre-update backup of Sentinel and Wiki.js.",
+        job_logger=job_logger,
+        phase_key="protect_current_system",
+        checkpoint_key="creating_pre_update_backup",
+    )
+    backup_metadata = prepare_backup(job, job_logger)
+
+    update_job(
+        job,
+        status="staging",
+        message=f"Preparing rollback artifacts for {current_version}.",
+        job_logger=job_logger,
+        phase_key="protect_current_system",
+        checkpoint_key="preparing_rollback_artifact",
+    )
     previous_artifact: dict[str, str] | None = None
     try:
         previous_artifact = cache_verified_release(current_version, job_logger, purpose="rollback")
@@ -1291,11 +1394,25 @@ def execute_update(job: dict[str, Any], job_logger: JobLogger) -> None:
         record_warning(job, f"Rollback artifact preparation was skipped for {current_version}: {error}")
         job["rollback"]["result"] = "not_available"
 
-    update_job(job, status="downloading", message=f"Downloading Sentinel release {target_version}.", job_logger=job_logger)
+    update_job(
+        job,
+        status="downloading",
+        message=f"Downloading Sentinel release {target_version}.",
+        job_logger=job_logger,
+        phase_key="install_release",
+        checkpoint_key="downloading_release",
+    )
     target_artifact = cache_verified_release(target_version, job_logger, purpose="target release")
     run_update_disk_preflight(target_artifact=target_artifact, job_logger=job_logger)
 
-    update_job(job, status="verifying", message=f"Verifying release artifacts for {target_version}.", job_logger=job_logger)
+    update_job(
+        job,
+        status="verifying",
+        message=f"Verifying release checksums and manifests for {target_version}.",
+        job_logger=job_logger,
+        phase_key="install_release",
+        checkpoint_key="verifying_release_artifacts",
+    )
     job["artifact"] = {"target": target_artifact}
     target_manifest_path = write_artifact_manifest(
         target_artifact,
@@ -1314,7 +1431,6 @@ def execute_update(job: dict[str, Any], job_logger: JobLogger) -> None:
         if previous_manifest_path is not None:
             job["artifact"]["previous"]["manifestPath"] = previous_manifest_path
 
-    backup_metadata = prepare_backup(job, job_logger)
     backup_output_dir = backup_metadata.get("outputDir")
     if isinstance(backup_output_dir, str) and backup_output_dir:
         output_dir = Path(backup_output_dir)
@@ -1329,19 +1445,64 @@ def execute_update(job: dict[str, Any], job_logger: JobLogger) -> None:
     save_appliance_state(current_state)
     persist_job(job)
 
-    update_job(job, status="installing", message=f"Installing Sentinel package {target_version}.", job_logger=job_logger)
+    update_job(
+        job,
+        status="installing",
+        message=f"Installing Sentinel package {target_version}.",
+        job_logger=job_logger,
+        phase_key="install_release",
+        checkpoint_key="installing_package",
+    )
     install_deb(Path(target_artifact["debPath"]), job_logger)
 
-    update_job(job, status="post_install", message="Applying updated appliance configuration.", job_logger=job_logger)
-    restart_stack(runtime_state, job_logger, version_override=target_version)
+    update_job(
+        job,
+        status="post_install",
+        message="Pulling updated container images.",
+        job_logger=job_logger,
+        phase_key="bring_services_back",
+        checkpoint_key="pulling_container_images",
+    )
+    pull_stack_images(runtime_state, job_logger, version_override=target_version)
 
-    update_job(job, status="restarting", message="Restarting Sentinel services.", job_logger=job_logger)
+    update_job(
+        job,
+        status="restarting",
+        message="Restarting Sentinel services.",
+        job_logger=job_logger,
+        phase_key="bring_services_back",
+        checkpoint_key="restarting_services",
+    )
+    restart_stack_services(runtime_state, job_logger, version_override=target_version)
 
-    update_job(job, status="health_check", message="Running post-update verification.", job_logger=job_logger)
-    run_backend_post_update(runtime_state, job_logger, version_override=target_version)
+    update_job(
+        job,
+        status="health_check",
+        message="Applying safe database migrations.",
+        job_logger=job_logger,
+        phase_key="verify_and_finalize",
+        checkpoint_key="applying_database_migrations",
+    )
+    run_backend_post_update(job, runtime_state, job_logger, version_override=target_version)
+    update_job(
+        job,
+        status="health_check",
+        message="Waiting for Sentinel health checks to pass.",
+        job_logger=job_logger,
+        phase_key="verify_and_finalize",
+        checkpoint_key="waiting_for_health_endpoint",
+    )
     wait_for_health(job_logger, expected_version=target_version)
     job["healthzPassed"] = True
     job["migration"] = {"mode": "deploy", "status": "completed"}
+    update_job(
+        job,
+        status="health_check",
+        message="Checking hosted hotspot recovery.",
+        job_logger=job_logger,
+        phase_key="verify_and_finalize",
+        checkpoint_key="recovering_hotspot",
+    )
     hotspot_warning = run_shared_hotspot_recovery(
         job_logger,
         context=f"update to {target_version}",
@@ -1383,6 +1544,8 @@ def execute_update(job: dict[str, Any], job_logger: JobLogger) -> None:
         ),
         job_logger=job_logger,
         finished=True,
+        phase_key="verify_and_finalize",
+        checkpoint_key="update_completed",
     )
 
 
@@ -1397,7 +1560,7 @@ def run_current_job() -> int:
         return 0
 
     job = load_job(CURRENT_JOB_PATH)
-    if is_terminal_status(str(job.get("status", ""))):
+    if is_terminal_job(job):
         LOGGER.info("Current job %s is already terminal; nothing to do.", job.get("jobId"))
         trace("info", f"Current job {job.get('jobId')} is already terminal; nothing to do.")
         return 0
@@ -1445,6 +1608,8 @@ def run_current_job() -> int:
             failure_summary=failure_summary,
             job_logger=job_logger,
             finished=not should_rollback,
+            phase_key="recovery",
+            checkpoint_key="update_failed",
         )
 
         if should_rollback:
@@ -1473,6 +1638,8 @@ def run_current_job() -> int:
                         failure_summary=sanitize_failure_summary(str(rollback_error)),
                         job_logger=job_logger,
                         finished=True,
+                        phase_key="recovery",
+                        checkpoint_key="rollback_failed",
                     )
             else:
                 trace(
@@ -1501,6 +1668,8 @@ def run_current_job() -> int:
                     failure_summary="Rollback metadata was unavailable.",
                     job_logger=job_logger,
                     finished=True,
+                    phase_key="recovery",
+                    checkpoint_key="rollback_failed",
                 )
         return 1
     finally:

--- a/deploy/deb/assets/usr/lib/sentinel/sentinel_update_common.py
+++ b/deploy/deb/assets/usr/lib/sentinel/sentinel_update_common.py
@@ -38,10 +38,270 @@ REPORT_SCHEMA_VERSION = 2
 VERSION_PATTERN = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+$")
 JOB_ID_PATTERN = re.compile(r"^system-update-[0-9]{13}-[0-9a-f-]{36}$")
 TERMINAL_JOB_STATUSES = {"completed", "failed", "rollback_attempted", "rolled_back"}
+PRIMARY_UPDATE_PHASE_KEYS = (
+    "prepare_update",
+    "protect_current_system",
+    "install_release",
+    "bring_services_back",
+    "verify_and_finalize",
+)
+UPDATE_PHASE_DEFINITIONS = {
+    "prepare_update": {
+        "key": "prepare_update",
+        "label": "Prepare update",
+        "description": "Confirm the requested release and gather trusted metadata.",
+        "kind": "primary",
+        "order": 1,
+        "total": len(PRIMARY_UPDATE_PHASE_KEYS),
+    },
+    "protect_current_system": {
+        "key": "protect_current_system",
+        "label": "Protect current system",
+        "description": "Create recovery assets before applying the new release.",
+        "kind": "primary",
+        "order": 2,
+        "total": len(PRIMARY_UPDATE_PHASE_KEYS),
+    },
+    "install_release": {
+        "key": "install_release",
+        "label": "Install release",
+        "description": "Download, verify, and install the requested Sentinel package.",
+        "kind": "primary",
+        "order": 3,
+        "total": len(PRIMARY_UPDATE_PHASE_KEYS),
+    },
+    "bring_services_back": {
+        "key": "bring_services_back",
+        "label": "Bring services back",
+        "description": "Pull updated images and restart the Sentinel stack.",
+        "kind": "primary",
+        "order": 4,
+        "total": len(PRIMARY_UPDATE_PHASE_KEYS),
+    },
+    "verify_and_finalize": {
+        "key": "verify_and_finalize",
+        "label": "Verify and finalize",
+        "description": "Run health checks and final appliance recovery tasks.",
+        "kind": "primary",
+        "order": 5,
+        "total": len(PRIMARY_UPDATE_PHASE_KEYS),
+    },
+    "recovery": {
+        "key": "recovery",
+        "label": "Recovery",
+        "description": "Attempt rollback or point the operator to restore guidance.",
+        "kind": "recovery",
+        "order": len(PRIMARY_UPDATE_PHASE_KEYS),
+        "total": len(PRIMARY_UPDATE_PHASE_KEYS),
+    },
+}
+UPDATE_CHECKPOINT_DEFINITIONS = {
+    "request_accepted": {
+        "key": "request_accepted",
+        "label": "Update request accepted",
+        "detail": "The updater has accepted the update request and is waiting to continue.",
+    },
+    "request_authorized": {
+        "key": "request_authorized",
+        "label": "Request authorized",
+        "detail": "The requested Sentinel release was validated and authorized to continue.",
+    },
+    "creating_pre_update_backup": {
+        "key": "creating_pre_update_backup",
+        "label": "Creating pre-update backup",
+        "detail": "Creating Sentinel and Wiki.js backups before any changes are applied.",
+    },
+    "preparing_rollback_artifact": {
+        "key": "preparing_rollback_artifact",
+        "label": "Preparing rollback artifact",
+        "detail": "Caching the current Sentinel release so rollback remains available.",
+    },
+    "downloading_release": {
+        "key": "downloading_release",
+        "label": "Downloading release",
+        "detail": "Downloading the requested Sentinel package and release metadata.",
+    },
+    "verifying_release_artifacts": {
+        "key": "verifying_release_artifacts",
+        "label": "Verifying release artifacts",
+        "detail": "Checking release checksums and manifests before installation.",
+    },
+    "installing_package": {
+        "key": "installing_package",
+        "label": "Installing package",
+        "detail": "Installing the requested Sentinel package on the host appliance.",
+    },
+    "pulling_container_images": {
+        "key": "pulling_container_images",
+        "label": "Pulling container images",
+        "detail": "Pulling the updated container images for the Sentinel stack.",
+    },
+    "restarting_services": {
+        "key": "restarting_services",
+        "label": "Restarting services",
+        "detail": "Recreating the Sentinel stack and waiting for containers to report healthy.",
+    },
+    "applying_database_migrations": {
+        "key": "applying_database_migrations",
+        "label": "Applying database migrations",
+        "detail": "Running safe database migrations inside the backend container.",
+    },
+    "checking_migration_status": {
+        "key": "checking_migration_status",
+        "label": "Checking migration status",
+        "detail": "Confirming the Sentinel database schema is up to date.",
+    },
+    "refreshing_bootstrap_account": {
+        "key": "refreshing_bootstrap_account",
+        "label": "Refreshing bootstrap account",
+        "detail": "Refreshing the Sentinel bootstrap account after the upgrade.",
+    },
+    "seeding_default_enums": {
+        "key": "seeding_default_enums",
+        "label": "Seeding defaults",
+        "detail": "Seeding default enums and appliance configuration values.",
+    },
+    "waiting_for_health_endpoint": {
+        "key": "waiting_for_health_endpoint",
+        "label": "Waiting for health checks",
+        "detail": "Waiting for Sentinel to report healthy at the local health endpoint.",
+    },
+    "recovering_hotspot": {
+        "key": "recovering_hotspot",
+        "label": "Checking hotspot recovery",
+        "detail": "Running shared hotspot recovery checks before finalizing the update.",
+    },
+    "update_completed": {
+        "key": "update_completed",
+        "label": "Update completed",
+        "detail": "Sentinel finished the update and returned to steady state.",
+    },
+    "update_failed": {
+        "key": "update_failed",
+        "label": "Update failed",
+        "detail": "The update stopped and needs operator attention before retrying.",
+    },
+    "attempting_rollback": {
+        "key": "attempting_rollback",
+        "label": "Attempting rollback",
+        "detail": "Rolling back to the last known good Sentinel release.",
+    },
+    "rollback_completed": {
+        "key": "rollback_completed",
+        "label": "Rollback completed",
+        "detail": "Sentinel rolled back to the previous known good release.",
+    },
+    "rollback_failed": {
+        "key": "rollback_failed",
+        "label": "Rollback failed",
+        "detail": "Rollback did not finish cleanly. Restore guidance is required.",
+    },
+}
 
 
 def utc_now() -> str:
     return datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def derive_progress_from_status(status: str, message: str | None = None) -> tuple[str, str]:
+    normalized_status = status.strip()
+    if normalized_status == "requested":
+        return "prepare_update", "request_accepted"
+    if normalized_status == "authorized":
+        return "prepare_update", "request_authorized"
+    if normalized_status == "staging":
+        return "protect_current_system", "creating_pre_update_backup"
+    if normalized_status == "downloading":
+        return "install_release", "downloading_release"
+    if normalized_status == "verifying":
+        return "install_release", "verifying_release_artifacts"
+    if normalized_status == "installing":
+        return "install_release", "installing_package"
+    if normalized_status == "post_install":
+        return "bring_services_back", "pulling_container_images"
+    if normalized_status == "restarting":
+        return "bring_services_back", "restarting_services"
+    if normalized_status == "health_check":
+        return "verify_and_finalize", "waiting_for_health_endpoint"
+    if normalized_status == "completed":
+        return "verify_and_finalize", "update_completed"
+    if normalized_status == "rolled_back":
+        return "recovery", "rollback_completed"
+    if normalized_status in {"failed", "rollback_attempted"}:
+        if message and "rollback failed" in message.lower():
+            return "recovery", "rollback_failed"
+        if normalized_status == "rollback_attempted":
+            return "recovery", "attempting_rollback"
+        return "recovery", "update_failed"
+    return "prepare_update", "request_accepted"
+
+
+def build_update_phase(phase_key: str) -> dict[str, Any]:
+    definition = UPDATE_PHASE_DEFINITIONS.get(phase_key) or UPDATE_PHASE_DEFINITIONS["prepare_update"]
+    return dict(definition)
+
+
+def build_update_checkpoint(checkpoint_key: str, *, detail: str | None = None) -> dict[str, Any]:
+    definition = UPDATE_CHECKPOINT_DEFINITIONS.get(checkpoint_key) or UPDATE_CHECKPOINT_DEFINITIONS[
+        "request_accepted"
+    ]
+    payload = dict(definition)
+    if detail is not None and detail.strip():
+        payload["detail"] = detail.strip()
+    return payload
+
+
+def apply_job_progress(
+    job: dict[str, Any],
+    *,
+    phase_key: str,
+    checkpoint_key: str,
+    checkpoint_detail: str | None = None,
+) -> None:
+    job["phase"] = build_update_phase(phase_key)
+    job["checkpoint"] = build_update_checkpoint(checkpoint_key, detail=checkpoint_detail)
+
+
+def ensure_job_progress(job: dict[str, Any]) -> None:
+    status = str(job.get("status", "")).strip()
+    message = str(job.get("message", "")).strip()
+
+    raw_phase = job.get("phase")
+    raw_checkpoint = job.get("checkpoint")
+    phase_key = (
+        str(raw_phase.get("key", "")).strip()
+        if isinstance(raw_phase, dict)
+        else ""
+    )
+    checkpoint_key = (
+        str(raw_checkpoint.get("key", "")).strip()
+        if isinstance(raw_checkpoint, dict)
+        else ""
+    )
+
+    if not phase_key or phase_key not in UPDATE_PHASE_DEFINITIONS:
+        phase_key, derived_checkpoint_key = derive_progress_from_status(status, message)
+    else:
+        derived_checkpoint_key = ""
+
+    if not checkpoint_key or checkpoint_key not in UPDATE_CHECKPOINT_DEFINITIONS:
+        checkpoint_key = derived_checkpoint_key or derive_progress_from_status(status, message)[1]
+
+    checkpoint_detail = None
+    if isinstance(raw_checkpoint, dict):
+        raw_detail = raw_checkpoint.get("detail")
+        if isinstance(raw_detail, str) and raw_detail.strip():
+            checkpoint_detail = raw_detail.strip()
+
+    if checkpoint_detail is None:
+        checkpoint_detail = message or None
+
+    apply_job_progress(
+        job,
+        phase_key=phase_key,
+        checkpoint_key=checkpoint_key,
+        checkpoint_detail=checkpoint_detail,
+    )
 
 
 def ensure_directory(path: Path, mode: int | None = None) -> None:
@@ -355,6 +615,18 @@ def normalize_version_tag(value: str | None) -> str | None:
 
 def is_terminal_status(status: str | None) -> bool:
     return bool(status and status in TERMINAL_JOB_STATUSES)
+
+
+def is_terminal_job(job: dict[str, Any] | None) -> bool:
+    if not isinstance(job, dict):
+        return True
+
+    status = str(job.get("status", "")).strip()
+    if status == "rollback_attempted":
+        finished_at = job.get("finishedAt")
+        return isinstance(finished_at, str) and bool(finished_at.strip())
+
+    return is_terminal_status(status)
 
 
 def compose_command(state: dict[str, Any], *subcommand: str) -> list[str]:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/contracts/src/schemas/system-update.schema.ts
+++ b/packages/contracts/src/schemas/system-update.schema.ts
@@ -35,6 +35,40 @@ export const SystemUpdateJobStatusSchema = v.picklist(
   'Choose a valid system update job status'
 )
 
+export const SystemUpdatePhaseSchema = v.object({
+  key: v.pipe(v.string('Phase key is required'), v.minLength(1, 'Phase key is required')),
+  label: v.pipe(v.string('Phase label is required'), v.minLength(1, 'Phase label is required')),
+  description: v.nullable(
+    v.pipe(
+      v.string('Phase description must be a string'),
+      v.minLength(1, 'Phase description is required')
+    )
+  ),
+  kind: v.pipe(v.string('Phase kind is required'), v.minLength(1, 'Phase kind is required')),
+  order: v.pipe(
+    v.number('Phase order is required'),
+    v.integer('Phase order must be an integer'),
+    v.minValue(1, 'Phase order must be at least 1')
+  ),
+  total: v.pipe(
+    v.number('Phase total is required'),
+    v.integer('Phase total must be an integer'),
+    v.minValue(1, 'Phase total must be at least 1')
+  ),
+})
+
+export const SystemUpdateCheckpointSchema = v.object({
+  key: v.pipe(v.string('Checkpoint key is required'), v.minLength(1, 'Checkpoint key is required')),
+  label: v.pipe(
+    v.string('Checkpoint label is required'),
+    v.minLength(1, 'Checkpoint label is required')
+  ),
+  detail: v.pipe(
+    v.string('Checkpoint detail is required'),
+    v.minLength(1, 'Checkpoint detail is required')
+  ),
+})
+
 const NullableVersionSchema = v.nullable(SystemUpdateVersionSchema)
 
 export const SystemUpdateRequestedBySchema = v.object({
@@ -55,6 +89,8 @@ export const SystemUpdateJobSchema = v.object({
   currentVersion: NullableVersionSchema,
   latestVersion: NullableVersionSchema,
   targetVersion: SystemUpdateVersionSchema,
+  phase: SystemUpdatePhaseSchema,
+  checkpoint: SystemUpdateCheckpointSchema,
   failureSummary: v.nullable(v.string()),
   rollbackAttempted: v.boolean(),
   requestedBy: SystemUpdateRequestedBySchema,
@@ -91,6 +127,8 @@ export const SystemUpdateJobParamsSchema = v.object({
 
 export type SystemUpdateVersion = v.InferOutput<typeof SystemUpdateVersionSchema>
 export type SystemUpdateJobStatus = v.InferOutput<typeof SystemUpdateJobStatusSchema>
+export type SystemUpdatePhase = v.InferOutput<typeof SystemUpdatePhaseSchema>
+export type SystemUpdateCheckpoint = v.InferOutput<typeof SystemUpdateCheckpointSchema>
 export type SystemUpdateRequestedBy = v.InferOutput<typeof SystemUpdateRequestedBySchema>
 export type SystemUpdateJob = v.InferOutput<typeof SystemUpdateJobSchema>
 export type SystemUpdateStatusResponse = v.InferOutput<typeof SystemUpdateStatusResponseSchema>

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary
- persist structured updater-owned `phase` and `checkpoint` fields into `current-job.json`
- expose those fields through contracts/backend sanitization and use them in the admin update UI
- replace the old generic update rail with a 5-phase progress model plus live checkpoint detail
- bump workspace versions to `2.8.1`

## Why
The old 1-10 update steps did not match the real appliance update flow. This change makes the updater itself the source of truth for active progress so the Upgrade page reflects what is actually happening.

## Validation
- `python3 -m py_compile deploy/deb/assets/usr/lib/sentinel/sentinel_update_common.py deploy/deb/assets/usr/lib/sentinel/sentinel-updater deploy/deb/assets/usr/lib/sentinel/sentinel-update-bridge`
- `pnpm --filter @sentinel/backend typecheck`
- `pnpm --filter frontend-admin typecheck`
- `pnpm --dir apps/frontend-admin exec vitest run src/components/settings/system-update-panel.logic.test.ts`
- `./apps/frontend-admin/node_modules/.bin/vitest run apps/backend/src/routes/system-update.test.ts apps/backend/src/services/system-update-status-service.test.ts`
- mocked Playwright sanity pass of `/settings?tab=updates`
