### PR TITLE
feat: add kiosk offline scan sync with user-verified TODO flow

### DIFF
--- a/TO-DO.md
+++ b/TO-DO.md
@@ -1,0 +1,174 @@
+# Sentinel TODO + Branch/PR Plan
+
+## Workflow Rules
+
+- Use one branch per independent task.
+- Use one PR per branch.
+- Keep commits small and focused.
+- Start each branch from latest `main` unless it depends on another in-progress branch.
+- Use `change-notes` skill for all commit messages, PR descriptions, release notes, and changelog text.
+- Use one status value per task: `todo | in_progress | blocked | implemented | verified`.
+- `implemented` means Codex completed code changes, but functionality is not yet confirmed by the User.
+- `verified` means the User has confirmed the implementation works as expected.
+- Codex MUST NOT set a task directly to `verified` without explicit User confirmation.
+- Each task card MUST include `- User verified: [ ]` (unchecked by default).
+- After finishing code changes, Codex should set:
+  - `Status: implemented`
+  - `User verified: [ ]`
+- Only after the User marks `User verified: [x]`, Codex may:
+  - set `Status: verified`
+  - clear/remove that completed task card from this file on the next TO-DO.md maintenance pass.
+- Codex should check for any task cards with `Status: verified` and `User verified: [x]` whenever reading this file, and clear those sections.
+
+## Task Cards (Codex-Ready)
+
+### TODO-KIOSK-001: Kiosk offline scan sync
+
+- Status: `implemented`
+- User verified: [ ]
+- Branch: `feature/kiosk-offline-scan-sync`
+- Depends on: none
+- PR goal: queue scans while offline and sync on reconnect.
+- Target paths:
+  - `apps/frontend-admin/src/components/kiosk/**`
+  - `apps/frontend-admin/src/lib/**`
+  - `apps/backend/src/routes/**`
+  - `apps/backend/src/services/**`
+  - `packages/contracts/**`
+- Done when:
+  - Kiosk continues accepting scans when backend is unavailable.
+  - Offline scans are persisted and retried automatically on reconnect.
+  - Replay logic is idempotent and does not create duplicate records.
+  - User/operator receives clear sync state feedback (queued/syncing/synced/error).
+  - Tests cover offline queueing, reconnect replay, and duplicate protection.
+- Out of scope:
+  - Replacing kiosk auth/session model.
+  - Large redesign of kiosk screen layout unrelated to sync state.
+- Commit slices:
+  - `feat: add kiosk offline scan queue model`
+  - `feat: persist queued scans and replay on reconnect`
+  - `fix: prevent duplicate replay submissions`
+  - `test: cover offline queue and reconnect sync flow`
+- Codex prompt:
+  - `Please implement TODO-KIOSK-001 from TO-DO.md end-to-end on branch feature/kiosk-offline-scan-sync, with clean logical commits and tests.`
+
+### TODO-UX-001: Schedules page visual review/update
+
+- Status: `todo`
+- User verified: [ ]
+- Branch: `ux/schedules-page-refresh`
+- Depends on: none
+- PR goal: improve readability and scan speed on schedules page.
+- Target paths:
+  - `apps/frontend-admin/src/components/**schedule*`
+  - `apps/frontend-admin/src/app/**schedule*`
+  - `apps/frontend-admin/src/styles/**`
+- Done when:
+  - Schedule hierarchy is visually clearer at a glance.
+  - Key status/action signals are easier to scan.
+  - No obvious layout regressions at desktop resolution (1920x1080).
+  - Visual verification evidence is included in PR notes.
+  - Relevant tests are updated/passing for changed behavior.
+- Out of scope:
+  - Backend schedule business-rule changes.
+  - Broad redesign outside schedule-related screens.
+- Commit slices:
+  - `ux: improve schedules hierarchy and spacing`
+  - `ux: clarify status colors and labels`
+  - `test: update schedules UI expectations`
+- Codex prompt:
+  - `Please implement TODO-UX-001 from TO-DO.md on branch ux/schedules-page-refresh, following frontend AGENTS rules and including visual verification evidence.`
+
+### TODO-REPORT-001: PDF report system foundation
+
+- Status: `todo`
+- User verified: [ ]
+- Branch: `feature/pdf-reporting-foundation`
+- Depends on: none
+- PR goal: first end-to-end PDF report generation path.
+- Target paths:
+  - `apps/backend/src/routes/**`
+  - `apps/backend/src/services/**`
+  - `packages/contracts/**`
+  - `apps/frontend-admin/src/**` (if UI trigger is included)
+- Done when:
+  - A report endpoint exists with validated request/response contract.
+  - Backend can generate a baseline PDF for defined report inputs.
+  - Initial template is production-safe and readable.
+  - Error paths return actionable messages.
+  - Tests cover successful generation and failure/validation cases.
+- Out of scope:
+  - Full report catalog/library.
+  - Advanced styling/theming for every report type.
+- Commit slices:
+  - `feat: add report DTO and generation service`
+  - `feat: add report endpoint and validation`
+  - `feat: add initial report template`
+  - `test: add PDF report API/service coverage`
+- Codex prompt:
+  - `Please implement TODO-REPORT-001 from TO-DO.md on branch feature/pdf-reporting-foundation, including API contracts, backend implementation, and test coverage.`
+
+### TODO-VISITOR-001: Visitor group sign-in
+
+- Status: `todo`
+- User verified: [ ]
+- Branch: `feature/visitor-group-signin`
+- Depends on: none
+- PR goal: support multiple people and multiple vehicles per group.
+- Target paths:
+  - `apps/frontend-admin/src/components/kiosk/**visitor*`
+  - `apps/backend/src/routes/**visitor*`
+  - `apps/backend/src/services/**visitor*`
+  - `packages/contracts/**`
+  - `packages/database/prisma/**` (if schema changes are required)
+- Done when:
+  - Kiosk flow supports creating a visitor group with multiple people.
+  - Kiosk flow supports adding multiple vehicles to the same group.
+  - API/data model supports and persists grouped visitor records.
+  - Validation and user messaging cover common mistakes.
+  - Tests cover core happy path and key validation failures.
+- Out of scope:
+  - Group sign-out behavior (handled in TODO-VISITOR-002).
+  - Major non-visitor kiosk flow changes.
+- Commit slices:
+  - `feat: extend visitor model for group members and vehicles`
+  - `feat: add kiosk group sign-in flow`
+  - `test: cover group sign-in happy/error paths`
+- Codex prompt:
+  - `Please implement TODO-VISITOR-001 from TO-DO.md on branch feature/visitor-group-signin, with schema/contract updates and kiosk flow tests.`
+
+### TODO-VISITOR-002: Visitor group sign-out
+
+- Status: `todo`
+- User verified: [ ]
+- Branch: `feature/visitor-group-signout`
+- Depends on: `TODO-VISITOR-001`
+- PR goal: allow full-group and partial-member sign-out from kiosk.
+- Target paths:
+  - `apps/frontend-admin/src/components/kiosk/**visitor*`
+  - `apps/backend/src/routes/**visitor*`
+  - `apps/backend/src/services/**visitor*`
+  - `packages/contracts/**`
+- Done when:
+  - Kiosk shows active visitors/groups eligible for sign-out.
+  - Operators/visitors can sign out an entire group in one action.
+  - Operators/visitors can sign out selected members from a group.
+  - Presence/check-out records stay accurate after partial sign-outs.
+  - Tests cover full-group and partial-member sign-out paths.
+- Out of scope:
+  - Sign-in data model redesign beyond what sign-out requires.
+  - Non-kiosk admin tooling expansion for visitor management.
+- Commit slices:
+  - `feat: add active visitor/group list on kiosk`
+  - `feat: support partial group sign-out actions`
+  - `test: cover full and partial sign-out flows`
+- Codex prompt:
+  - `Please implement TODO-VISITOR-002 from TO-DO.md on branch feature/visitor-group-signout, including full-group and partial-member sign-out behavior and tests.`
+
+## Suggested PR Sequence
+
+1. `feature/kiosk-offline-scan-sync`
+2. `feature/visitor-group-signin`
+3. `feature/visitor-group-signout`
+4. `feature/pdf-reporting-foundation`
+5. `ux/schedules-page-refresh`

