### PR TITLE
fix: prevent stale session checks from cancelling first login attempt

### DIFF
--- a/apps/frontend-admin/src/components/auth/auth-hydrator.logic.test.ts
+++ b/apps/frontend-admin/src/components/auth/auth-hydrator.logic.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { shouldIgnoreStaleUnauthorizedSessionCheck } from './auth-hydrator.logic'
+
+describe('auth hydrator logic', () => {
+  it('ignores stale unauthorized responses when login completed during the request', () => {
+    expect(
+      shouldIgnoreStaleUnauthorizedSessionCheck({
+        wasAuthenticatedAtRequestStart: false,
+        isAuthenticatedNow: true,
+      })
+    ).toBe(true)
+  })
+
+  it('does not ignore unauthorized responses for still-logged-out sessions', () => {
+    expect(
+      shouldIgnoreStaleUnauthorizedSessionCheck({
+        wasAuthenticatedAtRequestStart: false,
+        isAuthenticatedNow: false,
+      })
+    ).toBe(false)
+  })
+
+  it('does not ignore unauthorized responses for sessions that started authenticated', () => {
+    expect(
+      shouldIgnoreStaleUnauthorizedSessionCheck({
+        wasAuthenticatedAtRequestStart: true,
+        isAuthenticatedNow: true,
+      })
+    ).toBe(false)
+  })
+})

--- a/apps/frontend-admin/src/components/auth/auth-hydrator.logic.ts
+++ b/apps/frontend-admin/src/components/auth/auth-hydrator.logic.ts
@@ -1,0 +1,7 @@
+export function shouldIgnoreStaleUnauthorizedSessionCheck(input: {
+  wasAuthenticatedAtRequestStart: boolean
+  isAuthenticatedNow: boolean
+}): boolean {
+  const { wasAuthenticatedAtRequestStart, isAuthenticatedNow } = input
+  return !wasAuthenticatedAtRequestStart && isAuthenticatedNow
+}

--- a/apps/frontend-admin/src/components/auth/auth-hydrator.tsx
+++ b/apps/frontend-admin/src/components/auth/auth-hydrator.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/lib/post-login-destination'
 import { isKioskRoute } from '@/lib/kiosk-device-auth'
 import { useAuthStore } from '@/store/auth-store'
+import { shouldIgnoreStaleUnauthorizedSessionCheck } from './auth-hydrator.logic'
 
 /**
  * Validates the session cookie on mount and syncs the Zustand auth store.
@@ -25,6 +26,8 @@ export function AuthHydrator() {
   const kioskRoute = isKioskRoute(pathname)
 
   const validateSession = useEffectEvent(async () => {
+    const wasAuthenticatedAtRequestStart = useAuthStore.getState().isAuthenticated
+
     try {
       const response = await apiClient.auth.getSession()
 
@@ -54,6 +57,15 @@ export function AuthHydrator() {
       }
 
       if (response.status === 401) {
+        if (
+          shouldIgnoreStaleUnauthorizedSessionCheck({
+            wasAuthenticatedAtRequestStart,
+            isAuthenticatedNow: useAuthStore.getState().isAuthenticated,
+          })
+        ) {
+          return
+        }
+
         logout()
         if (pathname !== '/login' && !kioskRoute) {
           router.replace(buildForcedReauthLoginUrl())
@@ -61,7 +73,7 @@ export function AuthHydrator() {
         return
       }
 
-      if (isAuthenticated) {
+      if (useAuthStore.getState().isAuthenticated) {
         logout()
         if (pathname !== '/login' && !kioskRoute) {
           router.replace(buildLoginUrl(pathname, window.location.search))


### PR DESCRIPTION
## Summary

- Fixes a login race where a stale in-flight session validation response could clear newly set auth state.
- Prevents first-attempt sign-in failures that required users to retry.
- Adds focused auth-hydrator logic tests to prevent regression.

## Why this change was needed

Users were intermittently seeing first login attempts fail even with correct credentials. The root cause was a timing race between initial session hydration and login completion.

## What changed

### User-facing

- Login now remains stable on the first successful attempt.

### Frontend

- Added guard logic in auth hydration to ignore stale unauthorized responses when authentication becomes valid during the request.
- Added unit tests for stale unauthorized response handling.

### Tests

- Added `auth-hydrator.logic.test.ts` coverage for stale-response scenarios.
- Verified existing login helper and PIN selection logic tests remain green.

## User impact

Users should no longer need a second login attempt after entering valid credentials.

## Operator impact

No operational workflow changes.

## Upgrade or migration notes

- No upgrade action required.
- No database migration required.
- No configuration change required.

## Risk and rollback notes

- Main risk: low; scoped frontend auth-state handling change.
- Verification: successful local build and targeted tests.
- Rollback: safe to revert this commit with no data compatibility impact.

## Testing performed

- `pnpm --filter frontend-admin exec vitest run src/components/auth/auth-hydrator.logic.test.ts src/app/login/login-flow.test.ts src/components/auth/pin-input.logic.test.ts`
- `pnpm --filter frontend-admin type-check`
- `pnpm build`

## Changelog candidates

- Fixed a login race that could force users to attempt sign-in twice even with correct credentials.
