### PR TITLE
fix: stabilize kiosk connectivity status and expose kiosk presence for v3.0.2

### DIFF
--- a/apps/backend/src/lib/kiosk-device-presence.ts
+++ b/apps/backend/src/lib/kiosk-device-presence.ts
@@ -1,0 +1,64 @@
+interface KioskPresenceRecord {
+  apiKeyId: string
+  apiKeyName: string
+  ipAddress: string | null
+  lastSeenAt: Date
+}
+
+export interface KioskPresenceSession {
+  sessionId: string
+  memberId: string
+  memberName: string
+  memberRank: string
+  remoteSystemId: string | null
+  remoteSystemCode: string | null
+  remoteSystemName: string
+  lastSeenAt: Date
+  ipAddress: string | null
+}
+
+export class KioskDevicePresenceStore {
+  private records = new Map<string, KioskPresenceRecord>()
+
+  touch(input: { apiKeyId: string; apiKeyName?: string | null; ipAddress?: string | null }): void {
+    const now = new Date()
+    const apiKeyName =
+      input.apiKeyName && input.apiKeyName.trim().length > 0 ? input.apiKeyName.trim() : 'Kiosk'
+
+    this.records.set(input.apiKeyId, {
+      apiKeyId: input.apiKeyId,
+      apiKeyName,
+      ipAddress: input.ipAddress ?? null,
+      lastSeenAt: now,
+    })
+  }
+
+  listActive(input: { activeWithinSeconds: number; limit: number }): {
+    activeCount: number
+    overflowCount: number
+    sessions: KioskPresenceSession[]
+  } {
+    const activeThreshold = new Date(Date.now() - input.activeWithinSeconds * 1000)
+    const active = [...this.records.values()]
+      .filter((record) => record.lastSeenAt >= activeThreshold)
+      .sort((a, b) => b.lastSeenAt.getTime() - a.lastSeenAt.getTime())
+
+    return {
+      activeCount: active.length,
+      overflowCount: Math.max(active.length - input.limit, 0),
+      sessions: active.slice(0, input.limit).map((record) => ({
+        sessionId: `kiosk-device:${record.apiKeyId}`,
+        memberId: record.apiKeyId,
+        memberName: record.apiKeyName,
+        memberRank: 'DEVICE',
+        remoteSystemId: null,
+        remoteSystemCode: 'kiosk',
+        remoteSystemName: record.apiKeyName,
+        lastSeenAt: record.lastSeenAt,
+        ipAddress: record.ipAddress,
+      })),
+    }
+  }
+}
+
+export const kioskDevicePresenceStore = new KioskDevicePresenceStore()

--- a/apps/backend/src/middleware/auth.ts
+++ b/apps/backend/src/middleware/auth.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from 'express'
 import { authLogger } from '../lib/logger.js'
 import { requestContext } from '../lib/logger.js'
 import { recordAuthAttempt } from '../lib/metrics.js'
