### PR TITLE
chore(release): cut v2.8.2

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/routes/system-update.test.ts
+++ b/apps/backend/src/routes/system-update.test.ts
@@ -6,7 +6,8 @@ import { createExpressEndpoints } from '@ts-rest/express'
 import { systemUpdateContract } from '@sentinel/contracts'
 import express from 'express'
 import request from 'supertest'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { SystemUpdateStatusService } from '../services/system-update-status-service.js'
 import { createSystemUpdateRouter } from './system-update.js'
 
 function createMember(accountLevel: number) {
@@ -21,7 +22,12 @@ function createMember(accountLevel: number) {
   }
 }
 
-function createTestApp(accountLevel?: number) {
+function createTestApp(
+  accountLevel?: number,
+  options?: {
+    statusService?: SystemUpdateStatusService
+  }
+) {
   const app = express()
   app.use(express.json())
   app.use((req, _res, next) => {
@@ -32,7 +38,7 @@ function createTestApp(accountLevel?: number) {
     }
     next()
   })
-  createExpressEndpoints(systemUpdateContract, createSystemUpdateRouter(), app, {
+  createExpressEndpoints(systemUpdateContract, createSystemUpdateRouter(options), app, {
     requestValidationErrorHandler: (err, _req, res) => {
       return res.status(400).json({
         error: 'VALIDATION_ERROR',
@@ -42,6 +48,17 @@ function createTestApp(accountLevel?: number) {
     },
   })
   return app
+}
+
+function createStatusResponse(overrides?: Partial<Record<string, unknown>>) {
+  return {
+    currentVersion: 'v2.6.1',
+    latestVersion: 'v2.6.2',
+    latestReleaseUrl: 'https://github.com/DeadshotOMEGA/sentinel/releases/tag/v2.6.2',
+    updateAvailable: true,
+    currentJob: null,
+    ...overrides,
+  }
 }
 
 function createJob(overrides?: Partial<Record<string, unknown>>) {
@@ -155,6 +172,20 @@ describe('systemUpdateRouter', () => {
     expect(response.body).toMatchObject({
       error: 'UNAUTHORIZED',
     })
+  })
+
+  it('forwards forceRefresh status queries to the status service', async () => {
+    const getStatus = vi.fn().mockResolvedValue(createStatusResponse())
+    const statusService = {
+      getStatus,
+      getJob: vi.fn(),
+    } as unknown as SystemUpdateStatusService
+
+    const app = createTestApp(5, { statusService })
+    const response = await request(app).get('/api/admin/system/update?forceRefresh=true')
+
+    expect(response.status).toBe(200)
+    expect(getStatus).toHaveBeenCalledWith({ forceRefresh: true })
   })
 
   it('requires authentication for the update trace endpoint', async () => {

--- a/apps/backend/src/routes/system-update.ts
+++ b/apps/backend/src/routes/system-update.ts
@@ -14,7 +14,11 @@ import { SystemUpdateTraceService } from '../services/system-update-trace-servic
 
 const s = initServer()
 
-function requireMember(req: Request) {
+type RequestWithMember = {
+  member?: Request['member']
+}
+
+function requireMember(req: RequestWithMember) {
   if (!req.member) {
     return {
       status: 401 as const,
@@ -28,7 +32,7 @@ function requireMember(req: Request) {
   return null
 }
 
-function requireSystemUpdateAccess(req: Request) {
+function requireSystemUpdateAccess(req: RequestWithMember) {
   const auth = requireMember(req)
   if (auth) {
     return auth
@@ -47,7 +51,7 @@ function requireSystemUpdateAccess(req: Request) {
   return null
 }
 
-function buildRequesterName(req: Request): string {
+function buildRequesterName(req: RequestWithMember): string {
   if (!req.member) {
     return 'Unknown member'
   }
@@ -67,14 +71,16 @@ export function createSystemUpdateRouter(options?: {
   const traceService = options?.traceService ?? new SystemUpdateTraceService()
 
   return s.router(systemUpdateContract, {
-    getSystemUpdateStatus: async ({ req }) => {
+    getSystemUpdateStatus: async ({ req, query }) => {
       const auth = requireMember(req)
       if (auth) {
         return auth
       }
 
       try {
-        const status = await statusService.getStatus()
+        const status = await statusService.getStatus({
+          forceRefresh: query.forceRefresh === true,
+        })
         return {
           status: 200 as const,
           body: status,

--- a/apps/backend/src/services/system-update-status-service.test.ts
+++ b/apps/backend/src/services/system-update-status-service.test.ts
@@ -64,6 +64,49 @@ describe('SystemUpdateStatusService', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
+  it('bypasses the successful release cache when force refresh is requested', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new globalThis.Response(
+          JSON.stringify({
+            tag_name: 'v2.6.7',
+            html_url: 'https://github.com/DeadshotOMEGA/sentinel/releases/tag/v2.6.7',
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new globalThis.Response(
+          JSON.stringify({
+            tag_name: 'v2.6.8',
+            html_url: 'https://github.com/DeadshotOMEGA/sentinel/releases/tag/v2.6.8',
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          }
+        )
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const service = await createService()
+
+    const firstStatus = await service.getStatus()
+    const refreshedStatus = await service.getStatus({ forceRefresh: true })
+
+    expect(firstStatus.latestVersion).toBe('v2.6.7')
+    expect(refreshedStatus.latestVersion).toBe('v2.6.8')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
   it('caches rate-limited latest release failures until the GitHub reset window passes', async () => {
     const rateLimitResetSeconds = Math.floor(Date.now() / 1000) + 120
     const fetchMock = vi.fn().mockResolvedValue(

--- a/apps/backend/src/services/system-update-status-service.ts
+++ b/apps/backend/src/services/system-update-status-service.ts
@@ -68,13 +68,15 @@ export class SystemUpdateStatusService {
       options?.latestReleaseErrorCacheTtlMs ?? DEFAULT_RELEASE_LOOKUP_ERROR_CACHE_TTL_MS
   }
 
-  async getStatus(): Promise<SystemUpdateStatusResponse> {
+  async getStatus(options?: { forceRefresh?: boolean }): Promise<SystemUpdateStatusResponse> {
     const applianceStateVersion = await this.readApplianceCurrentVersion()
     const currentJob = this.filterSupersededTerminalJob(
       await this.readCurrentJob(),
       applianceStateVersion
     )
-    const releaseSummary = await this.fetchLatestReleaseSummary()
+    const releaseSummary = await this.fetchLatestReleaseSummary({
+      forceRefresh: options?.forceRefresh === true,
+    })
     const completedJobVersion =
       currentJob && isSystemUpdateJobFinished(currentJob) ? currentJob.currentVersion : null
     const currentVersion =
@@ -167,7 +169,9 @@ export class SystemUpdateStatusService {
     return sanitizeSystemUpdateJob(payload)
   }
 
-  private async fetchLatestReleaseSummary(): Promise<LatestReleaseSummary> {
+  private async fetchLatestReleaseSummary(options?: {
+    forceRefresh?: boolean
+  }): Promise<LatestReleaseSummary> {
     const repository = this.releaseRepository.trim()
     if (repository.length === 0) {
       return {
@@ -176,8 +180,9 @@ export class SystemUpdateStatusService {
       }
     }
 
+    const forceRefresh = options?.forceRefresh === true
     const cachedEntry = this.latestReleaseCache
-    if (cachedEntry && cachedEntry.expiresAt > Date.now()) {
+    if (!forceRefresh && cachedEntry && cachedEntry.expiresAt > Date.now()) {
       return cachedEntry.summary
     }
 

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/components/settings/system-update-panel.tsx
+++ b/apps/frontend-admin/src/components/settings/system-update-panel.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/components/ui/dialog'
 import { LoadingSpinner } from '@/components/ui/loading-spinner'
 import {
+  useRefreshSystemUpdateStatus,
   useStartSystemUpdate,
   useSystemUpdateStatus,
   useSystemUpdateTrace,
@@ -230,6 +231,7 @@ export function SystemUpdatePanel() {
     refetchIntervalMs: 5_000,
   })
   const startSystemUpdate = useStartSystemUpdate()
+  const refreshSystemUpdate = useRefreshSystemUpdateStatus()
 
   const status = systemUpdateQuery.data ?? null
   const currentJob = status?.currentJob ?? null
@@ -276,9 +278,13 @@ export function SystemUpdatePanel() {
   }, [traceRequested])
 
   const handleRefresh = async () => {
-    await systemUpdateQuery.refetch()
-    if (tracePanelOpen && canStartUpdates) {
-      await traceQuery.refetch()
+    try {
+      await refreshSystemUpdate.mutateAsync()
+      if (tracePanelOpen && canStartUpdates) {
+        await traceQuery.refetch()
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to refresh system update status')
     }
   }
 
@@ -381,10 +387,10 @@ export function SystemUpdatePanel() {
                 type="button"
                 className="btn btn-sm btn-outline"
                 onClick={() => void handleRefresh()}
-                disabled={systemUpdateQuery.isFetching}
+                disabled={systemUpdateQuery.isFetching || refreshSystemUpdate.isPending}
                 data-testid={TID.settings.updates.refresh}
               >
-                {systemUpdateQuery.isFetching ? (
+                {systemUpdateQuery.isFetching || refreshSystemUpdate.isPending ? (
                   <LoadingSpinner size="xs" className="mr-2" />
                 ) : (
                   <RefreshCw className="mr-2 h-4 w-4" />

--- a/apps/frontend-admin/src/hooks/use-system-update.ts
+++ b/apps/frontend-admin/src/hooks/use-system-update.ts
@@ -24,22 +24,40 @@ function getErrorMessage(body: unknown, fallback: string): string {
   return fallback
 }
 
+async function fetchSystemUpdateStatus(options?: {
+  forceRefresh?: boolean
+}): Promise<SystemUpdateStatusResponse> {
+  const response = await apiClient.systemUpdate.getSystemUpdateStatus(
+    options?.forceRefresh ? { query: { forceRefresh: 'true' } } : {}
+  )
+
+  if (response.status !== 200) {
+    throw new Error(getErrorMessage(response.body, 'Failed to load system update status'))
+  }
+
+  return response.body
+}
+
 export function useSystemUpdateStatus(options?: { enabled?: boolean; refetchIntervalMs?: number }) {
   return useQuery({
     queryKey: systemUpdateStatusQueryKey,
-    queryFn: async (): Promise<SystemUpdateStatusResponse> => {
-      const response = await apiClient.systemUpdate.getSystemUpdateStatus()
-
-      if (response.status !== 200) {
-        throw new Error(getErrorMessage(response.body, 'Failed to load system update status'))
-      }
-
-      return response.body
-    },
+    queryFn: async (): Promise<SystemUpdateStatusResponse> => fetchSystemUpdateStatus(),
     enabled: options?.enabled,
     refetchInterval: options?.refetchIntervalMs ?? 30_000,
     refetchOnWindowFocus: true,
     retry: 1,
+  })
+}
+
+export function useRefreshSystemUpdateStatus() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (): Promise<SystemUpdateStatusResponse> =>
+      fetchSystemUpdateStatus({ forceRefresh: true }),
+    onSuccess: (data) => {
+      queryClient.setQueryData(systemUpdateStatusQueryKey, data)
+    },
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/contracts/src/contracts/system-update.contract.ts
+++ b/packages/contracts/src/contracts/system-update.contract.ts
@@ -5,6 +5,7 @@ import {
   StartSystemUpdateSchema,
   SystemUpdateJobParamsSchema,
   SystemUpdateJobSchema,
+  SystemUpdateStatusQuerySchema,
   SystemUpdateStatusResponseSchema,
   SystemUpdateTraceResponseSchema,
 } from '../schemas/index.js'
@@ -16,6 +17,7 @@ export const systemUpdateContract = c.router(
     getSystemUpdateStatus: {
       method: 'GET',
       path: '/api/admin/system/update',
+      query: SystemUpdateStatusQuerySchema,
       responses: {
         200: SystemUpdateStatusResponseSchema,
         401: ErrorResponseSchema,

--- a/packages/contracts/src/schemas/system-update.schema.ts
+++ b/packages/contracts/src/schemas/system-update.schema.ts
@@ -104,6 +104,16 @@ export const SystemUpdateStatusResponseSchema = v.object({
   currentJob: v.nullable(SystemUpdateJobSchema),
 })
 
+export const SystemUpdateStatusQuerySchema = v.object({
+  forceRefresh: v.optional(
+    v.pipe(
+      v.string('forceRefresh must be true or false'),
+      v.picklist(['true', 'false'], 'forceRefresh must be true or false'),
+      v.transform((value) => value === 'true')
+    )
+  ),
+})
+
 export const SystemUpdateTraceResponseSchema = v.object({
   available: v.boolean(),
   path: v.string(),
@@ -132,6 +142,7 @@ export type SystemUpdateCheckpoint = v.InferOutput<typeof SystemUpdateCheckpoint
 export type SystemUpdateRequestedBy = v.InferOutput<typeof SystemUpdateRequestedBySchema>
 export type SystemUpdateJob = v.InferOutput<typeof SystemUpdateJobSchema>
 export type SystemUpdateStatusResponse = v.InferOutput<typeof SystemUpdateStatusResponseSchema>
+export type SystemUpdateStatusQuery = v.InferOutput<typeof SystemUpdateStatusQuerySchema>
 export type SystemUpdateTraceResponse = v.InferOutput<typeof SystemUpdateTraceResponseSchema>
 export type StartSystemUpdateInput = v.InferOutput<typeof StartSystemUpdateSchema>
 export type StartSystemUpdateResponse = v.InferOutput<typeof StartSystemUpdateResponseSchema>

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Release summary
- include the Update page refresh fix so manual refresh bypasses the backend GitHub release cache
- publish workspace version `2.8.2`

## Why
Operators were seeing a delay of up to several minutes before a newly published GitHub release appeared on the Update page, even after pressing Refresh. This release makes manual refresh perform a live release lookup while preserving caching for normal polling.

## Validation
- `pnpm version:check`
- `pnpm --filter @sentinel/backend typecheck`
- `pnpm --filter frontend-admin typecheck`
- `./apps/frontend-admin/node_modules/.bin/vitest run apps/backend/src/services/system-update-status-service.test.ts apps/backend/src/routes/system-update.test.ts`
- PR #118 checks: `label-pr`, `validate`
