### PR TITLE
Add dashboard Member Type fallback badges

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.0.7",
+  "version": "3.0.9",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/repositories/checkin-repository.ts
+++ b/apps/backend/src/repositories/checkin-repository.ts
@@ -48,10 +48,26 @@ export interface PresentMember {
   divisionCode: string
   divisionId: string | null
   memberType: MemberType
+  memberTypeInfo?: {
+    id: string
+    code: string
+    name: string
+    chipVariant?: string
+    chipColor?: string
+  }
   mess: string | null
   activeCheckinId: string
   checkedInAt: string
   kioskId?: string
+  tags: Array<{
+    id: string
+    name: string
+    chipVariant?: string
+    chipColor?: string
+    isPositional?: boolean
+    displayOrder?: number
+    source?: 'direct' | 'qualification'
+  }>
 }
 
 export class CheckinRepository {
@@ -747,6 +763,11 @@ export class CheckinRepository {
         division_name: string
         division_code: string
         member_type: string
+        member_type_id: string | null
+        member_type_code: string | null
+        member_type_name: string | null
+        member_type_chip_variant: string | null
+        member_type_chip_color: string | null
         active_checkin_id: string
         checked_in_at: Date
         kiosk_id: string | null
@@ -806,6 +827,11 @@ export class CheckinRepository {
         d.name as division_name,
         d.code as division_code,
         m.member_type,
+        mt.id as member_type_id,
+        mt.code as member_type_code,
+        mt.name as member_type_name,
+        mt.chip_variant as member_type_chip_variant,
+        mt.chip_color as member_type_chip_color,
         lc.id as active_checkin_id,
         lc.timestamp as checked_in_at,
         lc.kiosk_id,
@@ -815,6 +841,7 @@ export class CheckinRepository {
       INNER JOIN latest_checkins lc ON m.id = lc.member_id
       LEFT JOIN ranks r ON m.rank_id = r.id
       LEFT JOIN member_tags_agg mta ON m.id = mta.member_id
+      LEFT JOIN member_types mt ON mt.id = m.member_type_id OR (m.member_type_id IS NULL AND mt.code = m.member_type)
       WHERE m.status = 'active' AND lc.direction = 'in'
       ORDER BY lc.timestamp DESC
     `
@@ -831,6 +858,16 @@ export class CheckinRepository {
       divisionCode: row.division_code,
       divisionId: row.division_id,
       memberType: row.member_type as MemberType,
+      memberTypeInfo:
+        row.member_type_id && row.member_type_code && row.member_type_name
+          ? {
+              id: row.member_type_id,
+              code: row.member_type_code,
+              name: row.member_type_name,
+              chipVariant: row.member_type_chip_variant ?? undefined,
+              chipColor: row.member_type_chip_color ?? undefined,
+            }
+          : undefined,
       mess: row.mess,
       activeCheckinId: row.active_checkin_id,
       checkedInAt: row.checked_in_at.toISOString(),

--- a/apps/backend/src/routes/checkins.ts
+++ b/apps/backend/src/routes/checkins.ts
@@ -426,6 +426,7 @@ export const checkinsRouter = s.router(checkinContract, {
             divisionCode: p.divisionCode,
             divisionId: p.divisionId,
             memberType: p.memberType,
+            memberTypeInfo: p.memberTypeInfo,
             tags: p.tags,
             organization: p.organization,
             visitType: p.visitType,

--- a/apps/backend/src/services/presence-service.ts
+++ b/apps/backend/src/services/presence-service.ts
@@ -28,6 +28,13 @@ interface PresentMember {
   divisionCode: string
   divisionId: string
   memberType: string
+  memberTypeInfo?: {
+    id: string
+    code: string
+    name: string
+    chipVariant?: string
+    chipColor?: string
+  }
   mess: string | null
   activeCheckinId: string
   checkedInAt: string
@@ -56,6 +63,13 @@ interface MemberPresenceItem {
     mess?: string
     moc?: string
     memberType: string
+    memberTypeInfo?: {
+      id: string
+      code: string
+      name: string
+      chipVariant?: string
+      chipColor?: string
+    }
     classDetails?: string
     status: string
     email?: string
@@ -122,7 +136,22 @@ interface PresentPerson {
   divisionCode?: string
   divisionId?: string
   memberType?: string
-  tags?: Array<{ id: string; name: string; chipVariant?: string; chipColor?: string }>
+  memberTypeInfo?: {
+    id: string
+    code: string
+    name: string
+    chipVariant?: string
+    chipColor?: string
+  }
+  tags?: Array<{
+    id: string
+    name: string
+    chipVariant?: string
+    chipColor?: string
+    isPositional?: boolean
+    displayOrder?: number
+    source?: 'direct' | 'qualification'
+  }>
   organization?: string
   visitType?: { id: string; name: string; chipVariant?: string; chipColor?: string }
   visitReason?: string
@@ -226,6 +255,7 @@ export class PresenceService {
         divisionCode: m.divisionCode,
         divisionId: m.divisionId,
         memberType: m.memberType,
+        memberTypeInfo: m.memberTypeInfo,
         tags: m.tags,
         activeCheckinId: m.activeCheckinId,
         checkInTime: new Date(m.checkedInAt),

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.0.7",
+  "version": "3.0.9",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/components/dashboard/person-card.tsx
+++ b/apps/frontend-admin/src/components/dashboard/person-card.tsx
@@ -36,6 +36,7 @@ const CHIP_COLOR_AVATAR_CLASSES: Record<string, string> = fadedColorClasses
 // Tag names that represent active responsibilities — hidden from avatar fallback and chips
 // These are qualification tags (DDS, Duty Watch positions) that only display when scheduled
 const RESPONSIBILITY_TAG_NAMES = ['DDS', 'SWK', 'DSWK', 'QM', 'BM', 'APS']
+const DUTY_WATCH_TAG_NAMES = ['SWK', 'DSWK', 'QM', 'BM', 'APS']
 const FTS_TAG_NAME = 'FTS'
 const HOVER_3D_LAYER_KEYS = Array.from({ length: 8 }, (_, index) => index)
 
@@ -62,6 +63,12 @@ function getAvatarColorClass(chipColor?: string): string {
 
   const normalized = normalizeChipColor(chipColor as ChipColor)
   return CHIP_COLOR_AVATAR_CLASSES[normalized] || CHIP_COLOR_AVATAR_CLASSES.default
+}
+
+function hasNonDutyWatchTag(person: PresentPerson): boolean {
+  return Boolean(
+    person.tags?.some((tag) => !DUTY_WATCH_TAG_NAMES.includes(tag.name.trim().toUpperCase()))
+  )
 }
 
 function getVisitorTypeName(person: PresentPerson): string | undefined {
@@ -248,6 +255,8 @@ export const PersonCard = memo(function PersonCard({
   const visitorTitle = getVisitorTitle(person, displayName)
   const visitorSubtitle = getVisitorSubtitle(person)
   const visitorSummary = getVisitorSummary(person)
+  const memberTypeInfo = isMember ? person.memberTypeInfo : undefined
+  const shouldShowMemberTypeBadge = Boolean(memberTypeInfo && !hasNonDutyWatchTag(person))
 
   // Determine which tag the avatar is displaying (if any) to suppress from chip row
   const avatarTagId = (() => {
@@ -356,6 +365,16 @@ export const PersonCard = memo(function PersonCard({
                     {tag.name}
                   </Chip>
                 ))}
+              {shouldShowMemberTypeBadge && memberTypeInfo && (
+                <Chip
+                  size="sm"
+                  variant={(memberTypeInfo.chipVariant as ChipVariant) || 'solid'}
+                  color={(memberTypeInfo.chipColor as ChipColor) || 'default'}
+                  className="chip-enhanced"
+                >
+                  {memberTypeInfo.name}
+                </Chip>
+              )}
             </div>
           ) : (
             <div className="flex min-w-0 flex-col gap-1 text-xs text-base-content/70">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.0.7",
+  "version": "3.0.9",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.0.7",
+  "version": "3.0.9",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/contracts/src/schemas/checkin.schema.ts
+++ b/packages/contracts/src/schemas/checkin.schema.ts
@@ -178,6 +178,15 @@ export const PresentPersonSchema = v.object({
   divisionCode: v.optional(v.string()),
   divisionId: v.optional(v.string()),
   memberType: v.optional(v.string()),
+  memberTypeInfo: v.optional(
+    v.object({
+      id: v.string(),
+      code: v.string(),
+      name: v.string(),
+      chipVariant: v.optional(v.string()),
+      chipColor: v.optional(v.string()),
+    })
+  ),
   tags: v.optional(
     v.array(
       v.object({

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.0.7",
+  "version": "3.0.9",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.0.7",
+  "version": "3.0.9",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Adds a Member Type chip to Dashboard person cards when a member has no non-duty-watch tag.
- Keeps duty-watch responsibility tags (`SWK`, `DSWK`, `QM`, `BM`, `APS`) out of the fallback tag calculation.
- Uses the same configured Member Type chip style shown in the Config page Member Type preview.
- Prepares the workspace package versions for Sentinel `v3.0.9`.

## Why this change was needed

Dashboard cards could look visually unclassified for members who did not have a normal tag. Member Type is already configured by administrators with a chip preview, so the dashboard should use that same visual language as a fallback while ignoring duty-watch responsibility tags.

## What changed

### User-facing

- Member cards now show the configured Member Type chip when the member has no tag other than duty-watch responsibility tags.
- Members with a real direct tag keep showing their tag behavior instead of a Member Type fallback.

### Admin/operator-facing

- Member Type chip color and variant continue to come from the Config page Member Type tab.
- Workspace package metadata is updated to `3.0.9` for release tagging.

### Backend/API

- The present-people dashboard response now includes `memberTypeInfo` with the member type id, code, display name, chip variant, and chip color.
- The present-members query joins configured member type metadata by `member_type_id`, falling back to the legacy member type code when needed.

### Database

- No database migration required.

### Deployment/update

- No configuration change required.
- Normal service restart/update flow is sufficient.

### Documentation

- No documentation files changed.

### Tests

- Ran focused contract, backend, and frontend TypeScript checks.
- Ran backend and frontend lint; both completed with existing warnings only.

## User impact

Dashboard users will see Member Type badges on cards for members who do not have a normal tag. Duty-watch-only members still get a Member Type fallback instead of appearing untagged.

## Operator impact

Administrators can control the fallback badge appearance from the existing Member Type configuration. Operators do not need to change settings unless they want different chip colors or variants.

## Upgrade or migration notes

No upgrade action required beyond deploying `v3.0.9`. No database migration or configuration change is required.

## Risk and rollback notes

Main risk is dashboard card display behavior if member type metadata is missing or stale. The frontend treats the new payload field as optional, so older or incomplete data will simply omit the fallback chip.

Rollback is safe by returning to the previous release tag. No data compatibility concerns are expected.

## Testing performed

- `pnpm version:check`
- `pnpm --filter @sentinel/contracts typecheck`
- `pnpm --filter @sentinel/backend typecheck`
- `pnpm --filter frontend-admin typecheck`
- `pnpm --filter @sentinel/backend lint` (existing warnings only)
- `pnpm --filter frontend-admin lint` (existing warnings only)

## Changelog candidates

- Added Member Type fallback badges to Dashboard member cards. This helps operators identify untagged members using the same Member Type chip style configured in Settings.
- Updated the dashboard presence API to include configured Member Type chip metadata. This keeps Dashboard display aligned with administrator configuration.
- Prepared Sentinel package metadata for release `v3.0.9`.
