### PR TITLE
feat(visitors): add kiosk visitor group sign-out flow

### DIFF
--- a/TO-DO.md
+++ b/TO-DO.md
@@ -128,7 +128,7 @@
   - Validation and user messaging cover common mistakes.
   - Tests cover core happy path and key validation failures.
 - Out of scope:
-  - Group sign-out behavior (handled in TODO-VISITOR-002).
+  - Group sign-out behavior.
   - Major non-visitor kiosk flow changes.
 - Commit slices:
   - `feat: extend visitor model for group members and vehicles`
@@ -136,34 +136,6 @@
   - `test: cover group sign-in happy/error paths`
 - Codex prompt:
   - `Please implement TODO-VISITOR-001 from TO-DO.md on branch feature/visitor-group-signin, with schema/contract updates and kiosk flow tests.`
-
-### TODO-VISITOR-002: Visitor group sign-out
-
-- Status: `todo`
-- User verified: [ ]
-- Branch: `feature/visitor-group-signout`
-- Depends on: `TODO-VISITOR-001`
-- PR goal: allow full-group and partial-member sign-out from kiosk.
-- Target paths:
-  - `apps/frontend-admin/src/components/kiosk/**visitor*`
-  - `apps/backend/src/routes/**visitor*`
-  - `apps/backend/src/services/**visitor*`
-  - `packages/contracts/**`
-- Done when:
-  - Kiosk shows active visitors/groups eligible for sign-out.
-  - Operators/visitors can sign out an entire group in one action.
-  - Operators/visitors can sign out selected members from a group.
-  - Presence/check-out records stay accurate after partial sign-outs.
-  - Tests cover full-group and partial-member sign-out paths.
-- Out of scope:
-  - Sign-in data model redesign beyond what sign-out requires.
-  - Non-kiosk admin tooling expansion for visitor management.
-- Commit slices:
-  - `feat: add active visitor/group list on kiosk`
-  - `feat: support partial group sign-out actions`
-  - `test: cover full and partial sign-out flows`
-- Codex prompt:
-  - `Please implement TODO-VISITOR-002 from TO-DO.md on branch feature/visitor-group-signout, including full-group and partial-member sign-out behavior and tests.`
 
 ## Suggested PR Sequence
 

--- a/apps/backend/src/repositories/visitor-repository.ts
+++ b/apps/backend/src/repositories/visitor-repository.ts
@@ -6,6 +6,8 @@ import type {
   UpdateVisitorInput,
   CreateVisitorGroupInput,
   CreateVisitorGroupResult,
+  CheckoutVisitorGroupInput,
+  CheckoutVisitorGroupResult,
 } from '@sentinel/types'
 import {
   buildLegacyVisitorName,
@@ -385,6 +387,90 @@ export class VisitorRepository {
     })
 
     return result