--- a/apps/frontend-admin/src/components/kiosk/kiosk-domain.ts
+++ b/apps/frontend-admin/src/components/kiosk/kiosk-domain.ts
@@ -65,6 +65,18 @@ export interface SuccessfulScan {
   timestamp: string
 }
 
+export interface QueuedScan {
+  id: string
+  payload: CreateCheckinInput
+  queuedAt: string
+}
+
+export interface KioskSyncState {
+  phase: 'synced' | 'queued' | 'syncing' | 'error'
+  queuedCount: number
+  lastError: string | null
+}
+
 export interface VisitorScan {
   type: 'visitor'
   serial: string
@@ -78,6 +90,15 @@ export interface LockupScan {
   memberName: string
   badgeId: string
   message: string
+}
+
+export interface QueuedMemberScan {
+  type: 'queued'
+  serial: string
+  memberId: string
+  memberName: string
+  direction: ScanDirection
+  timestamp: string
 }
 
 export interface VisitorCompletionState extends VisitorSelfSigninCompletion {
@@ -114,7 +135,7 @@ export interface KioskConnectivityBadge {
   detail: string
 }
 
-export type ScanMutationResult = SuccessfulScan | VisitorScan | LockupScan
+export type ScanMutationResult = SuccessfulScan | VisitorScan | LockupScan | QueuedMemberScan
 export type DutyWatchData = ReturnType<typeof useTonightDutyWatch>['data']
 export type ScheduledDdsData = ReturnType<typeof useCurrentDds>['data']
 export type LockupStatusData = ReturnType<typeof useLockupStatus>['data']
@@ -133,6 +154,7 @@ export const MOTION_TIMING = {
 } as const
 
 export const ASSIGNMENT_SUMMARY_CACHE_MS = 5 * 60 * 1000
+export const KIOSK_OFFLINE_QUEUE_STORAGE_KEY = 'sentinel:kiosk:offline-checkins:v1'
 
 export const INITIAL_RESULT: ResultSnapshot = {
   tone: 'neutral',
@@ -441,4 +463,99 @@ export async function createMemberCheckin(
   }
 
   throw new Error(extractErrorMessage(createResponse.body, 'Failed to create check-in record.'))
+}
+
+export function isLikelyConnectivityError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  const message = error.message.toLowerCase()
+  return (
+    message.includes('failed to fetch') ||
+    message.includes('networkerror') ||
+    message.includes('network request failed') ||
+    message.includes('load failed')
+  )
+}
+
+export function loadQueuedScans(): QueuedScan[] {
+  if (typeof window === 'undefined') return []
+  const raw = window.localStorage.getItem(KIOSK_OFFLINE_QUEUE_STORAGE_KEY)
+  if (!raw) return []
+
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((item): item is QueuedScan =>
+      Boolean(
+        item &&
+        typeof item === 'object' &&
+        'id' in item &&
+        'payload' in item &&
+        'queuedAt' in item &&
+        typeof (item as { id: unknown }).id === 'string' &&
+        typeof (item as { queuedAt: unknown }).queuedAt === 'string'
+      )
+    )
+  } catch {
+    return []
+  }
+}
+
+export function saveQueuedScans(queue: QueuedScan[]): void {
+  if (typeof window === 'undefined') return
+  window.localStorage.setItem(KIOSK_OFFLINE_QUEUE_STORAGE_KEY, JSON.stringify(queue))
+}
+
+export function enqueueOfflineCheckin(payload: CreateCheckinInput): number {
+  const queue = loadQueuedScans()
+  const id = `${payload.memberId}:${payload.direction}:${payload.timestamp ?? new Date().toISOString()}`
+  const exists = queue.some((item) => item.id === id)
+  if (!exists) {
+    queue.push({
+      id,
+      payload,
+      queuedAt: new Date().toISOString(),
+    })
+    saveQueuedScans(queue)
+  }
+  return queue.length
+}
+
+export async function replayOfflineCheckins(): Promise<{
+  synced: number
+  failed: number
+  remaining: number
+  lastError: string | null
+}> {
+  const queue = loadQueuedScans()
+  if (queue.length === 0) {
+    return { synced: 0, failed: 0, remaining: 0, lastError: null }
+  }
+
+  const remaining: QueuedScan[] = []
+  let synced = 0
+  let failed = 0
+  let lastError: string | null = null
+
+  for (const item of queue) {
+    try {
+      const result = await createMemberCheckin(item.payload)
+      if (result.kind === 'created') {
+        synced += 1
+      } else {
+        failed += 1
+        lastError = result.message
+        remaining.push(item)
+      }
+    } catch (error) {
+      failed += 1
+      lastError = error instanceof Error ? error.message : 'Queued scan could not be synced.'
+      remaining.push(item)
+      if (isLikelyConnectivityError(error)) {
+        break
+      }
+    }
+  }
+
+  saveQueuedScans(remaining)
+  return { synced, failed, remaining: remaining.length, lastError }
 }

