### PR TITLE
ux(kiosk): redesign visitor sign-out for grouped high-volume flow

### DIFF
--- a/apps/frontend-admin/src/components/kiosk/visitor-self-signout-flow.tsx
+++ b/apps/frontend-admin/src/components/kiosk/visitor-self-signout-flow.tsx
@@ -1,14 +1,20 @@
 'use client'
 
 import { useMemo, useState } from 'react'
-import { Users, UserRoundMinus } from 'lucide-react'
+import { Clock3, Layers3, UserRoundMinus, Users } from 'lucide-react'
 import {
   useActiveVisitors,
   useCheckoutVisitor,
   useCheckoutVisitorGroup,
 } from '@/hooks/use-visitors'
+import { Chip } from '@/components/ui/chip'
 import type { VisitorResponse } from '@sentinel/contracts'
 import type { VisitorSelfSigninCompletion } from '@/components/kiosk/visitor-self-signin-flow'
+import {
+  buildVisitorSignoutGrouping,
+  filterVisitorSignoutGroups,
+  type VisitorSignoutGroupSummary,
+} from '@/lib/visitor-signout-grouping'
 
 interface VisitorSelfSignoutFlowProps {
   layout?: 'modal' | 'inline'
@@ -16,9 +22,19 @@ interface VisitorSelfSignoutFlowProps {
   onComplete?: (completion: VisitorSelfSigninCompletion) => void
 }
 
-interface VisitorGroupSummary {
-  groupId: string
-  members: VisitorResponse[]
+const GROUP_ACCENT_STYLES = [
+  { border: 'border-l-primary', chipColor: 'primary' as const },
+  { border: 'border-l-secondary', chipColor: 'secondary' as const },
+  { border: 'border-l-accent', chipColor: 'accent' as const },
+  { border: 'border-l-info', chipColor: 'info' as const },
+  { border: 'border-l-success', chipColor: 'success' as const },
+  { border: 'border-l-warning', chipColor: 'warning' as const },
+]
+
+function compactText(value: string, maxLength = 100): string {
+  const trimmed = value.trim()
+  if (trimmed.length <= maxLength) return trimmed
+  return `${trimmed.slice(0, maxLength - 1).trimEnd()}…`
 }
 
 function formatTime(value: string): string {
@@ -44,61 +60,17 @@ export function VisitorSelfSignoutFlow({
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [busyKey, setBusyKey] = useState<string | null>(null)
   const [selectedByGroup, setSelectedByGroup] = useState<Record<string, string[]>>({})
+  const [expandedGroupId, setExpandedGroupId] = useState<string | null>(null)
 
   const activeVisitors = data?.visitors ?? []
-  const normalizedSearch = search.trim().toLowerCase()
-
-  const grouped = useMemo(() => {
-    const groupMap = new Map<string, VisitorResponse[]>()
-    const soloVisitors: VisitorResponse[] = []
-
-    for (const visitor of activeVisitors) {
-      if (!visitor.visitorGroupId) {
-        soloVisitors.push(visitor)
-        continue
-      }
-
-      const existing = groupMap.get(visitor.visitorGroupId)
-      if (existing) {
-        existing.push(visitor)
-      } else {
-        groupMap.set(visitor.visitorGroupId, [visitor])
-      }
-    }
-
-    const groups: VisitorGroupSummary[] = Array.from(groupMap.entries())
-      .map(([groupId, members]) => ({
-        groupId,
-        members: [...members].sort((a, b) => a.checkInTime.localeCompare(b.checkInTime)),
-      }))
-      .sort((a, b) => b.members[0]!.checkInTime.localeCompare(a.members[0]!.checkInTime))
-
-    const ungroupedVisitors = [...soloVisitors].sort((a, b) =>
-      b.checkInTime.localeCompare(a.checkInTime)
-    )
-
-    return { groups, ungroupedVisitors }
-  }, [activeVisitors])
-
-  const filtered = useMemo(() => {
-    if (!normalizedSearch) {
-      return grouped
-    }
-
-    const searchMatch = (visitor: VisitorResponse): boolean => {
-      const haystack =
-        `${displayName(visitor)} ${visitor.organization ?? ''} ${visitor.visitType} ${visitor.visitReason ?? ''}`.toLowerCase()
-      return haystack.includes(normalizedSearch)
-    }
-
-    return {
-      groups: grouped.groups.filter((group) => group.members.some(searchMatch)),
-      ungroupedVisitors: grouped.ungroupedVisitors.filter(searchMatch),
-    }
-  }, [grouped, normalizedSearch])
-
-  const isInline = layout === 'inline'
+  const grouped = useMemo(() => buildVisitorSignoutGrouping(activeVisitors), [activeVisitors])
+  const filtered = useMemo(() => filterVisitorSignoutGroups(grouped, search), [grouped, search])
   const canInteract = !checkoutVisitor.isPending && !checkoutVisitorGroup.isPending
+  const isInline = layout === 'inline'
+
+  const activeGroupCount = filtered.groups.length
+  const activeUngroupedCount = filtered.ungroupedVisitors.length
+  const activeVisitorCount = filtered.activeVisitorCount
 
   const complete = (title: string, message: string) => {
     onComplete?.({
@@ -137,7 +109,7 @@ export function VisitorSelfSignoutFlow({
     }
   }
 
-  const handleSignoutGroup = async (group: VisitorGroupSummary, memberIds?: string[]) => {
+  const handleSignoutGroup = async (group: VisitorSignoutGroupSummary, memberIds?: string[]) => {
     setSubmitError(null)
     const memberScoped = Boolean(memberIds && memberIds.length > 0)
     setBusyKey(memberScoped ? `group-selected:${group.groupId}` : `group-all:${group.groupId}`)
@@ -157,11 +129,20 @@ export function VisitorSelfSignoutFlow({
     }
   }
 
+  const handleGroupToggle = (groupId: string, nextOpen: boolean) => {
+    if (nextOpen) {
+      setExpandedGroupId(groupId)
+      return
+    }
+
+    setExpandedGroupId((current) => (current === groupId ? null : current))
+  }
+
   if (isLoading) {
     return (
       <div className="flex h-full items-center justify-center rounded-box border border-base-300 bg-base-200/50 p-(--space-5)">
         <span className="loading loading-spinner loading-md" />
-        <span className="ml-(--space-3) text-sm">Loading active visitors…</span>
+        <span className="ml-(--space-3) text-sm">Loading grouped visitor sign-out list…</span>
       </div>
     )
   }
@@ -170,7 +151,7 @@ export function VisitorSelfSignoutFlow({
     return (
       <div className="space-y-(--space-4)">
         <div className="alert alert-error">
-          <span>Unable to load active visitors for sign-out.</span>
+          <span>Unable to load active visitors for grouped sign-out.</span>
         </div>
         <div className="flex gap-(--space-2)">
           <button type="button" className="btn btn-outline" onClick={() => void refetch()}>
@@ -184,10 +165,6 @@ export function VisitorSelfSignoutFlow({
     )
   }
 
-  const activeCount =
-    filtered.groups.reduce((sum, group) => sum + group.members.length, 0) +
-    filtered.ungroupedVisitors.length
-
   return (
     <div className={`flex min-h-0 flex-col gap-(--space-4) ${isInline ? 'h-full' : ''}`}>
       <div className="rounded-box border border-base-300 bg-base-200/50 p-(--space-4)">
@@ -197,15 +174,25 @@ export function VisitorSelfSignoutFlow({
               Visitor sign-out
             </p>
             <p className="mt-(--space-1) text-lg font-semibold leading-tight">
-              {activeCount} active visitor{activeCount === 1 ? '' : 's'}
+              {activeVisitorCount} active visitor{activeVisitorCount === 1 ? '' : 's'}
             </p>
+            <div className="mt-(--space-2) flex flex-wrap gap-(--space-2)">
+              <Chip variant="faded" color="secondary" size="sm">
+                <Layers3 className="h-3.5 w-3.5" />
+                {activeGroupCount} group{activeGroupCount === 1 ? '' : 's'}
+              </Chip>
+              <Chip variant="faded" color="neutral" size="sm">
+                <Users className="h-3.5 w-3.5" />
+                {activeUngroupedCount} ungrouped
+              </Chip>
+            </div>
           </div>
-          <label className="input input-bordered input-sm w-full sm:w-72">
+          <label className="input input-bordered input-sm w-full sm:w-80">
             <span className="label">Search</span>
             <input
               type="text"
               className="grow"
-              placeholder="Name, company, reason"
+              placeholder="Group code, name, company, reason"
               value={search}
               onChange={(event) => setSearch(event.target.value)}
               disabled={!canInteract}
@@ -216,7 +203,7 @@ export function VisitorSelfSignoutFlow({
 
       {submitError && <div className="alert alert-error">{submitError}</div>}
 
-      {activeCount === 0 ? (
+      {activeVisitorCount === 0 ? (
         <div className="rounded-box border border-base-300 bg-base-100 p-(--space-6) text-center">
           <Users className="mx-auto h-8 w-8 text-base-content/50" />
           <p className="mt-(--space-3) text-lg font-semibold">No active visitors</p>
@@ -225,99 +212,157 @@ export function VisitorSelfSignoutFlow({
           </p>
         </div>
       ) : (
-        <div className="min-h-0 flex-1 space-y-(--space-3) overflow-y-auto pr-(--space-1)">
-          {filtered.groups.map((group) => {
-            const selectedIds = selectedByGroup[group.groupId] ?? []
-            const selectedCount = selectedIds.length
-            return (
-              <div
-                key={group.groupId}
-                className="rounded-box border border-base-300 bg-base-100 p-(--space-4)"
-              >
-                <div className="flex flex-wrap items-center justify-between gap-(--space-3)">
-                  <div>
-                    <p className="text-xs uppercase tracking-[0.18em] text-base-content/50">
-                      Group
-                    </p>
-                    <p className="text-lg font-semibold">
-                      {group.members.length} member{group.members.length === 1 ? '' : 's'}
-                    </p>
-                  </div>
-                  <div className="flex flex-wrap gap-(--space-2)">
-                    <button
-                      type="button"
-                      className="btn btn-sm btn-outline"
-                      disabled={!canInteract || selectedCount === 0}
-                      onClick={() => void handleSignoutGroup(group, selectedIds)}
+        <div className="min-h-0 flex-1 space-y-(--space-4) overflow-y-auto pr-(--space-1)">
+          {activeGroupCount > 0 && (
+            <section className="space-y-(--space-2)">
+              <p className="text-xs uppercase tracking-[0.18em] text-base-content/55">
+                Visitor groups
+              </p>
+              <div className="space-y-(--space-2)">
+                {filtered.groups.map((group) => {
+                  const selectedIds = selectedByGroup[group.groupId] ?? []
+                  const selectedCount = selectedIds.length
+                  const isExpanded = expandedGroupId === group.groupId
+                  const accent = GROUP_ACCENT_STYLES[group.accentIndex % GROUP_ACCENT_STYLES.length]
+
+                  return (
+                    <details
+                      key={group.groupId}
+                      open={isExpanded}
+                      onToggle={(event) =>
+                        handleGroupToggle(group.groupId, event.currentTarget.open)
+                      }
+                      className={`collapse collapse-arrow border border-base-300 bg-base-100 border-l-4 ${accent.border}`}
                     >
-                      Sign out selected ({selectedCount})
-                    </button>
+                      <summary className="collapse-title pr-(--space-4)">
+                        <div className="flex flex-wrap items-start justify-between gap-(--space-3)">
+                          <div className="min-w-0">
+                            <div className="flex flex-wrap items-center gap-(--space-2)">
+                              <Chip variant="faded" color={accent.chipColor} size="sm">
+                                {group.groupCode}
+                              </Chip>
+                              <p className="truncate text-lg font-semibold">
+                                {group.identityTitle}
+                              </p>
+                            </div>
+                            <p className="mt-(--space-1) text-sm text-base-content/70">
+                              {group.identityDetail}
+                            </p>
+                            <p className="mt-(--space-1) truncate text-sm text-base-content/60">
+                              {compactText(group.contextLine)}
+                            </p>
+                            <p className="mt-(--space-1) flex items-center gap-(--space-1) text-xs text-base-content/55">
+                              <Clock3 className="h-3 w-3" />
+                              Latest check-in {formatTime(group.mostRecentCheckInTime)}
+                            </p>
+                          </div>
+                          <button
+                            type="button"
+                            className="btn btn-sm btn-error"
+                            disabled={!canInteract}
+                            onClick={(event) => {
+                              event.preventDefault()
+                              event.stopPropagation()
+                              void handleSignoutGroup(group)
+                            }}
+                          >
+                            Sign out full group
+                          </button>
+                        </div>
+                      </summary>
+
+                      <div className="collapse-content border-t border-base-300 bg-base-200/35 pt-(--space-3)">
+                        <div className="mb-(--space-3) flex flex-wrap gap-(--space-2)">
+                          <button
+                            type="button"
+                            className="btn btn-sm btn-outline"
+                            disabled={!canInteract || selectedCount === 0}
+                            onClick={() => void handleSignoutGroup(group, selectedIds)}
+                          >
+                            Sign out selected ({selectedCount})
+                          </button>
+                          <button
+                            type="button"
+                            className="btn btn-sm btn-error"
+                            disabled={!canInteract}
+                            onClick={() => void handleSignoutGroup(group)}
+                          >
+                            Sign out full group
+                          </button>
+                        </div>
+
+                        <div className="grid gap-(--space-2)">
+                          {group.members.map((visitor) => {
+                            const inputId = `group-${group.groupId}-${visitor.id}`
+                            return (
+                              <label
+                                key={visitor.id}
+                                htmlFor={inputId}
+                                className="flex items-start gap-(--space-3) rounded-box border border-base-300 bg-base-100 px-(--space-3) py-(--space-2)"
+                              >
+                                <input
+                                  id={inputId}
+                                  type="checkbox"
+                                  className="checkbox checkbox-sm mt-1"
+                                  checked={selectedIds.includes(visitor.id)}
+                                  onChange={() =>
+                                    handleGroupSelectionToggle(group.groupId, visitor.id)
+                                  }
+                                  disabled={!canInteract}
+                                />
+                                <div className="min-w-0">
+                                  <p className="font-semibold leading-tight">
+                                    {displayName(visitor)}
+                                  </p>
+                                  <p className="text-sm text-base-content/70">
+                                    Checked in {formatTime(visitor.checkInTime)}
+                                    {visitor.organization ? ` • ${visitor.organization}` : ''}
+                                  </p>
+                                </div>
+                              </label>
+                            )
+                          })}
+                        </div>
+                      </div>
+                    </details>
+                  )
+                })}
+              </div>
+            </section>
+          )}
+
+          {activeUngroupedCount > 0 && (
+            <section className="space-y-(--space-2)">
+              <p className="text-xs uppercase tracking-[0.18em] text-base-content/55">
+                Ungrouped visitors
+              </p>
+              <div className="grid gap-(--space-2)">
+                {filtered.ungroupedVisitors.map((visitor) => (
+                  <div
+                    key={visitor.id}
+                    className="flex flex-wrap items-center justify-between gap-(--space-3) rounded-box border border-base-300 bg-base-100 p-(--space-3)"
+                  >
+                    <div className="min-w-0">
+                      <p className="font-semibold">{displayName(visitor)}</p>
+                      <p className="text-sm text-base-content/70">
+                        Checked in {formatTime(visitor.checkInTime)}
+                        {visitor.organization ? ` • ${visitor.organization}` : ''}
+                      </p>
+                    </div>
                     <button
                       type="button"
                       className="btn btn-sm btn-error"
                       disabled={!canInteract}
-                      onClick={() => void handleSignoutGroup(group)}
+                      onClick={() => void handleSignoutVisitor(visitor)}
                     >
-                      Sign out full group
+                      <UserRoundMinus className="h-4 w-4" />
+                      Sign out
                     </button>
                   </div>
-                </div>
-
-                <div className="mt-(--space-3) grid gap-(--space-2)">
-                  {group.members.map((visitor) => {
-                    const inputId = `group-${group.groupId}-${visitor.id}`
-                    return (
-                      <label
-                        key={visitor.id}
-                        htmlFor={inputId}
-                        className="flex items-start gap-(--space-3) rounded-box border border-base-300 bg-base-200/40 p-(--space-3)"
-                      >
-                        <input
-                          id={inputId}
-                          type="checkbox"
-                          className="checkbox checkbox-sm mt-1"
-                          checked={selectedIds.includes(visitor.id)}
-                          onChange={() => handleGroupSelectionToggle(group.groupId, visitor.id)}
-                          disabled={!canInteract}
-                        />
-                        <div className="min-w-0">
-                          <p className="font-semibold leading-tight">{displayName(visitor)}</p>
-                          <p className="text-sm text-base-content/70">
-                            Checked in {formatTime(visitor.checkInTime)}
-                            {visitor.organization ? ` • ${visitor.organization}` : ''}
-                          </p>
-                        </div>
-                      </label>
-                    )
-                  })}
-                </div>
+                ))}
               </div>
-            )
-          })}
-
-          {filtered.ungroupedVisitors.map((visitor) => (
-            <div
-              key={visitor.id}
-              className="flex flex-wrap items-center justify-between gap-(--space-3) rounded-box border border-base-300 bg-base-100 p-(--space-4)"
-            >
-              <div className="min-w-0">
-                <p className="font-semibold">{displayName(visitor)}</p>
-                <p className="text-sm text-base-content/70">
-                  Checked in {formatTime(visitor.checkInTime)}
-                  {visitor.organization ? ` • ${visitor.organization}` : ''}
-                </p>
-              </div>
-              <button
-                type="button"
-                className="btn btn-sm btn-error"
-                disabled={!canInteract}
-                onClick={() => void handleSignoutVisitor(visitor)}
-              >
-                <UserRoundMinus className="h-4 w-4" />
-                Sign out
-              </button>
-            </div>
-          ))}
+            </section>
+          )}
         </div>
       )}
 

--- a/apps/frontend-admin/src/lib/visitor-signout-grouping.test.ts
+++ b/apps/frontend-admin/src/lib/visitor-signout-grouping.test.ts
@@ -1,0 +1,156 @@
+import type { VisitorResponse } from '@sentinel/contracts'
+import { describe, expect, it } from 'vitest'
+import { buildVisitorSignoutGrouping } from './visitor-signout-grouping'
+
+function createVisitor(overrides: Partial<VisitorResponse>): VisitorResponse {
+  const id = overrides.id ?? '00000000-0000-0000-0000-000000000000'
+  return {
+    id,
+    name: overrides.name ?? 'Test Visitor',
+    rankPrefix: overrides.rankPrefix ?? null,
+    firstName: overrides.firstName ?? null,
+    lastName: overrides.lastName ?? null,
+    displayName: overrides.displayName ?? overrides.name ?? 'Test Visitor',
+    organization: overrides.organization ?? null,
+    unit: overrides.unit ?? null,
+    mobilePhone: overrides.mobilePhone ?? null,
+    licensePlate: overrides.licensePlate ?? null,
+    visitType: overrides.visitType ?? 'guest',
+    visitTypeId: overrides.visitTypeId ?? null,
+    visitReason: overrides.visitReason ?? null,
+    visitPurpose: overrides.visitPurpose ?? null,
+    purposeDetails: overrides.purposeDetails ?? null,
+    recruitmentStep: overrides.recruitmentStep ?? null,
+    eventId: overrides.eventId ?? null,
+    hostMemberId: overrides.hostMemberId ?? null,
+    checkInTime: overrides.checkInTime ?? '2026-05-04T12:00:00.000Z',
+    checkOutTime: overrides.checkOutTime ?? null,
+    temporaryBadgeId: overrides.temporaryBadgeId ?? null,
+    kioskId: overrides.kioskId ?? 'DASHBOARD_KIOSK',
+    adminNotes: overrides.adminNotes ?? null,
+    checkInMethod: overrides.checkInMethod ?? 'kiosk_self_service',
+    createdByAdmin: overrides.createdByAdmin ?? null,
+    visitorGroupId: overrides.visitorGroupId ?? null,
+    createdAt: overrides.createdAt ?? '2026-05-04T12:00:00.000Z',
+  }
+}
+
+describe('buildVisitorSignoutGrouping', () => {
+  it('labels contractor groups with their most common company', () => {
+    const grouping = buildVisitorSignoutGrouping([
+      createVisitor({
+        id: '11111111-1111-1111-1111-111111111111',
+        visitorGroupId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        visitType: 'contractor',
+        organization: 'Black & MacDonald',
+      }),
+      createVisitor({
+        id: '22222222-2222-2222-2222-222222222222',
+        visitorGroupId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        visitType: 'contractor',
+        organization: 'Black & MacDonald',
+      }),
+      createVisitor({
+        id: '33333333-3333-3333-3333-333333333333',
+        visitorGroupId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        visitType: 'contractor',
+        organization: 'Another Company',
+      }),
+    ])
+
+    expect(grouping.groups[0]?.identityTitle).toBe('Black & MacDonald')
+    expect(grouping.groups[0]?.identityDetail).toBe('3 contractors')
+  })
+
+  it('labels civilian-style groups with a shared surname', () => {
+    const grouping = buildVisitorSignoutGrouping([
+      createVisitor({
+        id: '44444444-4444-4444-4444-444444444444',
+        visitorGroupId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        firstName: 'Jane',
+        lastName: 'Doe',
+        displayName: 'Doe, Jane',
+      }),
+      createVisitor({
+        id: '55555555-5555-5555-5555-555555555555',
+        visitorGroupId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        firstName: 'John',
+        lastName: 'DOE',
+        displayName: 'Doe, John',
+      }),
+    ])
+
+    expect(grouping.groups[0]?.identityTitle).toBe('Doe group')
+    expect(grouping.groups[0]?.identityDetail).toBe('2 visitors')
+  })
+
+  it('uses a mixed fallback label when surnames and companies differ', () => {
+    const grouping = buildVisitorSignoutGrouping([
+      createVisitor({
+        id: '66666666-6666-6666-6666-666666666666',
+        visitorGroupId: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        displayName: 'Sauk, C',
+        lastName: 'Sauk',
+      }),
+      createVisitor({
+        id: '77777777-7777-7777-7777-777777777777',
+        visitorGroupId: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        displayName: 'Smith, M',
+        lastName: 'Smith',
+      }),
+      createVisitor({
+        id: '88888888-8888-8888-8888-888888888888',
+        visitorGroupId: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        displayName: 'Cook, D',
+        lastName: 'Cook',
+      }),
+    ])
+
+    expect(grouping.groups[0]?.identityTitle).toContain('Sauk')
+    expect(grouping.groups[0]?.identityTitle).toContain('+1 more')
+  })
+
+  it('handles missing names and organizations without crashing', () => {
+    const grouping = buildVisitorSignoutGrouping([
+      createVisitor({
+        id: '99999999-9999-9999-9999-999999999999',
+        visitorGroupId: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+        displayName: 'Visitor One',
+        lastName: null,
+        organization: null,
+      }),
+      createVisitor({
+        id: 'aaaaaaaa-1111-1111-1111-111111111111',
+        visitorGroupId: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+        displayName: 'Visitor Two',
+        lastName: null,
+        organization: null,
+      }),
+    ])
+
+    expect(grouping.groups[0]?.identityTitle.length).toBeGreaterThan(0)
+    expect(grouping.groups[0]?.contextLine.length).toBeGreaterThan(0)
+  })
+
+  it('assigns stable group codes based on sorted recency', () => {
+    const visitors = [
+      createVisitor({
+        id: 'bbbbbbbb-1111-1111-1111-111111111111',
+        visitorGroupId: 'group-older',
+        checkInTime: '2026-05-04T09:00:00.000Z',
+      }),
+      createVisitor({
+        id: 'cccccccc-1111-1111-1111-111111111111',
+        visitorGroupId: 'group-newer',
+        checkInTime: '2026-05-04T10:00:00.000Z',
+      }),
+    ]
+
+    const first = buildVisitorSignoutGrouping(visitors)
+    const second = buildVisitorSignoutGrouping(visitors)
+
+    expect(first.groups.map((group) => group.groupCode)).toEqual(['G-01', 'G-02'])
+    expect(second.groups.map((group) => group.groupCode)).toEqual(['G-01', 'G-02'])
+    expect(first.groups[0]?.groupId).toBe('group-newer')
+  })
+})

--- a/apps/frontend-admin/src/lib/visitor-signout-grouping.ts
+++ b/apps/frontend-admin/src/lib/visitor-signout-grouping.ts
@@ -1,0 +1,277 @@
+import type { VisitorResponse } from '@sentinel/contracts'
+
+export interface VisitorSignoutGroupSummary {
+  groupId: string
+  groupCode: string
+  accentIndex: number
+  members: VisitorResponse[]
+  memberCount: number
+  mostRecentCheckInTime: string
+  identityTitle: string
+  identityDetail: string
+  contextLine: string
+  searchableText: string
+}
+
+export interface VisitorSignoutGroupingResult {
+  groups: VisitorSignoutGroupSummary[]
+  ungroupedVisitors: VisitorResponse[]
+  activeVisitorCount: number
+}
+
+const ACCENT_BUCKET_COUNT = 6
+
+function clean(value: string | null | undefined): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+function titleCase(value: string): string {
+  return value
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1).toLowerCase()}`)
+    .join(' ')
+}
+
+function visitorDisplayName(visitor: VisitorResponse): string {
+  return clean(visitor.displayName) ?? clean(visitor.name) ?? 'Visitor'
+}
+
+function extractFallbackSurname(visitor: VisitorResponse): string | undefined {
+  const direct = clean(visitor.lastName)
+  if (direct) return direct
+
+  const display = clean(visitor.displayName) ?? clean(visitor.name)
+  if (!display) return undefined
+
+  if (display.includes(',')) {
+    const [beforeComma] = display.split(',')
+    return clean(beforeComma)
+  }
+
+  const parts = display.split(/\s+/).filter(Boolean)
+  return parts.length > 1 ? parts[parts.length - 1] : undefined
+}
+
+function mostCommonValue(values: string[]): string | undefined {
+  if (values.length === 0) return undefined
+
+  const counts = new Map<string, { count: number; firstIndex: number; sample: string }>()
+  values.forEach((value, index) => {
+    const key = value.toLowerCase()
+    const entry = counts.get(key)
+    if (entry) {
+      entry.count += 1
+      return
+    }
+    counts.set(key, { count: 1, firstIndex: index, sample: value })
+  })
+
+  const winner = Array.from(counts.values()).sort((left, right) => {
+    if (right.count !== left.count) return right.count - left.count
+    return left.firstIndex - right.firstIndex
+  })[0]
+
+  return winner?.sample
+}
+
+function buildIdentity(members: VisitorResponse[]): {
+  identityTitle: string
+  identityDetail: string
+  contextLine: string
+} {
+  const memberCount = members.length
+  const allContractors = members.every((member) => member.visitType === 'contractor')
+  const companyNames = members
+    .map((member) => clean(member.organization))
+    .filter(Boolean) as string[]
+  const dominantCompany = mostCommonValue(companyNames)
+
+  if (allContractors && dominantCompany) {
+    const context = clean(members[0]?.visitReason) ?? 'Contractor group'
+    return {
+      identityTitle: dominantCompany,
+      identityDetail: `${memberCount} contractor${memberCount === 1 ? '' : 's'}`,
+      contextLine: context,
+    }
+  }
+
+  const surnames = members
+    .map((member) => extractFallbackSurname(member))
+    .filter(Boolean) as string[]
+  if (surnames.length === memberCount) {
+    const normalizedSurnames = new Set(surnames.map((surname) => surname.toLowerCase()))
+    if (normalizedSurnames.size === 1) {
+      const surname = titleCase(surnames[0] ?? 'Visitor')
+      const context =
+        clean(members[0]?.visitReason) ?? clean(members[0]?.organization) ?? 'Visitor group'
+      return {
+        identityTitle: `${surname} group`,
+        identityDetail: `${memberCount} visitor${memberCount === 1 ? '' : 's'}`,
+        contextLine: context,
+      }
+    }
+  }
+
+  const namePool = Array.from(
+    new Set(
+      members
+        .map((member) => extractFallbackSurname(member) ?? visitorDisplayName(member))
+        .filter(Boolean)
+        .map((entry) => titleCase(entry))
+    )
+  )
+  const shownNames = namePool.slice(0, 2)
+  const overflow = Math.max(namePool.length - shownNames.length, 0)
+  const title =
+    shownNames.length > 0
+      ? `${shownNames.join(' • ')}${overflow > 0 ? ` +${overflow} more` : ''}`
+      : `${memberCount} visitors`
+
+  const context =
+    dominantCompany ??
+    clean(members[0]?.visitReason) ??
+    clean(members[0]?.organization) ??
+    'Mixed visitor group'
+
+  return {
+    identityTitle: title,
+    identityDetail: `${memberCount} visitor${memberCount === 1 ? '' : 's'}`,
+    contextLine: context,
+  }
+}
+
+function hashToAccentIndex(input: string): number {
+  let hash = 0
+  for (let index = 0; index < input.length; index += 1) {
+    hash = (hash * 31 + input.charCodeAt(index)) >>> 0
+  }
+  return hash % ACCENT_BUCKET_COUNT
+}
+
+function buildSearchText(group: VisitorSignoutGroupSummary): string {
+  const memberTerms = group.members
+    .map((member) =>
+      [
+        visitorDisplayName(member),
+        clean(member.firstName),
+        clean(member.lastName),
+        clean(member.organization),
+        clean(member.visitReason),
+      ]
+        .filter(Boolean)
+        .join(' ')
+    )
+    .join(' ')
+
+  return [
+    group.groupCode,
+    group.identityTitle,
+    group.identityDetail,
+    group.contextLine,
+    memberTerms,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+}
+
+export function buildVisitorSignoutGrouping(
+  activeVisitors: VisitorResponse[]
+): VisitorSignoutGroupingResult {
+  const groupedMap = new Map<string, VisitorResponse[]>()
+  const ungroupedVisitors: VisitorResponse[] = []
+
+  for (const visitor of activeVisitors) {
+    if (!visitor.visitorGroupId) {
+      ungroupedVisitors.push(visitor)
+      continue
+    }
+
+    const existing = groupedMap.get(visitor.visitorGroupId)
+    if (existing) {
+      existing.push(visitor)
+    } else {
+      groupedMap.set(visitor.visitorGroupId, [visitor])
+    }
+  }
+
+  const groupsWithoutCodes = Array.from(groupedMap.entries())
+    .map(([groupId, members]) => {
+      const sortedMembers = [...members].sort((left, right) =>
+        left.checkInTime.localeCompare(right.checkInTime)
+      )
+      const mostRecentCheckInTime = sortedMembers[sortedMembers.length - 1]?.checkInTime ?? ''
+      const identity = buildIdentity(sortedMembers)
+      const accentIndex = hashToAccentIndex(groupId)
+
+      return {
+        groupId,
+        groupCode: '',
+        accentIndex,
+        members: sortedMembers,
+        memberCount: sortedMembers.length,
+        mostRecentCheckInTime,
+        identityTitle: identity.identityTitle,
+        identityDetail: identity.identityDetail,
+        contextLine: identity.contextLine,
+        searchableText: '',
+      }
+    })
+    .sort((left, right) => right.mostRecentCheckInTime.localeCompare(left.mostRecentCheckInTime))
+
+  const groups = groupsWithoutCodes.map((group, index) => {
+    const groupCode = `G-${String(index + 1).padStart(2, '0')}`
+    const finalized: VisitorSignoutGroupSummary = {
+      ...group,
+      groupCode,
+      searchableText: '',
+    }
+    return {
+      ...finalized,
+      searchableText: buildSearchText(finalized),
+    }
+  })
+
+  const sortedUngrouped = [...ungroupedVisitors].sort((left, right) =>
+    right.checkInTime.localeCompare(left.checkInTime)
+  )
+
+  return {
+    groups,
+    ungroupedVisitors: sortedUngrouped,
+    activeVisitorCount: activeVisitors.length,
+  }
+}
+
+export function filterVisitorSignoutGroups(
+  grouping: VisitorSignoutGroupingResult,
+  query: string
+): VisitorSignoutGroupingResult {
+  const normalizedQuery = query.trim().toLowerCase()
+  if (!normalizedQuery) return grouping
+
+  const groups = grouping.groups.filter((group) => group.searchableText.includes(normalizedQuery))
+  const ungroupedVisitors = grouping.ungroupedVisitors.filter((visitor) => {
+    const haystack = [
+      visitorDisplayName(visitor),
+      clean(visitor.firstName),
+      clean(visitor.lastName),
+      clean(visitor.organization),
+      clean(visitor.visitReason),
+    ]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase()
+    return haystack.includes(normalizedQuery)
+  })
+
+  return {
+    groups,
+    ungroupedVisitors,
+    activeVisitorCount:
+      groups.reduce((sum, group) => sum + group.memberCount, 0) + ungroupedVisitors.length,
+  }
+}


### PR DESCRIPTION
## Summary

- Redesigns kiosk Visitor Sign-out into a single-open accordion for high group volume workflows.
- Adds smart collapsed group identity labels so staff can quickly distinguish groups without expanding each one.
- Preserves full-group sign-out from collapsed cards and partial-member sign-out inside expanded group details.
- Adds deterministic group codes and stable visual accents for faster verbal/operator coordination.
- Adds focused unit tests for grouping and identity heuristics.

## Why this change was needed

The previous sign-out layout rendered all group members in expanded lists, which became hard to scan when many groups were active. Staff needed a compact, high-signal view that supports rapid identification and selective sign-out actions during busy kiosk periods.

## What changed

### User-facing

- Visitor groups now render as collapsed accordion cards by default.
- Collapsed cards show group identity, member count, latest check-in, and context line.
- Full-group sign-out is available directly from collapsed cards.
- Partial sign-out remains available after expanding a group.

### Admin/operator-facing

- Faster scan-and-act workflow for high traffic (for example, 30 visitors across 12 groups).
- Group codes (`G-01`, `G-02`, etc.) improve station-to-station coordination.

### Backend/API

- No backend/API changes.

### Database

- No schema changes.
- No migration required.

### Deployment/update

- No deployment process changes.
- No environment/configuration changes.

### Documentation

- No documentation updates in this patch.

### Tests

- Added unit coverage for group identity heuristics and deterministic grouping behavior.
- Re-ran frontend typecheck and targeted test suite.

## User impact

Kiosk users can identify the correct visitor group faster and sign out groups with fewer interactions, while still handling partial group departures when needed.

## Operator impact

Duty and front-desk staff get a denser operational view with better group differentiation and reduced scrolling/cognitive load.

## Upgrade or migration notes

- No upgrade action required.
- No database migration required.
- No configuration change required.

## Risk and rollback notes

- Main risk: visual interaction regressions in accordion toggle behavior.
- Verification: confirm one-group-open behavior, collapsed full-group action, and expanded partial-member action.
- Rollback: safe by reverting this PR.
- Data compatibility: unchanged.

## Testing performed

- `pnpm --filter frontend-admin typecheck`
- `pnpm --filter frontend-admin exec vitest run src/lib/visitor-signout-grouping.test.ts`

## Changelog candidates

- Redesigned kiosk Visitor Sign-out into a compact grouped accordion for high-volume operations.
- Added smart group identity labels (company/surname/mixed fallback) to speed group recognition.
- Preserved full-group and partial-member sign-out actions in the new grouped workflow.