+  }
+
+  async checkoutGroup(data: CheckoutVisitorGroupInput): Promise<CheckoutVisitorGroupResult> {
+    return this.prisma.$transaction(async (tx) => {
+      const group = await tx.visitorGroup.findUnique({
+        where: { id: data.groupId },
+        select: { id: true },
+      })
+
+      if (!group) {
+        throw new Error('Visitor group not found')
+      }
+
+      const groupMembers = await tx.visitor.findMany({
+        where: { visitorGroupId: data.groupId },
+        select: {
+          id: true,
+          checkOutTime: true,
+        },
+      })
+
+      if (groupMembers.length === 0) {
+        throw new Error('Visitor group not found')
+      }
+
+      const groupMemberIds = new Set(groupMembers.map((member) => member.id))
+      const selectedMemberIds = data.memberIds?.length ? data.memberIds : undefined
+
+      if (selectedMemberIds) {
+        const invalidMemberIds = selectedMemberIds.filter(
+          (memberId) => !groupMemberIds.has(memberId)
+        )
+        if (invalidMemberIds.length > 0) {
+          throw new Error('Selected visitors are not members of this group')
+        }
+      }
+
+      const activeMemberIds = groupMembers
+        .filter((member) => member.checkOutTime === null)
+        .map((member) => member.id)
+      const activeMemberSet = new Set(activeMemberIds)
+      const membersToCheckout = selectedMemberIds
+        ? selectedMemberIds.filter((memberId) => activeMemberSet.has(memberId))
+        : activeMemberIds
+
+      if (selectedMemberIds && membersToCheckout.length === 0) {
+        throw new Error('No selected active group members found')
+      }
+
+      const checkedOutAt = new Date()
+      if (membersToCheckout.length > 0) {
+        await tx.visitor.updateMany({
+          where: {
+            id: { in: membersToCheckout },
+            checkOutTime: null,
+          },
+          data: {
+            checkOutTime: checkedOutAt,
+          },
+        })
+      }
+
+      const checkedOutVisitors =
+        membersToCheckout.length > 0
+          ? await tx.visitor.findMany({
+              where: {
+                id: { in: membersToCheckout },
+              },
+              include: {
+                event: true,
+                hostMember: true,
+                badge: true,
+              },
+            })
+          : []
+
+      return {
+        groupId: data.groupId,
+        visitors: checkedOutVisitors.map((visitor) => this.toVisitorType(visitor)),
+        checkedOutCount: membersToCheckout.length,
+        activeGroupMemberCount: activeMemberIds.length,
+        alreadyCheckedOutCount: groupMembers.length - activeMemberIds.length,
+      }
+    })
   }
 
   /**

--- a/apps/backend/src/routes/visitor-self-service-schema.test.ts
+++ b/apps/backend/src/routes/visitor-self-service-schema.test.ts
@@ -1,4 +1,8 @@
-import { CreateVisitorGroupSchema, CreateVisitorSchema } from '@sentinel/contracts'
+import {
+  CheckoutVisitorGroupSchema,
+  CreateVisitorGroupSchema,
+  CreateVisitorSchema,
+} from '@sentinel/contracts'
 import { describe, expect, it } from 'vitest'
 import * as v from 'valibot'
 
@@ -103,5 +107,19 @@ describe('CreateVisitorGroupSchema validation', () => {
     })
 
     expect(parsed.success).toBe(false)
+  })
+})
+
+describe('CheckoutVisitorGroupSchema validation', () => {
+  it('accepts an empty payload for full-group sign-out', () => {
+    const parsed = v.safeParse(CheckoutVisitorGroupSchema, {})
+    expect(parsed.success).toBe(true)
+  })
+
+  it('accepts a selected member list for partial-group sign-out', () => {
+    const parsed = v.safeParse(CheckoutVisitorGroupSchema, {
+      memberIds: ['11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222'],
+    })
+    expect(parsed.success).toBe(true)
   })
 })

--- a/apps/backend/src/routes/visitors.ts
+++ b/apps/backend/src/routes/visitors.ts
@@ -4,8 +4,10 @@ import type {
   VisitorListQuery,
   CreateVisitorInput,
   CreateVisitorGroupInput,
+  CheckoutVisitorGroupInput,
   UpdateVisitorInput,
   IdParam,
+  VisitorGroupIdParam,
   VisitType,
   VisitorCheckInMethod,
 } from '@sentinel/contracts'
@@ -280,6 +282,83 @@ export const visitorsRouter = s.router(visitorContract, {
         body: {
           error: 'INTERNAL_ERROR',
           message: error instanceof Error ? error.message : 'Failed to create visitor group',
+        },
+      }
+    }
+  },
+
+  checkoutVisitorGroup: async ({
+    params,
+    body,
+  }: {
+    params: VisitorGroupIdParam
+    body: CheckoutVisitorGroupInput
+  }) => {
+    try {
+      const checkoutResult = await visitorRepo.checkoutGroup({
+        groupId: params.groupId,
+        memberIds: body.memberIds,
+      })
+
+      for (const visitor of checkoutResult.visitors) {
+        if (!visitor.checkOutTime) continue
+        broadcastVisitorSignout({
+          id: visitor.id,
+          name: visitor.displayName ?? visitor.name,
+          checkOutTime: visitor.checkOutTime.toISOString(),
+        })
+      }
+
+      const checkedOutCount = checkoutResult.checkedOutCount
+      const memberScopedRequest = Boolean(body.memberIds && body.memberIds.length > 0)
+      const message =
+        checkedOutCount === 0
+          ? 'No active visitors were signed out'
+          : memberScopedRequest
+            ? `Signed out ${checkedOutCount} selected visitor${checkedOutCount === 1 ? '' : 's'}`
+            : `Signed out ${checkedOutCount} visitor${checkedOutCount === 1 ? '' : 's'} from group`
+
+      return {
+        status: 200 as const,
+        body: {
+          success: true,
+          message,
+          groupId: checkoutResult.groupId,
+          checkedOutCount: checkoutResult.checkedOutCount,
+          activeGroupMemberCount: checkoutResult.activeGroupMemberCount,
+          alreadyCheckedOutCount: checkoutResult.alreadyCheckedOutCount,
+          visitors: checkoutResult.visitors.map(toVisitorResponse),
+        },
+      }
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('not found')) {
+        return {
+          status: 404 as const,
+          body: {
+            error: 'NOT_FOUND',
+            message: `Visitor group with ID '${params.groupId}' not found`,
+          },
+        }
+      }
+
+      if (
+        error instanceof Error &&
+        (error.message.includes('selected') || error.message.includes('members'))
+      ) {
+        return {
+          status: 400 as const,
+          body: {
+            error: 'VALIDATION_ERROR',
+            message: error.message,
+          },
+        }
+      }
+
+      return {
+        status: 500 as const,
+        body: {
+          error: 'INTERNAL_ERROR',
+          message: error instanceof Error ? error.message : 'Failed to checkout visitor group',
         },
       }
     }

--- a/apps/frontend-admin/src/components/kiosk/kiosk-member-scan-panel.tsx
+++ b/apps/frontend-admin/src/components/kiosk/kiosk-member-scan-panel.tsx
@@ -42,6 +42,7 @@ interface KioskMemberScanPanelProps {
   resultPill: ResultPill | null
   visitorScanPromptVisible: boolean
   visitorFlowActive: boolean
+  visitorFlowMode: 'signin' | 'signout'
   scanningDisabled: boolean
   syncState: KioskSyncState
   serial: string
@@ -70,6 +71,7 @@ export function KioskMemberScanPanel({
   resultPill,
   visitorScanPromptVisible,
   visitorFlowActive,
+  visitorFlowMode,
   scanningDisabled,
   syncState,
   serial,
@@ -238,7 +240,7 @@ export function KioskMemberScanPanel({
                         Current mode
                       </p>
                       <p className="mt-(--space-2) text-xl font-semibold leading-tight">
-                        Visitor sign-in in progress
+                        Visitor {visitorFlowMode === 'signin' ? 'sign-in' : 'sign-out'} in progress
                       </p>
                       <p className="mt-(--space-2) text-sm leading-relaxed text-base-content/70">
                         Keep the visitor on the right-hand panel until the flow completes.
@@ -289,7 +291,8 @@ export function KioskMemberScanPanel({
                 Member scanning
               </p>
               <p className="mt-(--space-2) text-lg font-semibold leading-tight">
-                Paused while visitor check-in is active
+                Paused while visitor {visitorFlowMode === 'signin' ? 'sign-in' : 'sign-out'} is
+                active
               </p>
               <p className="mt-(--space-1) text-sm leading-relaxed text-base-content/70">
                 The scanner lane and manual fallback will return as soon as the visitor flow closes.

--- a/apps/frontend-admin/src/components/kiosk/kiosk-visitor-rail.tsx
+++ b/apps/frontend-admin/src/components/kiosk/kiosk-visitor-rail.tsx
@@ -1,29 +1,36 @@
 'use client'
 
 import { AnimatePresence, motion } from 'motion/react'
-import { ChevronRight, UserRoundPlus } from 'lucide-react'
+import { ChevronRight, UserRoundMinus, UserRoundPlus } from 'lucide-react'
 import { AppCard, AppCardContent, AppCardHeader, AppCardTitle } from '@/components/ui/AppCard'
 import { Chip } from '@/components/ui/chip'
 import {
   VisitorSelfSigninFlow,
   type VisitorSelfSigninCompletion,
 } from '@/components/kiosk/visitor-self-signin-flow'
+import { VisitorSelfSignoutFlow } from '@/components/kiosk/visitor-self-signout-flow'
 import { KIOSK_ID, MOTION_TIMING } from './kiosk-domain'
+
+export type VisitorRailMode = 'signin' | 'signout'
 
 interface KioskVisitorRailProps {
   active: boolean
+  mode: VisitorRailMode
   fatalOperationalOutage: boolean
   shouldReduceMotion: boolean
-  onStart: () => void
+  onStart: (mode: VisitorRailMode) => void
+  onModeChange: (mode: VisitorRailMode) => void
   onCancel: () => void
   onComplete: (completion: VisitorSelfSigninCompletion) => void
 }
 
 export function KioskVisitorRail({
   active,
+  mode,
   fatalOperationalOutage,
   shouldReduceMotion,
   onStart,
+  onModeChange,
   onCancel,
   onComplete,
 }: KioskVisitorRailProps) {
@@ -58,8 +65,27 @@ export function KioskVisitorRail({
                     size="sm"
                     className="uppercase tracking-[0.16em]"
                   >
-                    Visitor Sign-In
+                    Visitor {mode === 'signin' ? 'Sign-In' : 'Sign-Out'}
                   </Chip>
+                </div>
+
+                <div className="join join-horizontal">
+                  <button
+                    type="button"
+                    className={`btn btn-sm join-item ${mode === 'signin' ? 'btn-secondary' : 'btn-outline'}`}
+                    onClick={() => onModeChange('signin')}
+                    disabled={fatalOperationalOutage}
+                  >
+                    Sign in
+                  </button>
+                  <button
+                    type="button"
+                    className={`btn btn-sm join-item ${mode === 'signout' ? 'btn-secondary' : 'btn-outline'}`}
+                    onClick={() => onModeChange('signout')}
+                    disabled={fatalOperationalOutage}
+                  >
+                    Sign out
+                  </button>
                 </div>
               </AppCardHeader>
 
@@ -67,12 +93,20 @@ export function KioskVisitorRail({
                 className="min-h-0 flex-1 overflow-y-auto"
                 style={{ padding: 'var(--space-5)' }}
               >
-                <VisitorSelfSigninFlow
-                  kioskId={KIOSK_ID}
-                  layout="inline"
-                  onCancel={onCancel}
-                  onComplete={onComplete}
-                />
+                {mode === 'signin' ? (
+                  <VisitorSelfSigninFlow
+                    kioskId={KIOSK_ID}
+                    layout="inline"
+                    onCancel={onCancel}
+                    onComplete={onComplete}
+                  />
+                ) : (
+                  <VisitorSelfSignoutFlow
+                    layout="inline"
+                    onCancel={onCancel}
+                    onComplete={onComplete}
+                  />
+                )}
               </AppCardContent>
             </AppCard>
           </motion.div>
@@ -97,7 +131,7 @@ export function KioskVisitorRail({
                     size="sm"
                     className="uppercase tracking-[0.16em]"
                   >
-                    Visitor Sign-In
+                    Visitor Services
                   </Chip>
                 </div>
 
@@ -107,24 +141,34 @@ export function KioskVisitorRail({
                   </div>
                   <div>
                     <AppCardTitle className="font-display text-3xl leading-tight text-base-content">
-                      Visitor Sign-In
+                      Visitor Services
                     </AppCardTitle>
                   </div>
                 </div>
               </AppCardHeader>
 
               <AppCardContent
-                className="mt-auto flex"
+                className="mt-auto grid gap-(--space-3)"
                 style={{ padding: '0 var(--space-5) var(--space-5)' }}
               >
                 <button
                   type="button"
                   className="btn btn-secondary btn-lg gap-(--space-4) px-(--space-5) py-(--space-4) text-xl"
-                  onClick={onStart}
+                  onClick={() => onStart('signin')}
                   disabled={fatalOperationalOutage}
                 >
                   <span className="text-left text-xl font-semibold">Start</span>
+                  <span className="text-base font-medium opacity-85">Sign in</span>
                   <ChevronRight className="h-6 w-6" />
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-outline btn-lg gap-(--space-3) px-(--space-5) py-(--space-4) text-lg"
+                  onClick={() => onStart('signout')}
+                  disabled={fatalOperationalOutage}
+                >
+                  <UserRoundMinus className="h-5 w-5" />
+                  Sign out visitors
                 </button>
               </AppCardContent>
             </AppCard>

--- a/apps/frontend-admin/src/components/kiosk/use-kiosk-screen.ts
+++ b/apps/frontend-admin/src/components/kiosk/use-kiosk-screen.ts
@@ -65,6 +65,7 @@ export function useKioskScreen() {
   const [responsibilityDismissed, setResponsibilityDismissed] = useState(false)
   const [responsibilityError, setResponsibilityError] = useState<string | null>(null)
   const [visitorFlowActive, setVisitorFlowActive] = useState(false)
+  const [visitorFlowMode, setVisitorFlowMode] = useState<'signin' | 'signout'>('signin')
   const [visitorCompletion, setVisitorCompletion] = useState<VisitorCompletionState | null>(null)
   const [assignmentSummary, setAssignmentSummary] = useState<AssignmentSummary | null>(null)
   const [assignmentSummaryMemberId, setAssignmentSummaryMemberId] = useState<string | null>(null)
@@ -562,14 +563,18 @@ export function useKioskScreen() {
   const resultMessage = visitorCompletion
     ? visitorCompletion.message
     : visitorFlowActive
-      ? 'Visitor check-in is active on the right. Member scanning resumes when that flow is closed or finished.'
+      ? visitorFlowMode === 'signin'
+        ? 'Visitor sign-in is active on the right. Member scanning resumes when that flow is closed or finished.'
+        : 'Visitor sign-out is active on the right. Member scanning resumes when that flow is closed or finished.'
       : fatalOperationalOutage
         ? 'Live kiosk services are offline. Refresh the kiosk or use the hidden maintenance controls.'
         : result.message
   const resultEyebrow = visitorCompletion
     ? 'Visitor Complete'
     : visitorFlowActive
-      ? 'Visitor Sign-In'
+      ? visitorFlowMode === 'signin'
+        ? 'Visitor Sign-In'
+        : 'Visitor Sign-Out'
       : fatalOperationalOutage
         ? 'Service Outage'
         : result.eyebrow
@@ -773,7 +778,8 @@ export function useKioskScreen() {
     }
   }
 
-  const handleVisitorFlowStart = () => {
+  const handleVisitorFlowStart = (mode: 'signin' | 'signout' = 'signin') => {
+    setVisitorFlowMode(mode)
     setVisitorCompletion(null)
     setVisitorFlowActive(true)
   }
@@ -795,6 +801,7 @@ export function useKioskScreen() {
     prefersReducedMotion,
     fatalOperationalOutage,
     visitorFlowActive,
+    visitorFlowMode,
     header: {
       fatalOperationalOutage,
       connectivityBadge,
@@ -823,12 +830,13 @@ export function useKioskScreen() {
       resultPill,
       visitorScanPromptVisible,
       visitorFlowActive,
+      visitorFlowMode,
       scanningDisabled,
       syncState,
       serial,
       onSerialChange: setSerial,
       onSubmitScan: submitCurrentSerial,
-      onStartVisitorFlow: handleVisitorFlowStart,
+      onStartVisitorFlow: () => handleVisitorFlowStart('signin'),
       onRefreshOperationalData: () => void refreshOperationalData(),
       onRefocusBadgeInput: refocusBadgeInput,
       registerBadgeInputRef: (node: HTMLInputElement | null) => {
@@ -837,8 +845,10 @@ export function useKioskScreen() {
     },
     visitorRail: {
       active: visitorFlowActive,
+      mode: visitorFlowMode,
       fatalOperationalOutage,
       onStart: handleVisitorFlowStart,
+      onModeChange: setVisitorFlowMode,
       onCancel: handleVisitorFlowCancel,
       onComplete: handleVisitorFlowComplete,
     },

--- a/apps/frontend-admin/src/components/kiosk/visitor-self-signin-flow.tsx
+++ b/apps/frontend-admin/src/components/kiosk/visitor-self-signin-flow.tsx
@@ -174,6 +174,12 @@ export function VisitorSelfSigninFlow({
   const usesContractInputs = reason ? reasonUsesContractInputs(reason) : false
   const followsMilitaryPath = reason !== '' && reason !== 'recruitment' && branch === 'military'
   const followsCivilianPath = reason === 'recruitment' || branch === 'civilian'
+  const hasPendingMemberInput = followsMilitaryPath
+    ? Boolean(rankPrefix.trim() || lastName.trim() || initials.trim() || unit.trim())
+    : followsCivilianPath
+      ? Boolean(firstName.trim() || lastName.trim())
+      : false
+  const requiresCurrentMemberFields = groupMembers.length === 0 || hasPendingMemberInput
   const hasSelectionStep = requiresMemberSelection || requiresEventSelection
   const selectionStep: FlowStep | null = hasSelectionStep ? 2 : null
   const routingStep: FlowStep | null = requiresBranch ? (hasSelectionStep ? 3 : 2) : null
@@ -679,10 +685,6 @@ export function VisitorSelfSigninFlow({
     }
 
     if (step === personalInfoStep) {
-      const hasPendingMemberInput = followsMilitaryPath
-        ? Boolean(rankPrefix.trim() || lastName.trim() || initials.trim() || unit.trim())
-        : Boolean(firstName.trim() || lastName.trim())
-
       if (!hasPendingMemberInput && groupMembers.length > 0) {
         setStep((contractInfoStep ?? reviewStep) as FlowStep)
         return
@@ -1071,23 +1073,38 @@ export function VisitorSelfSigninFlow({
 
   const rankPrefixRegistration = register('rankPrefix', {
     validate: (value) =>
-      !followsMilitaryPath || Boolean(value.trim()) || 'Rank is required for military visitors',
+      !followsMilitaryPath ||
+      !requiresCurrentMemberFields ||
+      Boolean(value.trim()) ||
+      'Rank is required for military visitors',
   })
   const initialsRegistration = register('initials', {
     validate: (value) =>
       !followsMilitaryPath ||
+      !requiresCurrentMemberFields ||
       Boolean(value.trim()) ||
       'Initials are required for military visitors',
   })
   const firstNameRegistration = register('firstName', {
-    validate: (value) => !followsCivilianPath || Boolean(value.trim()) || 'First name is required',
+    validate: (value) =>
+      !followsCivilianPath ||
+      !requiresCurrentMemberFields ||
+      Boolean(value.trim()) ||
+      'First name is required',
   })
   const lastNameRegistration = register('lastName', {
-    validate: (value) => Boolean(value.trim()) || 'Last name is required',
+    validate: (value) =>
+      !requiresCurrentMemberFields ||
+      !(followsMilitaryPath || followsCivilianPath) ||
+      Boolean(value.trim()) ||
+      'Last name is required',
   })
   const unitRegistration = register('unit', {
     validate: (value) =>
-      !followsMilitaryPath || Boolean(value.trim()) || 'Unit is required for military visitors',
+      !followsMilitaryPath ||
+      !requiresCurrentMemberFields ||
+      Boolean(value.trim()) ||
+      'Unit is required for military visitors',
   })
 
   const organizationRegistration = register('organization', {

--- a/apps/frontend-admin/src/components/kiosk/visitor-self-signout-flow.tsx
+++ b/apps/frontend-admin/src/components/kiosk/visitor-self-signout-flow.tsx
@@ -1,0 +1,332 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { Users, UserRoundMinus } from 'lucide-react'
+import {
+  useActiveVisitors,
+  useCheckoutVisitor,
+  useCheckoutVisitorGroup,
+} from '@/hooks/use-visitors'
+import type { VisitorResponse } from '@sentinel/contracts'
+import type { VisitorSelfSigninCompletion } from '@/components/kiosk/visitor-self-signin-flow'
+
+interface VisitorSelfSignoutFlowProps {
+  layout?: 'modal' | 'inline'
+  onCancel: () => void
+  onComplete?: (completion: VisitorSelfSigninCompletion) => void
+}
+
+interface VisitorGroupSummary {
+  groupId: string
+  members: VisitorResponse[]
+}
+
+function formatTime(value: string): string {
+  return new Date(value).toLocaleString('en-CA', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  })
+}
+
+function displayName(visitor: VisitorResponse): string {
+  return visitor.displayName || visitor.name
+}
+
+export function VisitorSelfSignoutFlow({
+  layout = 'inline',
+  onCancel,
+  onComplete,
+}: VisitorSelfSignoutFlowProps) {
+  const { data, isLoading, isError, refetch } = useActiveVisitors()
+  const checkoutVisitor = useCheckoutVisitor()
+  const checkoutVisitorGroup = useCheckoutVisitorGroup()
+  const [search, setSearch] = useState('')
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [busyKey, setBusyKey] = useState<string | null>(null)
+  const [selectedByGroup, setSelectedByGroup] = useState<Record<string, string[]>>({})
+
+  const activeVisitors = data?.visitors ?? []
+  const normalizedSearch = search.trim().toLowerCase()
+
+  const grouped = useMemo(() => {
+    const groupMap = new Map<string, VisitorResponse[]>()
+    const soloVisitors: VisitorResponse[] = []
+
+    for (const visitor of activeVisitors) {
+      if (!visitor.visitorGroupId) {
+        soloVisitors.push(visitor)
+        continue
+      }
+
+      const existing = groupMap.get(visitor.visitorGroupId)
+      if (existing) {
+        existing.push(visitor)
+      } else {
+        groupMap.set(visitor.visitorGroupId, [visitor])
+      }
+    }
+
+    const groups: VisitorGroupSummary[] = Array.from(groupMap.entries())
+      .map(([groupId, members]) => ({
+        groupId,
+        members: [...members].sort((a, b) => a.checkInTime.localeCompare(b.checkInTime)),
+      }))
+      .sort((a, b) => b.members[0]!.checkInTime.localeCompare(a.members[0]!.checkInTime))
+
+    const ungroupedVisitors = [...soloVisitors].sort((a, b) =>
+      b.checkInTime.localeCompare(a.checkInTime)
+    )
+
+    return { groups, ungroupedVisitors }
+  }, [activeVisitors])
+
+  const filtered = useMemo(() => {
+    if (!normalizedSearch) {
+      return grouped
+    }
+
+    const searchMatch = (visitor: VisitorResponse): boolean => {
+      const haystack =
+        `${displayName(visitor)} ${visitor.organization ?? ''} ${visitor.visitType} ${visitor.visitReason ?? ''}`.toLowerCase()
+      return haystack.includes(normalizedSearch)
+    }
+
+    return {
+      groups: grouped.groups.filter((group) => group.members.some(searchMatch)),
+      ungroupedVisitors: grouped.ungroupedVisitors.filter(searchMatch),
+    }
+  }, [grouped, normalizedSearch])
+
+  const isInline = layout === 'inline'
+  const canInteract = !checkoutVisitor.isPending && !checkoutVisitorGroup.isPending
+
+  const complete = (title: string, message: string) => {
+    onComplete?.({
+      title,
+      message,
+      actionLabel: 'Done',
+    })
+  }
+
+  const handleGroupSelectionToggle = (groupId: string, memberId: string) => {
+    setSelectedByGroup((previous) => {
+      const current = new Set(previous[groupId] ?? [])
+      if (current.has(memberId)) {
+        current.delete(memberId)
+      } else {
+        current.add(memberId)
+      }
+
+      return {
+        ...previous,
+        [groupId]: Array.from(current),
+      }
+    })
+  }
+
+  const handleSignoutVisitor = async (visitor: VisitorResponse) => {
+    setSubmitError(null)
+    setBusyKey(`visitor:${visitor.id}`)
+    try {
+      await checkoutVisitor.mutateAsync(visitor.id)
+      complete('Visitor signed out', `${displayName(visitor)} has been checked out.`)
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error.message : 'Failed to sign out visitor')
+    } finally {
+      setBusyKey(null)
+    }
+  }
+
+  const handleSignoutGroup = async (group: VisitorGroupSummary, memberIds?: string[]) => {
+    setSubmitError(null)
+    const memberScoped = Boolean(memberIds && memberIds.length > 0)
+    setBusyKey(memberScoped ? `group-selected:${group.groupId}` : `group-all:${group.groupId}`)
+    try {
+      const response = await checkoutVisitorGroup.mutateAsync({
+        groupId: group.groupId,
+        memberIds,
+      })
+      if (memberScoped) {
+        setSelectedByGroup((previous) => ({ ...previous, [group.groupId]: [] }))
+      }
+      complete('Visitor group signed out', response.message)
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error.message : 'Failed to sign out visitor group')
+    } finally {
+      setBusyKey(null)
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center rounded-box border border-base-300 bg-base-200/50 p-(--space-5)">
+        <span className="loading loading-spinner loading-md" />
+        <span className="ml-(--space-3) text-sm">Loading active visitors…</span>
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <div className="space-y-(--space-4)">
+        <div className="alert alert-error">
+          <span>Unable to load active visitors for sign-out.</span>
+        </div>
+        <div className="flex gap-(--space-2)">
+          <button type="button" className="btn btn-outline" onClick={() => void refetch()}>
+            Retry
+          </button>
+          <button type="button" className="btn btn-ghost" onClick={onCancel}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  const activeCount =
+    filtered.groups.reduce((sum, group) => sum + group.members.length, 0) +
+    filtered.ungroupedVisitors.length
+
+  return (
+    <div className={`flex min-h-0 flex-col gap-(--space-4) ${isInline ? 'h-full' : ''}`}>
+      <div className="rounded-box border border-base-300 bg-base-200/50 p-(--space-4)">
+        <div className="flex flex-wrap items-center justify-between gap-(--space-3)">
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-base-content/50">
+              Visitor sign-out
+            </p>
+            <p className="mt-(--space-1) text-lg font-semibold leading-tight">
+              {activeCount} active visitor{activeCount === 1 ? '' : 's'}
+            </p>
+          </div>
+          <label className="input input-bordered input-sm w-full sm:w-72">
+            <span className="label">Search</span>
+            <input
+              type="text"
+              className="grow"
+              placeholder="Name, company, reason"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              disabled={!canInteract}
+            />
+          </label>
+        </div>
+      </div>
+
+      {submitError && <div className="alert alert-error">{submitError}</div>}
+
+      {activeCount === 0 ? (
+        <div className="rounded-box border border-base-300 bg-base-100 p-(--space-6) text-center">
+          <Users className="mx-auto h-8 w-8 text-base-content/50" />
+          <p className="mt-(--space-3) text-lg font-semibold">No active visitors</p>
+          <p className="mt-(--space-1) text-sm text-base-content/70">
+            There are no active visitor records available for sign-out.
+          </p>
+        </div>
+      ) : (
+        <div className="min-h-0 flex-1 space-y-(--space-3) overflow-y-auto pr-(--space-1)">
+          {filtered.groups.map((group) => {
+            const selectedIds = selectedByGroup[group.groupId] ?? []
+            const selectedCount = selectedIds.length
+            return (
+              <div
+                key={group.groupId}
+                className="rounded-box border border-base-300 bg-base-100 p-(--space-4)"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-(--space-3)">
+                  <div>
+                    <p className="text-xs uppercase tracking-[0.18em] text-base-content/50">
+                      Group
+                    </p>
+                    <p className="text-lg font-semibold">
+                      {group.members.length} member{group.members.length === 1 ? '' : 's'}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap gap-(--space-2)">
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-outline"
+                      disabled={!canInteract || selectedCount === 0}
+                      onClick={() => void handleSignoutGroup(group, selectedIds)}
+                    >
+                      Sign out selected ({selectedCount})
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-error"
+                      disabled={!canInteract}
+                      onClick={() => void handleSignoutGroup(group)}
+                    >
+                      Sign out full group
+                    </button>
+                  </div>
+                </div>
+
+                <div className="mt-(--space-3) grid gap-(--space-2)">
+                  {group.members.map((visitor) => {
+                    const inputId = `group-${group.groupId}-${visitor.id}`
+                    return (
+                      <label
+                        key={visitor.id}
+                        htmlFor={inputId}
+                        className="flex items-start gap-(--space-3) rounded-box border border-base-300 bg-base-200/40 p-(--space-3)"
+                      >
+                        <input
+                          id={inputId}
+                          type="checkbox"
+                          className="checkbox checkbox-sm mt-1"
+                          checked={selectedIds.includes(visitor.id)}
+                          onChange={() => handleGroupSelectionToggle(group.groupId, visitor.id)}
+                          disabled={!canInteract}
+                        />
+                        <div className="min-w-0">
+                          <p className="font-semibold leading-tight">{displayName(visitor)}</p>
+                          <p className="text-sm text-base-content/70">
+                            Checked in {formatTime(visitor.checkInTime)}
+                            {visitor.organization ? ` • ${visitor.organization}` : ''}
+                          </p>
+                        </div>
+                      </label>
+                    )
+                  })}
+                </div>
+              </div>
+            )
+          })}
+
+          {filtered.ungroupedVisitors.map((visitor) => (
+            <div
+              key={visitor.id}
+              className="flex flex-wrap items-center justify-between gap-(--space-3) rounded-box border border-base-300 bg-base-100 p-(--space-4)"
+            >
+              <div className="min-w-0">
+                <p className="font-semibold">{displayName(visitor)}</p>
+                <p className="text-sm text-base-content/70">
+                  Checked in {formatTime(visitor.checkInTime)}
+                  {visitor.organization ? ` • ${visitor.organization}` : ''}
+                </p>
+              </div>
+              <button
+                type="button"
+                className="btn btn-sm btn-error"
+                disabled={!canInteract}
+                onClick={() => void handleSignoutVisitor(visitor)}
+              >
+                <UserRoundMinus className="h-4 w-4" />
+                Sign out
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-auto flex flex-wrap justify-end gap-(--space-2) border-t border-base-300 pt-(--space-3)">
+        {busyKey ? <span className="loading loading-spinner loading-sm mr-auto" /> : null}
+        <button type="button" className="btn btn-ghost" onClick={onCancel} disabled={!canInteract}>
+          Close
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend-admin/src/hooks/use-visitors.ts
+++ b/apps/frontend-admin/src/hooks/use-visitors.ts
@@ -89,6 +89,29 @@ export function useCheckoutVisitor() {
   })
 }
 
+export function useCheckoutVisitorGroup() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ groupId, memberIds }: { groupId: string; memberIds?: string[] }) => {
+      const response = await apiClient.visitors.checkoutVisitorGroup({
+        params: { groupId },
+        body: memberIds && memberIds.length > 0 ? { memberIds } : {},
+      })
+      if (response.status !== 200) {
+        const body = response.body as { message?: string }
+        throw new Error(body?.message ?? 'Failed to sign out visitor group')
+      }
+      return response.body
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['active-visitors'] })
+      queryClient.invalidateQueries({ queryKey: ['present-people'] })
+      void invalidateDashboardQueries(queryClient)
+    },
+  })
+}
+
 export function useVisitorById(id: string | null) {
   return useQuery({
     queryKey: ['visitor', id],

--- a/packages/contracts/src/contracts/visitor.contract.ts
+++ b/packages/contracts/src/contracts/visitor.contract.ts
@@ -3,6 +3,9 @@ import {
   CreateVisitorSchema,
   CreateVisitorGroupSchema,
   CreateVisitorGroupResponseSchema,
+  CheckoutVisitorGroupSchema,
+  CheckoutVisitorGroupResponseSchema,
+  VisitorGroupIdParamSchema,
   UpdateVisitorSchema,
   VisitorResponseSchema,
   VisitorListQuerySchema,
@@ -87,6 +90,26 @@ export const visitorContract = c.router({
     summary: 'Create visitor group',
     description:
       'Atomically create a visitor group with one or more members and optional group-level vehicles',
+  },
+
+  /**
+   * Checkout one or more members of a visitor group
+   */
+  checkoutVisitorGroup: {
+    method: 'POST',
+    path: '/api/visitors/groups/:groupId/checkout',
+    pathParams: VisitorGroupIdParamSchema,
+    body: CheckoutVisitorGroupSchema,
+    responses: {
+      200: CheckoutVisitorGroupResponseSchema,
+      400: ErrorResponseSchema,
+      401: ErrorResponseSchema,
+      404: ErrorResponseSchema,
+      500: ErrorResponseSchema,
+    },
+    summary: 'Checkout visitor group members',
+    description:
+      'Sign out an entire visitor group or selected active members from that visitor group',
   },
 
   /**

--- a/packages/contracts/src/schemas/visitor.schema.ts
+++ b/packages/contracts/src/schemas/visitor.schema.ts
@@ -320,6 +320,20 @@ export const CreateVisitorGroupResponseSchema = v.object({
   vehicles: v.array(VisitorGroupVehicleResponseSchema),
 })
 
+export const VisitorGroupIdParamSchema = v.object({
+  groupId: v.pipe(v.string(), v.uuid('Invalid visitor group ID')),
+})
+
+export const CheckoutVisitorGroupSchema = v.pipe(
+  v.object({
+    memberIds: v.optional(v.array(v.pipe(v.string(), v.uuid('Invalid visitor ID')))),
+  }),
+  v.check((data) => {
+    if (!data.memberIds || data.memberIds.length === 0) return true
+    return new Set(data.memberIds).size === data.memberIds.length
+  }, 'Duplicate visitor IDs are not allowed in memberIds')
+)
+
 /**
  * Visitor list query schema
  */