+import { kioskDevicePresenceStore } from '../lib/kiosk-device-presence.js'
 import {
   authenticateKioskDeviceApiKey,
   extractKioskDeviceApiKeyFromCookies,
@@ -84,6 +85,22 @@ function extractApiKey(req: Request): string | null {
   return extractKioskDeviceApiKeyFromCookies(req.cookies)
 }
 
+function resolveRequestIpAddress(req: Request): string | null {
+  const forwardedFor = req.headers['x-forwarded-for']
+  if (typeof forwardedFor === 'string' && forwardedFor.trim().length > 0) {
+    return forwardedFor.split(',')[0]?.trim() ?? null
+  }
+
+  if (Array.isArray(forwardedFor) && forwardedFor.length > 0) {
+    const first = forwardedFor[0]?.trim()
+    if (first) {
+      return first
+    }
+  }
+
+  return req.ip ?? null
+}
+
 function isPinChangeExemptPath(req: Request): boolean {
   const method = req.method.toUpperCase()
   const path = req.path
@@ -161,6 +178,11 @@ export function requireAuth(required: boolean = true) {
         if (authenticatedApiKey) {
           recordAuthAttempt('success', 'apikey')
           req.apiKey = authenticatedApiKey
+          kioskDevicePresenceStore.touch({
+            apiKeyId: authenticatedApiKey.id,
+            apiKeyName: authenticatedApiKey.name,
+            ipAddress: resolveRequestIpAddress(req),
+          })
 
           const store = requestContext.getStore()
           if (store) {

--- a/apps/backend/src/services/system-status-service.test.ts
+++ b/apps/backend/src/services/system-status-service.test.ts
@@ -1,5 +1,6 @@
 import type { PrismaClientInstance } from '@sentinel/database'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { KioskDevicePresenceStore } from '../lib/kiosk-device-presence.js'
 import type { SessionRepository } from '../repositories/session-repository.js'
 import type { HostNetworkStatusService } from './host-network-status-service.js'
 import type { NetworkSettingsService } from './network-settings-service.js'
@@ -37,6 +38,7 @@ function createService(options?: {
   approvedSsids?: string[]
   telemetryResult?: Awaited<ReturnType<HostNetworkStatusService['readTelemetry']>>
   databaseHealthy?: boolean
+  kioskPresence?: ReturnType<KioskDevicePresenceStore['listActive']>
 }) {
   const prisma = {
     $queryRaw:
@@ -67,10 +69,20 @@ function createService(options?: {
   } as unknown as HostNetworkStatusService
 
   const sessionRepository = createSessionRepositoryMock()
+  const kioskPresenceStore = {
+    listActive: vi.fn().mockReturnValue(
+      options?.kioskPresence ?? {
+        activeCount: 0,
+        overflowCount: 0,
+        sessions: [],
+      }
+    ),
+  } as unknown as KioskDevicePresenceStore
 
   const service = new SystemStatusService(prisma, {
     hostNetworkStatusService,
     networkSettingsService,
+    kioskPresenceStore,
   })
 
   ;(service as unknown as { sessionRepository: SessionRepository }).sessionRepository =
@@ -130,6 +142,36 @@ describe('SystemStatusService', () => {
     expect(result.network.message).toContain('unapproved Wi-Fi SSID')
     expect(result.remoteSystems.sessions[0]?.ipAddress).toBe('192.168.0.20')
     expect(result.overall.status).toBe('warning')
+  })
+
+  it('includes active kiosk API key presence in remote systems summary', async () => {
+    const { service } = createService({
+      kioskPresence: {
+        activeCount: 1,
+        overflowCount: 0,
+        sessions: [
+          {
+            sessionId: 'kiosk-device:kiosk-device',
+            memberId: 'kiosk-device',
+            memberName: 'Front entrance kiosk',
+            memberRank: 'DEVICE',
+            remoteSystemId: null,
+            remoteSystemCode: 'kiosk',
+            remoteSystemName: 'Front entrance kiosk',
+            lastSeenAt: new Date('2026-04-01T11:59:40.000Z'),
+            ipAddress: '192.168.0.55',
+          },
+        ],
+      },
+    })
+
+    const result = await service.getSystemStatus()
+
+    expect(result.remoteSystems.activeCount).toBe(2)
+    expect(result.remoteSystems.status).toBe('healthy')
+    expect(
+      result.remoteSystems.sessions.some((session) => session.remoteSystemCode === 'kiosk')
+    ).toBe(true)
   })
 
   it('keeps network status healthy when internet reachability is unavailable but Wi-Fi is approved', async () => {

--- a/apps/backend/src/services/system-status-service.ts
+++ b/apps/backend/src/services/system-status-service.ts
@@ -11,6 +11,11 @@ import {
   hostNetworkStatusAgeSeconds,
   networkStatusDegradationsTotal,
 } from '../lib/metrics.js'
+import {
+  kioskDevicePresenceStore,
+  type KioskDevicePresenceStore,
+  type KioskPresenceSession,
+} from '../lib/kiosk-device-presence.js'
 import { logger } from '../lib/logger.js'
 import { isDevelopmentBuild, isRunningInsideContainer } from '../lib/runtime-context.js'
 import { resolveServiceVersionDisplay } from '../lib/service-version.js'
@@ -225,12 +230,14 @@ export class SystemStatusService {
   private sessionRepository: SessionRepository
   private networkSettingsService: NetworkSettingsService
   private hostNetworkStatusService: HostNetworkStatusService
+  private kioskPresenceStore: KioskDevicePresenceStore
 
   constructor(
     prismaClient: PrismaClientInstance = defaultPrisma,
     options?: {
       hostNetworkStatusService?: HostNetworkStatusService
       networkSettingsService?: NetworkSettingsService
+      kioskPresenceStore?: KioskDevicePresenceStore
     }
   ) {
     this.prisma = prismaClient
@@ -239,6 +246,7 @@ export class SystemStatusService {
       options?.networkSettingsService ?? new NetworkSettingsService(prismaClient)
     this.hostNetworkStatusService =
       options?.hostNetworkStatusService ?? new HostNetworkStatusService()
+    this.kioskPresenceStore = options?.kioskPresenceStore ?? kioskDevicePresenceStore
   }
 
   async getSystemStatus(): Promise<SystemStatusResponse> {
@@ -246,7 +254,7 @@ export class SystemStatusService {
     const developmentBuild = isDevelopmentBuild()
     const runningInsideContainer = isRunningInsideContainer()
 
-    const [networkSettingsState, telemetryResult, remoteSessions, activeSessionCount] =
+    const [networkSettingsState, telemetryResult, memberRemoteSessions, activeSessionCount] =
       await Promise.all([
         this.networkSettingsService.getNetworkSettings(),
         this.hostNetworkStatusService.readTelemetry(),
@@ -304,9 +312,19 @@ export class SystemStatusService {
       networkStatusDegradationsTotal.inc({ status: networkStatus })
     }
 
+    const kioskPresence = this.kioskPresenceStore.listActive({
+      limit: REMOTE_SESSION_LIMIT,
+      activeWithinSeconds: ACTIVE_REMOTE_SESSION_THRESHOLD_SECONDS,
+    })
+    const mergedRemoteSessions = mergeRemoteSessions({
+      memberRemoteSessions,
+      kioskPresence: kioskPresence.sessions,
+      limit: REMOTE_SESSION_LIMIT,
+    })
+
     hostNetworkStatusAgeSeconds.set(telemetryAgeSeconds ?? -1)
     activeSessions.set(activeSessionCount)
-    activeRemoteSessions.set(remoteSessions.activeCount)
+    activeRemoteSessions.set(mergedRemoteSessions.activeCount)
 
     return {
       overall: resolveOverallStatus({
@@ -360,11 +378,11 @@ export class SystemStatusService {
         generatedAt: telemetry?.generatedAt.toISOString() ?? null,
       },
       remoteSystems: {
-        status: remoteSessions.activeCount > 0 ? 'healthy' : 'unknown',
-        activeCount: remoteSessions.activeCount,
+        status: mergedRemoteSessions.activeCount > 0 ? 'healthy' : 'unknown',
+        activeCount: mergedRemoteSessions.activeCount,
         staleThresholdSeconds: ACTIVE_REMOTE_SESSION_THRESHOLD_SECONDS,
-        overflowCount: remoteSessions.overflowCount,
-        sessions: remoteSessions.sessions.map((session) => ({
+        overflowCount: mergedRemoteSessions.overflowCount,
+        sessions: mergedRemoteSessions.sessions.map((session) => ({
           sessionId: session.sessionId,
           memberId: session.memberId,
           memberName: session.memberName,
@@ -381,5 +399,29 @@ export class SystemStatusService {
       },
       lastCheckedAt: lastCheckedAt.toISOString(),
     }
+  }
+}
+
+function mergeRemoteSessions(input: {
+  memberRemoteSessions: Awaited<ReturnType<SessionRepository['findActiveRemoteSessions']>>
+  kioskPresence: KioskPresenceSession[]
+  limit: number
+}): {
+  activeCount: number
+  overflowCount: number
+  sessions: Array<
+    | Awaited<ReturnType<SessionRepository['findActiveRemoteSessions']>>['sessions'][number]
+    | KioskPresenceSession
+  >
+} {
+  const combined = [...input.memberRemoteSessions.sessions, ...input.kioskPresence].sort(
+    (left, right) => right.lastSeenAt.getTime() - left.lastSeenAt.getTime()
+  )
+  const activeCount = input.memberRemoteSessions.activeCount + input.kioskPresence.length
+
+  return {
+    activeCount,
+    overflowCount: Math.max(activeCount - input.limit, 0),
+    sessions: combined.slice(0, input.limit),
   }
 }

--- a/apps/frontend-admin/src/components/kiosk/kiosk-domain.test.ts
+++ b/apps/frontend-admin/src/components/kiosk/kiosk-domain.test.ts
@@ -1,0 +1,81 @@
+import type { SystemStatusResponse } from '@sentinel/contracts'
+import { describe, expect, it } from 'vitest'
+import { getKioskConnectivityBadge } from './kiosk-domain'
+
+function createSystemStatus(overrides?: Partial<SystemStatusResponse>): SystemStatusResponse {
+  return {
+    overall: { status: 'healthy', label: 'Healthy' },
+    backend: {
+      status: 'healthy',
+      environment: 'production',
+      version: 'v3.0.1',
+      uptimeSeconds: 10,
+      serviceTimestamp: '2026-05-01T12:00:00.000Z',
+    },
+    database: {
+      healthy: true,
+      address: 'localhost:5432',
+    },
+    network: {
+      status: 'healthy',
+      telemetryAvailable: true,
+      telemetryAgeSeconds: 2,
+      message: 'Network checks are healthy.',
+      issueCode: 'none',
+      wifiConnected: true,
+      currentSsid: 'Sentinel',
+      hostIpAddress: '192.168.1.10',
+      hotspotProfilePresent: true,
+      hotspotAdapterApproved: true,
+      scanAdapterPresent: true,
+      hotspotDevice: 'wlan0',
+      hotspotSsid: 'Sentinel-Setup',
+      hotspotScanDevice: 'wlan1',
+      hotspotSsidVisibleFromLaptop: true,
+      approvedSsids: ['Sentinel'],
+      approvedSsid: true,
+      internetReachable: true,
+      remoteTarget: null,
+      remoteReachable: null,
+      portalRecoveryLikely: false,
+      generatedAt: '2026-05-01T12:00:00.000Z',
+    },
+    remoteSystems: {
+      status: 'unknown',
+      activeCount: 0,
+      staleThresholdSeconds: 120,
+      overflowCount: 0,
+      sessions: [],
+    },
+    lastCheckedAt: '2026-05-01T12:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('getKioskConnectivityBadge', () => {
+  it('shows stale warning when refresh fails but last known status is healthy', () => {
+    const badge = getKioskConnectivityBadge({
+      systemStatus: createSystemStatus(),
+      isLoading: false,
+      isError: true,
+    })
+
+    expect(badge).toMatchObject({
+      status: 'warning',
+      label: 'CONNECTED (STATUS STALE)',
+    })
+  })
+
+  it('shows disconnected when there is no status data and request failed', () => {
+    const badge = getKioskConnectivityBadge({
+      systemStatus: null,
+      isLoading: false,
+      isError: true,
+    })
+
+    expect(badge).toMatchObject({
+      status: 'error',
+      label: 'DISCONNECTED',
+    })
+  })
+})

--- a/apps/frontend-admin/src/components/kiosk/kiosk-domain.ts
+++ b/apps/frontend-admin/src/components/kiosk/kiosk-domain.ts
@@ -344,11 +344,22 @@ export function getKioskConnectivityBadge({
     }
   }
 
-  if (isError || !systemStatus || systemStatus.backend.status !== 'healthy') {
+  // Keep showing the last known backend status when background refetches fail.
+  // React Query can report `isError` while still retaining valid cached data.
+  if (!systemStatus || systemStatus.backend.status !== 'healthy') {
     return {
       status: 'error',
       label: 'DISCONNECTED',
       detail: 'Kiosk cannot reach a healthy backend API.',
+    }
+  }
+
+  if (isError) {
+    return {
+      status: 'warning',
+      label: 'CONNECTED (STATUS STALE)',
+      detail:
+        'Backend is reachable from the last successful check, but a live status refresh failed.',
     }
   }
 

--- a/apps/frontend-admin/src/proxy.ts
+++ b/apps/frontend-admin/src/proxy.ts
@@ -2,7 +2,12 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { buildLoginUrl } from '@/lib/post-login-destination'
-import { isKioskDeviceBootstrapRoute, isKioskRoute } from '@/lib/kiosk-device-auth'
+import {
+  isKioskDeviceBootstrapRoute,
+  isKioskRoute,
+  KIOSK_DEVICE_BOOTSTRAP_PATH,
+  KIOSK_DEVICE_COOKIE_NAME,
+} from '@/lib/kiosk-device-auth'
 
 export function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname
@@ -11,8 +16,15 @@ export function proxy(request: NextRequest) {
   }
 
   const sessionCookie = request.cookies.get('sentinel-session')
+  const kioskDeviceCookie = request.cookies.get(KIOSK_DEVICE_COOKIE_NAME)
 
   if (isKioskRoute(pathname)) {
+    if (!sessionCookie?.value && !kioskDeviceCookie?.value) {
+      const bootstrapUrl = new URL(KIOSK_DEVICE_BOOTSTRAP_PATH, request.url)
+      bootstrapUrl.searchParams.set('next', `${pathname}${request.nextUrl.search}`)
+      return NextResponse.redirect(bootstrapUrl)
+    }
+
     return NextResponse.next()
   }
 


### PR DESCRIPTION
## Summary

- Fixes a false `DISCONNECTED` state on the kiosk when backend status refresh fails transiently.
- Adds automatic kiosk device-auth bootstrap for `/kiosk` so kiosk sessions self-recover when cookies are missing.
- Adds backend kiosk API-key presence tracking and includes active kiosk devices in `system-status` remote systems.
- Preserves kiosk-safe system-status redaction for API-key callers while improving operator visibility on server/admin views.

## Why this change was needed

Kiosks were showing disconnected even when they were reachable and actively working. In parallel, server operators could not see kiosk connectivity reflected in Remote Systems unless a member session existed, which made patch-release verification and incident triage harder.

## What changed

### User-facing

- Kiosk status no longer flips to hard disconnected on brief system-status refresh failures when a healthy status is already cached.
- Kiosk routes now automatically bootstrap device auth when needed.

### Admin/operator-facing

- System status now includes active kiosk device presence in the Remote Systems summary.
- Operators can confirm kiosk connectivity without requiring a member login session on that kiosk.

### Backend/API

- Added in-memory kiosk device presence store, touched on successful API-key auth.
- Merged kiosk presence with member remote sessions in `SystemStatusService` output.

### Database

- No schema or migration changes.

### Deployment/update

- Requires backend and frontend-admin service restart to activate middleware and status logic updates.

### Tests

- Added kiosk connectivity badge regression tests in frontend-admin.
- Added backend system-status unit coverage for kiosk presence inclusion.

## User impact

Kiosk operators should see more accurate top-banner connectivity status and fewer false outage indicators.

## Operator impact

Server/admin operators can now see kiosk device presence in Remote Systems for faster diagnosis and release verification.

## Upgrade or migration notes

No upgrade action required.

Operational step: restart backend and frontend-admin services after deploying this patch.

## Risk and rollback notes

- Main risk: kiosk presence tracking is in-memory, so entries clear on backend restart until new authenticated kiosk requests arrive.
- Verification: confirm kiosk shows connected state and server Remote Systems includes a `kiosk` entry after kiosk traffic.
- Rollback: safe to rollback by reverting this PR; no database or data-shape migration involved.

## Testing performed

- `pnpm --filter @sentinel/backend typecheck`
- `pnpm --filter frontend-admin type-check`
- Note: backend/package-local Vitest command is not currently available in this environment.

## Changelog candidates

- Fixed kiosk false-disconnect status when backend refresh errors are transient.
- Added automatic kiosk device-auth bootstrap when kiosk cookies are missing.
- Added kiosk device presence to system-status Remote Systems for server/admin visibility.
