### PR TITLE
ux: inline visitor checkout list for kiosk and prep patch v3.0.7

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.0.1",
+  "version": "3.0.7",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.0.1",
+  "version": "3.0.7",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/components/kiosk/kiosk-visitor-rail.tsx
+++ b/apps/frontend-admin/src/components/kiosk/kiosk-visitor-rail.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { AnimatePresence, motion } from 'motion/react'
-import { ChevronRight, UserRoundMinus, UserRoundPlus } from 'lucide-react'
+import { ChevronRight, UserRoundPlus } from 'lucide-react'
 import { AppCard, AppCardContent, AppCardHeader, AppCardTitle } from '@/components/ui/AppCard'
 import { Chip } from '@/components/ui/chip'
 import {
@@ -148,7 +148,7 @@ export function KioskVisitorRail({
               </AppCardHeader>
 
               <AppCardContent
-                className="mt-auto grid gap-(--space-3)"
+                className="mt-auto flex min-h-0 flex-1 flex-col gap-(--space-3)"
                 style={{ padding: '0 var(--space-5) var(--space-5)' }}
               >
                 <button
@@ -161,15 +161,17 @@ export function KioskVisitorRail({
                   <span className="text-base font-medium opacity-85">Sign in</span>
                   <ChevronRight className="h-6 w-6" />
                 </button>
-                <button
-                  type="button"
-                  className="btn btn-outline btn-lg gap-(--space-3) px-(--space-5) py-(--space-4) text-lg"
-                  onClick={() => onStart('signout')}
-                  disabled={fatalOperationalOutage}
-                >
-                  <UserRoundMinus className="h-5 w-5" />
-                  Sign out visitors
-                </button>
+
+                <div className="mt-(--space-2) border-t border-base-300 pt-(--space-3)">
+                  <VisitorSelfSignoutFlow
+                    layout="inline"
+                    presentation="embedded"
+                    interactionDisabled={fatalOperationalOutage}
+                    showCloseAction={false}
+                    onCancel={onCancel}
+                    onComplete={onComplete}
+                  />
+                </div>
               </AppCardContent>
             </AppCard>
           </motion.div>

--- a/apps/frontend-admin/src/components/kiosk/visitor-self-signout-flow.tsx
+++ b/apps/frontend-admin/src/components/kiosk/visitor-self-signout-flow.tsx
@@ -18,6 +18,9 @@ import {
 
 interface VisitorSelfSignoutFlowProps {
   layout?: 'modal' | 'inline'
+  presentation?: 'full' | 'embedded'
+  interactionDisabled?: boolean
+  showCloseAction?: boolean
   onCancel: () => void
   onComplete?: (completion: VisitorSelfSigninCompletion) => void
 }
@@ -50,6 +53,9 @@ function displayName(visitor: VisitorResponse): string {
 
 export function VisitorSelfSignoutFlow({
   layout = 'inline',
+  presentation = 'full',
+  interactionDisabled = false,
+  showCloseAction = true,
   onCancel,
   onComplete,
 }: VisitorSelfSignoutFlowProps) {
@@ -65,8 +71,10 @@ export function VisitorSelfSignoutFlow({
   const activeVisitors = data?.visitors ?? []
   const grouped = useMemo(() => buildVisitorSignoutGrouping(activeVisitors), [activeVisitors])
   const filtered = useMemo(() => filterVisitorSignoutGroups(grouped, search), [grouped, search])
-  const canInteract = !checkoutVisitor.isPending && !checkoutVisitorGroup.isPending
+  const canInteract =
+    !interactionDisabled && !checkoutVisitor.isPending && !checkoutVisitorGroup.isPending
   const isInline = layout === 'inline'
+  const isEmbedded = presentation === 'embedded'
 
   const activeGroupCount = filtered.groups.length
   const activeUngroupedCount = filtered.ungroupedVisitors.length
@@ -140,7 +148,7 @@ export function VisitorSelfSignoutFlow({
 
   if (isLoading) {
     return (
-      <div className="flex h-full items-center justify-center rounded-box border border-base-300 bg-base-200/50 p-(--space-5)">
+      <div className="flex items-center justify-center rounded-box border border-base-300 bg-base-200/50 p-(--space-5)">
         <span className="loading loading-spinner loading-md" />
         <span className="ml-(--space-3) text-sm">Loading grouped visitor sign-out list…</span>
       </div>
@@ -157,16 +165,26 @@ export function VisitorSelfSignoutFlow({
           <button type="button" className="btn btn-outline" onClick={() => void refetch()}>
             Retry
           </button>
-          <button type="button" className="btn btn-ghost" onClick={onCancel}>
-            Cancel
-          </button>
+          {showCloseAction ? (
+            <button type="button" className="btn btn-ghost" onClick={onCancel}>
+              Cancel
+            </button>
+          ) : null}
         </div>
       </div>
     )
   }
 
   return (
-    <div className={`flex min-h-0 flex-col gap-(--space-4) ${isInline ? 'h-full' : ''}`}>
+    <div
+      className={`flex min-h-0 flex-col gap-(--space-4) ${isInline && !isEmbedded ? 'h-full' : ''}`}
+    >
+      {interactionDisabled ? (
+        <div className="alert alert-warning">
+          <span>Visitor sign-out is temporarily unavailable while services are offline.</span>
+        </div>
+      ) : null}
+
       <div className="rounded-box border border-base-300 bg-base-200/50 p-(--space-4)">
         <div className="flex flex-wrap items-center justify-between gap-(--space-3)">
           <div>
@@ -212,7 +230,11 @@ export function VisitorSelfSignoutFlow({
           </p>
         </div>
       ) : (
-        <div className="min-h-0 flex-1 space-y-(--space-4) overflow-y-auto pr-(--space-1)">
+        <div
+          className={`min-h-0 space-y-(--space-4) overflow-y-auto pr-(--space-1) ${
+            isEmbedded ? 'max-h-[26rem]' : 'flex-1'
+          }`}
+        >
           {activeGroupCount > 0 && (
             <section className="space-y-(--space-2)">
               <p className="text-xs uppercase tracking-[0.18em] text-base-content/55">
@@ -366,12 +388,19 @@ export function VisitorSelfSignoutFlow({
         </div>
       )}
 
-      <div className="mt-auto flex flex-wrap justify-end gap-(--space-2) border-t border-base-300 pt-(--space-3)">
-        {busyKey ? <span className="loading loading-spinner loading-sm mr-auto" /> : null}
-        <button type="button" className="btn btn-ghost" onClick={onCancel} disabled={!canInteract}>
-          Close
-        </button>
-      </div>
+      {showCloseAction ? (
+        <div className="mt-auto flex flex-wrap justify-end gap-(--space-2) border-t border-base-300 pt-(--space-3)">
+          {busyKey ? <span className="loading loading-spinner loading-sm mr-auto" /> : null}
+          <button
+            type="button"
+            className="btn btn-ghost"
+            onClick={onCancel}
+            disabled={!canInteract}
+          >
+            Close
+          </button>
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.0.1",
+  "version": "3.0.7",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.0.1",
+  "version": "3.0.7",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.0.1",
+  "version": "3.0.7",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.0.1",
+  "version": "3.0.7",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Replaces the idle `Sign out visitors` button in kiosk Visitor Services with an inline checkout list shown directly below `Start Sign in`.
- Keeps grouped and ungrouped visitor checkout actions available in-place, removing one extra click.
- Adds embedded presentation controls to the sign-out flow so the same logic can be reused without modal-style close chrome.
- Bumps workspace versions to `3.0.7` for patch release preparation.

## Why this change was needed

The kiosk sign-out flow required an unnecessary extra click before users could see and act on visitors ready for checkout. This change improves throughput at the front desk by making checkout candidates immediately visible.

## What changed

### User-facing

- Kiosk Visitor Services now shows active visitor checkout candidates immediately in idle state.
- Direct sign-out actions for grouped and ungrouped visitors remain available.

### Admin/operator-facing

- No operator workflow changes outside kiosk visitor interactions.

### Backend/API

- No API or contract behavior change.

### Database

- No schema or migration changes.

### Deployment/update

- Workspace package versions updated to `3.0.7`.

### Tests

- Frontend typecheck was run for touched kiosk UI.

## User impact

Kiosk users can sign out visitors faster because they no longer need to open a separate sign-out view first.

## Operator impact

No manual operator action is required for this UI change itself.

## Upgrade or migration notes

- No upgrade action required.
- No database migration required.
- No configuration change required.

## Risk and rollback notes

- Main risk: visual density in the kiosk rail could increase with large active visitor counts.
- Verification: confirm idle rail shows sign-in CTA first, then inline checkout list, and that fatal outage disables checkout actions.
- Rollback: safe by reverting this PR; no data compatibility concerns.

## Testing performed

- `pnpm --filter frontend-admin typecheck`
- `pnpm --filter frontend-admin lint` (warnings only, pre-existing in repo)

## Changelog candidates

- Kiosk: active visitors ready for checkout are now listed directly below the visitor sign-in button, removing one extra click.
- Kiosk: grouped and ungrouped visitor sign-out actions remain available inline.
- Release prep: workspace package versions bumped to `3.0.7`.