@@ -362,10 +376,21 @@ export const CheckoutResponseSchema = v.object({
   visitor: VisitorResponseSchema,
 })
 
+export const CheckoutVisitorGroupResponseSchema = v.object({
+  success: v.boolean(),
+  message: v.string(),
+  groupId: v.string(),
+  checkedOutCount: v.number(),
+  activeGroupMemberCount: v.number(),
+  alreadyCheckedOutCount: v.number(),
+  visitors: v.array(VisitorResponseSchema),
+})
+
 // Type exports
 export type CreateVisitorInput = v.InferOutput<typeof CreateVisitorSchema>
 export type CreateVisitorGroupInput = v.InferOutput<typeof CreateVisitorGroupSchema>
 export type CreateVisitorGroupMemberInput = v.InferOutput<typeof CreateVisitorGroupMemberSchema>
+export type CheckoutVisitorGroupInput = v.InferOutput<typeof CheckoutVisitorGroupSchema>
 export type UpdateVisitorInput = v.InferOutput<typeof UpdateVisitorSchema>
 export type VisitorResponse = v.InferOutput<typeof VisitorResponseSchema>
 export type VisitorGroupVehicleResponse = v.InferOutput<typeof VisitorGroupVehicleResponseSchema>
@@ -374,3 +399,5 @@ export type VisitorListQuery = v.InferOutput<typeof VisitorListQuerySchema>
 export type VisitorListResponse = v.InferOutput<typeof VisitorListResponseSchema>
 export type ActiveVisitorsResponse = v.InferOutput<typeof ActiveVisitorsResponseSchema>
 export type CheckoutResponse = v.InferOutput<typeof CheckoutResponseSchema>
