### PR TITLE
fix(kiosk): prevent empty member rows in multi-visitor sign-in

### DIFF
--- a/apps/frontend-admin/src/components/kiosk/visitor-self-signin-flow.tsx
+++ b/apps/frontend-admin/src/components/kiosk/visitor-self-signin-flow.tsx
@@ -741,6 +741,15 @@ export function VisitorSelfSigninFlow({
       return
     }
 
+    if (!hasPendingMemberInput) {
+      setSubmitError(
+        followsMilitaryPath
+          ? 'Enter rank, initials, last name, and unit before adding another member'
+          : 'Enter first and last name before adding another member'
+      )
+      return
+    }
+
     const fields: Array<keyof VisitorSelfSigninFormValues> = followsMilitaryPath
       ? ['rankPrefix', 'lastName', 'initials', 'unit']
       : ['firstName', 'lastName']
@@ -1654,6 +1663,7 @@ export function VisitorSelfSigninFlow({
                     <button
                       type="button"
                       className="btn btn-secondary btn-sm"
+                      disabled={!hasPendingMemberInput}
                       onClick={() => void handleAddCurrentMember()}
                     >
                       Add member


### PR DESCRIPTION
## Summary

- Fixes the kiosk multi-visitor flow so Add member cannot append blank member rows.
- Adds an explicit input guard before member add.
- Disables Add member until current member fields contain input.

## Why this change was needed

After the first member was added, validation could allow another add action with empty fields, which caused invalid group payloads and made multi-visitor sign-in fail in real use.

## What changed

### User-facing

- Add member now requires active member input.
- Empty member rows can no longer be added.

### Admin/operator-facing

- Multi-visitor kiosk sign-in is reliable again for group entry workflows.

### Backend/API

- No backend/API change.

### Database

- No database change.

### Deployment/update

- No deployment or config change.

### Tests

- 
> frontend-admin@3.0.1 typecheck /home/sentinel000/Projects/Sentinel/apps/frontend-admin
> pnpm --filter @sentinel/contracts build && tsc --noEmit


> @sentinel/contracts@3.0.1 build /home/sentinel000/Projects/Sentinel/packages/contracts
> tsc

## User impact

Kiosk users can add multiple visitors without the flow failing from accidental blank members.

## Operator impact

Staff can complete group check-in faster with fewer retries.

## Upgrade or migration notes

- No upgrade action required.
- No database migration required.
- No configuration change required.

## Risk and rollback notes

- Main risk is low and isolated to kiosk form state behavior.
- Verification: add first member, try Add member with blank fields (should block), then add valid second member (should succeed).
- Rollback is safe by reverting this PR.

## Changelog candidates

- Fixed kiosk multi-visitor sign-in so empty member entries are blocked before submission.