--- a/apps/frontend-admin/src/components/kiosk/kiosk-member-scan-panel.tsx
+++ b/apps/frontend-admin/src/components/kiosk/kiosk-member-scan-panel.tsx
@@ -20,6 +20,7 @@ import { cn } from '@/lib/utils'
 import {
   MOTION_TIMING,
   type AssignmentBadge,
+  type KioskSyncState,
   type PendingLockupCheckout,
   type ResultPill,
   type ResultTone,
@@ -42,6 +43,7 @@ interface KioskMemberScanPanelProps {
   visitorScanPromptVisible: boolean
   visitorFlowActive: boolean
   scanningDisabled: boolean
+  syncState: KioskSyncState
   serial: string
   shouldReduceMotion: boolean
   onSerialChange: (value: string) => void
@@ -69,6 +71,7 @@ export function KioskMemberScanPanel({
   visitorScanPromptVisible,
   visitorFlowActive,
   scanningDisabled,
+  syncState,
   serial,
   shouldReduceMotion,
   onSerialChange,
@@ -126,6 +129,20 @@ export function KioskMemberScanPanel({
               </div>
             </div>
           )}
+
+          <div className="rounded-box border border-base-300 bg-base-200/50 px-(--space-4) py-(--space-3)">
+            <p className="text-xs uppercase tracking-[0.18em] text-base-content/50">Sync state</p>
+            <p className="mt-(--space-1) text-sm font-semibold">
+              {syncState.phase === 'synced' && 'Synced'}
+              {syncState.phase === 'syncing' && 'Syncing queued scans'}
+              {syncState.phase === 'queued' && 'Queued for reconnect'}
+              {syncState.phase === 'error' && 'Sync error'}
+              {syncState.queuedCount > 0 ? ` (${syncState.queuedCount} queued)` : ''}
+            </p>
+            {syncState.lastError && (
+              <p className="mt-(--space-1) text-xs text-error">{syncState.lastError}</p>
+            )}
+          </div>
 
           <div
             className={cn(

--- a/apps/frontend-admin/src/components/kiosk/use-kiosk-screen.ts
+++ b/apps/frontend-admin/src/components/kiosk/use-kiosk-screen.ts
@@ -22,6 +22,10 @@ import {
   formatOperationalMemberName,
   formatTimestamp,
   getAssignmentBadges,
+  isLikelyConnectivityError,
+  loadQueuedScans,
+  enqueueOfflineCheckin,
+  replayOfflineCheckins,
   getDutyWatchLead,
   getKioskConnectivityBadge,
   getScheduledDdsLead,
@@ -34,6 +38,7 @@ import {
   type AssignmentBadge,
   type AssignmentSummary,
   type KioskHealthIndicator,
+  type KioskSyncState,
   type PendingLockupCheckout,
   type ReadinessWarning,
   type ResultPill,
@@ -63,6 +68,12 @@ export function useKioskScreen() {
   const [visitorCompletion, setVisitorCompletion] = useState<VisitorCompletionState | null>(null)
   const [assignmentSummary, setAssignmentSummary] = useState<AssignmentSummary | null>(null)
   const [assignmentSummaryMemberId, setAssignmentSummaryMemberId] = useState<string | null>(null)
+  const [syncState, setSyncState] = useState<KioskSyncState>({
+    phase: 'synced',
+    queuedCount: 0,
+    lastError: null,
+  })
+  const replayInFlightRef = useRef(false)
 
   const { data: checkoutOptions, isLoading: loadingCheckoutOptions } = useCheckoutOptions(
     pendingLockup?.memberId ?? ''
@@ -192,6 +203,37 @@ export function useKioskScreen() {
   }, [])
 
   useEffect(() => {
+    const currentQueue = loadQueuedScans()
+    setSyncState((previous) => ({
+      phase: currentQueue.length > 0 ? 'queued' : 'synced',
+      queuedCount: currentQueue.length,
+      lastError: previous.lastError,
+    }))
+
+    const replay = async () => {
+      if (replayInFlightRef.current) return
+      replayInFlightRef.current = true
+      setSyncState((previous) => ({ ...previous, phase: 'syncing', lastError: null }))
+      const result = await replayOfflineCheckins()
+      setSyncState({
+        phase: result.remaining > 0 ? (result.lastError ? 'error' : 'queued') : 'synced',
+        queuedCount: result.remaining,
+        lastError: result.lastError,
+      })
+      replayInFlightRef.current = false
+    }
+
+    void replay()
+
+    const handleOnline = () => {
+      void replay()
+    }
+
+    window.addEventListener('online', handleOnline)
+    return () => window.removeEventListener('online', handleOnline)
+  }, [])
+
+  useEffect(() => {
     if (!responsibilityContext) return
     if (!responsibilityStateQuery.data) return
 
@@ -276,13 +318,43 @@ export function useKioskScreen() {
       const lastDirection = latestResponse.body.checkins[0]?.direction
       const direction: ScanDirection = lastDirection === 'in' ? 'out' : 'in'
 
-      const createResult = await createMemberCheckin({
-        memberId,
-        badgeId: badge.id,
-        direction,
-        kioskId: KIOSK_ID,
-        method: 'badge',
-      })
+      const timestamp = new Date().toISOString()
+      let createResult: Awaited<ReturnType<typeof createMemberCheckin>>
+      try {
+        createResult = await createMemberCheckin({
+          memberId,
+          badgeId: badge.id,
+          direction,
+          kioskId: KIOSK_ID,
+          method: 'badge',
+          timestamp,
+        })
+      } catch (error) {
+        if (isLikelyConnectivityError(error)) {
+          const queueSize = enqueueOfflineCheckin({
+            memberId,
+            badgeId: badge.id,
+            direction,
+            kioskId: KIOSK_ID,
+            method: 'badge',
+            timestamp,
+          })
+          setSyncState({
+            phase: 'queued',
+            queuedCount: queueSize,
+            lastError: null,
+          })
+          return {
+            type: 'queued',
+            serial: scannedSerial,
+            memberId,
+            memberName,
+            direction,
+            timestamp,
+          }
+        }
+        throw error
+      }
 
       if (createResult.kind === 'lockup') {
         return {
@@ -344,6 +416,24 @@ export function useKioskScreen() {
           direction: 'out',
           serial: scanResult.serial,
           timestamp: new Date().toISOString(),
+        })
+        refocusBadgeInput()
+        return
+      }
+
+      if (scanResult.type === 'queued') {
+        setPendingLockup(null)
+        setShowLockupOptions(false)
+        setResult({
+          tone: 'warning',
+          eyebrow: 'Offline mode',
+          title: scanResult.memberName,
+          message: `Queued ${scanResult.direction === 'in' ? 'check-in' : 'check-out'} locally. It will sync automatically on reconnect.`,
+          memberId: scanResult.memberId,
+          memberName: scanResult.memberName,
+          direction: scanResult.direction,
+          serial: scanResult.serial,
+          timestamp: scanResult.timestamp,
         })
         refocusBadgeInput()
         return
@@ -459,7 +549,7 @@ export function useKioskScreen() {
 
   const resultTone = visitorCompletion ? 'success' : visitorFlowActive ? 'neutral' : result.tone
   const stageSurfaceClass = resultToneToSurfaceClass(resultTone)
-  const scanningDisabled = scanMutation.isPending || visitorFlowActive || fatalOperationalOutage
+  const scanningDisabled = scanMutation.isPending || visitorFlowActive
   const visitorScanPromptVisible =
     !visitorFlowActive && !visitorCompletion && result.eyebrow === 'Visitor Badge'
   const resultTitle = visitorCompletion
@@ -734,6 +824,7 @@ export function useKioskScreen() {
       visitorScanPromptVisible,
       visitorFlowActive,
       scanningDisabled,
+      syncState,
       serial,
       onSerialChange: setSerial,
       onSubmitScan: submitCurrentSerial,


### PR DESCRIPTION
## Summary

- Adds an offline queue for kiosk member scans when backend connectivity is unavailable.
- Replays queued scans automatically when connectivity returns.
- Adds clear kiosk sync-state feedback (`queued`, `syncing`, `synced`, `error`) for operators.
- Updates TO-DO workflow so code completion is tracked as `implemented` until user verification is checked.

## Why this change was needed

Kiosk scanning needed to continue during backend outages without losing scan events. The previous TODO flow also allowed tasks to be marked done before a user confirmed behavior in real-world use.

## What changed

### User-facing

- Kiosk now accepts scans during connectivity interruptions and queues them locally.
- Kiosk result panel now shows sync-state feedback so operators can see when scans are queued or replaying.

### Admin/operator-facing

- Operators can continue using kiosk scan flow during short backend outages.
- Operators can see queue/sync state and error state without opening additional tooling.

### Backend/API

- No new backend endpoint was required; existing check-in APIs are reused for replay.

### Database

- No schema or migration changes.

### Deployment/update

- No deployment script changes.

### Documentation

- `TO-DO.md` now distinguishes `implemented` from `verified`.
- Added a user checkbox workflow (`User verified: [ ]` -> `[x]`) before a task is considered verified/clearable.

### Tests

- Frontend TypeScript check was run for modified kiosk code.

## User impact

Kiosk users can keep scanning even if backend connectivity drops briefly. Scan outcomes remain visible, and queued scans synchronize automatically after reconnect.

## Operator impact

Operators get immediate visibility into queue health and can verify when sync has completed. No manual migration or config work is required.

## Upgrade or migration notes

No upgrade action required.

## Risk and rollback notes

- Main risk: queued replay depends on browser local storage and connectivity error detection.
- Verification: simulate offline mode, perform scans, restore connectivity, and confirm replay.
- Rollback: safe via standard PR revert; no database migration involved.
- Compatibility: no breaking API or schema changes.

## Testing performed

- `pnpm --filter frontend-admin type-check`

## Changelog candidates

- Added kiosk offline scan queueing so member scans continue during temporary backend outages.
- Added automatic reconnect replay of queued kiosk scans.
- Added kiosk sync-state visibility (`queued/syncing/synced/error`) for operators.
- Updated TODO workflow to require user verification before tasks are treated as fully complete.