+export type CheckoutVisitorGroupResponse = v.InferOutput<typeof CheckoutVisitorGroupResponseSchema>
+export type VisitorGroupIdParam = v.InferOutput<typeof VisitorGroupIdParamSchema>

--- a/packages/types/src/visitor.types.ts
+++ b/packages/types/src/visitor.types.ts
@@ -143,3 +143,16 @@ export interface CreateVisitorGroupResult {
   members: Visitor[]
   vehicles: VisitorGroupVehicle[]
 }
+
+export interface CheckoutVisitorGroupInput {
+  groupId: string
+  memberIds?: string[]
+}
+
+export interface CheckoutVisitorGroupResult {
+  groupId: string
+  visitors: Visitor[]
+  checkedOutCount: number
+  activeGroupMemberCount: number
+  alreadyCheckedOutCount: number
+}


### PR DESCRIPTION
## Summary

- Adds a new visitor group checkout API endpoint that supports full-group sign-out and selected-member sign-out.
- Adds kiosk visitor sign-out UI that lists active visitors and grouped visitors eligible for checkout.
- Supports one-click full-group sign-out and partial-member sign-out within the same group.
- Keeps kiosk lane state consistent by introducing explicit visitor rail mode handling for sign-in vs sign-out.
- Removes completed TODO-VISITOR-002 planning entry from TO-DO.md.

## Why this change was needed

Visitor group sign-in was available, but kiosk sign-out only supported individual checkout behavior. Staff needed a fast operational path to sign out entire groups or only selected members while keeping presence records accurate.

## What changed

### User-facing

- Kiosk visitor rail now supports both visitor sign-in and visitor sign-out modes.
- Visitor sign-out mode shows active visitors, grouped visitors, and checkout actions.
- Operators can sign out all members in a group or only selected members.

### Admin/operator-facing

- Faster group departure handling at kiosk during high traffic.
- Clearer kiosk messaging when member scanning is paused for visitor sign-out.

### Backend/API

- Added `POST /api/visitors/groups/:groupId/checkout`.
- Request supports optional `memberIds` for partial sign-out.
- Response returns checked-out count plus remaining/previous group activity context.

### Database

- No schema migration.
- Existing `visitorGroupId` relations are reused.

### Deployment/update

- No deployment workflow changes.
- No environment variable changes.

### Documentation

- Removed completed TODO-VISITOR-002 entry from project TODO list.

### Tests

- Added schema validation coverage for full-group and partial-member checkout payloads.
- Backend and frontend typechecks pass.

## User impact

Kiosk users can now complete visitor departures faster, especially for multi-person groups, without manually signing out each person one by one.

## Operator impact

Duty staff can perform group departures in fewer interactions and maintain accurate presence status during partial departures.

## Upgrade or migration notes

- No upgrade action required.
- No database migration required.
- No configuration change required.

## Risk and rollback notes

- Main risk: incorrect member selection in partial sign-out flows.
- Verification: confirm full-group and partial-member checkout behavior in kiosk UI and API responses.
- Rollback: safe by reverting this PR; no data migration rollback is needed.
- Data compatibility: unchanged schema and existing relations.

## Testing performed

- `pnpm --filter @sentinel/backend typecheck`
- `pnpm --filter frontend-admin typecheck`

## Changelog candidates

- Added kiosk visitor group sign-out with full-group and selected-member checkout actions.
- Added backend API support for partial visitor group sign-out.
- Improved kiosk operational flow by splitting visitor sign-in and sign-out modes.
