### PR TITLE
Release v3.1.0 Admin settings polish

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.0.10",
+  "version": "3.1.0",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/frontend-admin/README.md
+++ b/apps/frontend-admin/README.md
@@ -28,7 +28,7 @@ Frontend Admin is the operational web interface for Sentinel, including dashboar
 - `/schedules` - Schedule and duty-watch planning
 - `/dds` - DDS checklist and handover-focused workflows
 - `/kiosk` - Touch-first kiosk mode
-- `/admin` - Admin Control Center for updates, network, badges, diagnostics, and system definitions
+- `/admin` - Admin Control Centre for updates, network, badges, diagnostics, and system definitions
 - `/badges`, `/database`, `/settings`, `/logs` - Legacy redirects into `/admin/**`
 
 ## Kiosk (Current)

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.0.10",
+  "version": "3.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/app/admin/account-levels/page.tsx
+++ b/apps/frontend-admin/src/app/admin/account-levels/page.tsx
@@ -1,0 +1,5 @@
+import { AdminAccountLevelsPage } from '@/components/admin/admin-account-levels-page'
+
+export default function AdminAccountLevelsRoute() {
+  return <AdminAccountLevelsPage />
+}

--- a/apps/frontend-admin/src/app/admin/dashboard-sorting/page.tsx
+++ b/apps/frontend-admin/src/app/admin/dashboard-sorting/page.tsx
@@ -1,0 +1,5 @@
+import { AdminDashboardSortingPage } from '@/components/admin/admin-dashboard-sorting-page'
+
+export default function AdminDashboardSortingRoute() {
+  return <AdminDashboardSortingPage />
+}

--- a/apps/frontend-admin/src/app/admin/timings/page.tsx
+++ b/apps/frontend-admin/src/app/admin/timings/page.tsx
@@ -1,0 +1,5 @@
+import { AdminTimingsPage } from '@/components/admin/admin-timings-page'
+
+export default function AdminTimingsRoute() {
+  return <AdminTimingsPage />
+}

--- a/apps/frontend-admin/src/components/admin/admin-account-levels-page.tsx
+++ b/apps/frontend-admin/src/components/admin/admin-account-levels-page.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { AccountLevelSettingsPanel } from '@/components/settings/account-level-settings-panel'
+
+export function AdminAccountLevelsPage() {
+  return (
+    <div className="space-y-(--space-4)">
+      <div>
+        <h1 id="admin-page-title" className="font-display text-3xl font-bold">
+          Account Levels
+        </h1>
+        <p className="mt-(--space-1) max-w-3xl text-sm text-base-content/65">
+          Review access by level and reassign member account levels.
+        </p>
+      </div>
+
+      <AccountLevelSettingsPanel />
+    </div>
+  )
+}

--- a/apps/frontend-admin/src/components/admin/admin-config-page.tsx
+++ b/apps/frontend-admin/src/components/admin/admin-config-page.tsx
@@ -1,28 +1,22 @@
 'use client'
 
-import { Suspense } from 'react'
+import { Suspense, useEffect } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import {
-  ArrowUpDown,
   Award,
   BadgeCheck,
   Building,
   Calendar,
   CalendarClock,
-  Clock3,
-  Shield,
   Tag,
   UserCheck,
   Users,
 } from 'lucide-react'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { AccountLevelSettingsPanel } from '@/components/settings/account-level-settings-panel'
-import { DashboardPersonCardSortSettingsPanel } from '@/components/settings/dashboard-person-card-sort-settings-panel'
 import { EnumTable } from '@/components/settings/enum-table'
 import { EventTypeTable } from '@/components/settings/event-type-table'
 import { QualificationTypeTable } from '@/components/settings/qualification-type-table'
 import { StatHolidayTable } from '@/components/settings/stat-holiday-table'
-import { TimingsSettingsPanel } from '@/components/settings/timings-settings-panel'
 import { LoadingSpinner } from '@/components/ui/loading-spinner'
 import { TID } from '@/lib/test-ids'
 
@@ -35,10 +29,13 @@ const CONFIG_TAB_VALUES = [
   'qualifications',
   'tags',
   'stat-holidays',
-  'timings',
-  'account-levels',
-  'dashboard-sorting',
 ] as const
+
+const PROMOTED_CONFIG_TAB_PATHS = {
+  timings: '/admin/timings',
+  'account-levels': '/admin/account-levels',
+  'dashboard-sorting': '/admin/dashboard-sorting',
+} as const
 
 type ConfigTabValue = (typeof CONFIG_TAB_VALUES)[number]
 
@@ -51,6 +48,31 @@ function AdminConfigPageContent() {
   const searchParams = useSearchParams()
   const requestedTab = searchParams.get('tab')
   const currentTab: ConfigTabValue = isConfigTabValue(requestedTab) ? requestedTab : 'member-types'
+
+  useEffect(() => {
+    if (!isPromotedConfigTabValue(requestedTab)) {
+      return
+    }
+
+    const params = new globalThis.URLSearchParams(searchParams.toString())
+    params.delete('tab')
+
+    const queryString = params.toString()
+    router.replace(
+      queryString
+        ? `${PROMOTED_CONFIG_TAB_PATHS[requestedTab]}?${queryString}`
+        : PROMOTED_CONFIG_TAB_PATHS[requestedTab],
+      { scroll: false }
+    )
+  }, [requestedTab, router, searchParams])
+
+  if (isPromotedConfigTabValue(requestedTab)) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <LoadingSpinner size="lg" className="text-base-content/60" />
+      </div>
+    )
+  }
 
   const handleTabChange = (nextTab: string) => {
     if (!isConfigTabValue(nextTab)) {
@@ -75,11 +97,10 @@ function AdminConfigPageContent() {
     <div className="space-y-(--space-4)">
       <div>
         <h1 id="admin-page-title" className="font-display text-3xl font-bold">
-          System Definitions
+          Lists & Types
         </h1>
         <p className="mt-(--space-1) max-w-3xl text-sm text-base-content/65">
-          Manage the shared lists, categories, defaults, and account-level definitions that shape
-          Sentinel operations.
+          Manage the shared lists, categories, and types that shape Sentinel records and workflows.
         </p>
       </div>
 
@@ -120,22 +141,6 @@ function AdminConfigPageContent() {
           <TabsTrigger value="stat-holidays" className="flex items-center gap-2">
             <Calendar className="h-4 w-4" />
             <span className="hidden sm:inline">Stat Holidays</span>
-          </TabsTrigger>
-          <TabsTrigger
-            value="timings"
-            className="flex items-center gap-2"
-            data-testid={TID.settings.timings.tab}
-          >
-            <Clock3 className="h-4 w-4" />
-            <span className="hidden sm:inline">Timings</span>
-          </TabsTrigger>
-          <TabsTrigger value="account-levels" className="flex items-center gap-2">
-            <Shield className="h-4 w-4" />
-            <span className="hidden sm:inline">Account Levels</span>
-          </TabsTrigger>
-          <TabsTrigger value="dashboard-sorting" className="flex items-center gap-2">
-            <ArrowUpDown className="h-4 w-4" />
-            <span className="hidden sm:inline">Dashboard Sorting</span>
           </TabsTrigger>
         </TabsList>
 
@@ -199,21 +204,15 @@ function AdminConfigPageContent() {
             description="Holidays that affect DDS handover timing and operational days"
           />
         </TabsContent>
-
-        <TabsContent value="timings">
-          <TimingsSettingsPanel />
-        </TabsContent>
-
-        <TabsContent value="account-levels">
-          <AccountLevelSettingsPanel />
-        </TabsContent>
-
-        <TabsContent value="dashboard-sorting">
-          <DashboardPersonCardSortSettingsPanel />
-        </TabsContent>
       </Tabs>
     </div>
   )
+}
+
+function isPromotedConfigTabValue(
+  value: string | null
+): value is keyof typeof PROMOTED_CONFIG_TAB_PATHS {
+  return value !== null && value in PROMOTED_CONFIG_TAB_PATHS
 }
 
 export function AdminConfigPage() {

--- a/apps/frontend-admin/src/components/admin/admin-control-center.tsx
+++ b/apps/frontend-admin/src/components/admin/admin-control-center.tsx
@@ -936,7 +936,7 @@ export function AdminControlCenter() {
 
       {!canAccessAdmin && (
         <AppAlert tone="warning" heading="Admin access required">
-          Sign in with an Admin or Developer account to use the Admin Control Center.
+          Sign in with an Admin or Developer account to use the Admin Control Centre.
         </AppAlert>
       )}
 
@@ -1425,6 +1425,9 @@ function getRouteIdForAction(action: AdminQuickAction): AdminRouteId {
   if (action.href.startsWith('/admin/logs')) return 'logs'
   if (action.href.startsWith('/admin/database')) return 'database'
   if (action.href.startsWith('/admin/badges')) return 'badges'
+  if (action.href.startsWith('/admin/timings')) return 'timings'
+  if (action.href.startsWith('/admin/account-levels')) return 'account-levels'
+  if (action.href.startsWith('/admin/dashboard-sorting')) return 'dashboard-sorting'
   if (action.href.startsWith('/admin/config')) return 'config'
 
   return 'admin-home'

--- a/apps/frontend-admin/src/components/admin/admin-dashboard-sorting-page.tsx
+++ b/apps/frontend-admin/src/components/admin/admin-dashboard-sorting-page.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { DashboardPersonCardSortSettingsPanel } from '@/components/settings/dashboard-person-card-sort-settings-panel'
+
+export function AdminDashboardSortingPage() {
+  return (
+    <div className="space-y-(--space-4)">
+      <div>
+        <h1 id="admin-page-title" className="font-display text-3xl font-bold">
+          Dashboard Sorting
+        </h1>
+        <p className="mt-(--space-1) max-w-3xl text-sm text-base-content/65">
+          Control how member cards are sorted on the dashboard.
+        </p>
+      </div>
+
+      <DashboardPersonCardSortSettingsPanel />
+    </div>
+  )
+}

--- a/apps/frontend-admin/src/components/admin/admin-icons.tsx
+++ b/apps/frontend-admin/src/components/admin/admin-icons.tsx
@@ -1,8 +1,10 @@
 import type { ComponentPropsWithoutRef } from 'react'
 import {
   Activity,
+  ArrowUpDown,
   BadgePlus,
   BookOpen,
+  Clock3,
   Database,
   Download,
   ListChecks,
@@ -21,10 +23,14 @@ export function AdminIcon({ icon, ...props }: AdminIconProps) {
   switch (icon) {
     case 'activity':
       return <Activity {...props} />
+    case 'arrow-up-down':
+      return <ArrowUpDown {...props} />
     case 'badge':
       return <BadgePlus {...props} />
     case 'book-open':
       return <BookOpen {...props} />
+    case 'clock':
+      return <Clock3 {...props} />
     case 'database':
       return <Database {...props} />
     case 'download':

--- a/apps/frontend-admin/src/components/admin/admin-shell.tsx
+++ b/apps/frontend-admin/src/components/admin/admin-shell.tsx
@@ -34,7 +34,7 @@ export function AdminShell({ children }: AdminShellProps) {
             Admin
           </p>
           <div className="mt-(--space-1) flex items-center justify-between gap-(--space-2)">
-            <h2 className="font-display text-xl font-bold leading-tight">Control Center</h2>
+            <h2 className="font-display text-xl font-bold leading-tight">Control Centre</h2>
           </div>
         </div>
 
@@ -85,15 +85,19 @@ function AdminSidebarLink({
   currentRouteId: AdminNavRoute['id']
   active: boolean
 }) {
+  const descriptionId = `admin-sidebar-${route.id}-description`
+
   return (
     <li>
       <Link
         href={route.href}
         className={cn(
-          'grid min-h-14 grid-cols-[1.1rem_minmax(0,1fr)] items-center gap-(--space-3) rounded-box border-l-4 border-l-transparent px-(--space-3) py-(--space-2) text-base-content/90 transition-colors duration-(--duration-fast) hover:bg-base-200 hover:text-base-content',
+          'tooltip tooltip-right grid min-h-12 grid-cols-[1.1rem_minmax(0,1fr)] items-center gap-(--space-3) rounded-box border-l-4 border-l-transparent px-(--space-3) py-(--space-2) text-left text-base-content/90 transition-colors duration-(--duration-fast) hover:z-(--z-tooltip) hover:bg-base-200 hover:text-base-content focus-visible:z-(--z-tooltip)',
           active && 'border-l-primary bg-base-200 text-base-content shadow-[var(--shadow-1)]'
         )}
         aria-current={active ? 'page' : undefined}
+        aria-describedby={descriptionId}
+        data-tip={route.description}
         onClick={() => {
           recordAdminNavigationTelemetry({
             eventType: 'nav_click',
@@ -111,12 +115,7 @@ function AdminSidebarLink({
           <span className={cn('block truncate text-sm font-semibold', active && 'font-bold')}>
             {route.label}
           </span>
-          <span
-            className={cn(
-              'block truncate text-xs leading-snug text-base-content/62',
-              active && 'text-base-content/78'
-            )}
-          >
+          <span id={descriptionId} className="sr-only">
             {route.description}
           </span>
         </span>

--- a/apps/frontend-admin/src/components/admin/admin-timings-page.tsx
+++ b/apps/frontend-admin/src/components/admin/admin-timings-page.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { TimingsSettingsPanel } from '@/components/settings/timings-settings-panel'
+
+export function AdminTimingsPage() {
+  return (
+    <div className="space-y-(--space-4)">
+      <div>
+        <h1 id="admin-page-title" className="font-display text-3xl font-bold">
+          Timings
+        </h1>
+        <p className="mt-(--space-1) max-w-3xl text-sm text-base-content/65">
+          Manage scheduler cutoffs, Duty Watch timing, working hours, and duplicate-alert limits.
+        </p>
+      </div>
+
+      <TimingsSettingsPanel />
+    </div>
+  )
+}

--- a/apps/frontend-admin/src/components/admin/legacy-admin-redirect.tsx
+++ b/apps/frontend-admin/src/components/admin/legacy-admin-redirect.tsx
@@ -32,7 +32,7 @@ export function LegacyAdminRedirect() {
     <div className="flex min-h-80 items-center justify-center">
       <div className="flex items-center gap-(--space-3) text-sm text-base-content/70">
         <LoadingSpinner size="sm" className="text-base-content/60" />
-        <span>Opening Admin Control Center...</span>
+        <span>Opening Admin Control Centre...</span>
       </div>
     </div>
   )
@@ -44,6 +44,9 @@ function getTargetRouteId(target: string): AdminNavigationRouteId {
   if (target.startsWith('/admin/logs')) return 'logs'
   if (target.startsWith('/admin/database')) return 'database'
   if (target.startsWith('/admin/badges')) return 'badges'
+  if (target.startsWith('/admin/timings')) return 'timings'
+  if (target.startsWith('/admin/account-levels')) return 'account-levels'
+  if (target.startsWith('/admin/dashboard-sorting')) return 'dashboard-sorting'
   if (target.startsWith('/admin/config')) return 'config'
 
   return 'admin-home'

--- a/apps/frontend-admin/src/components/settings/dashboard-person-card-sort-settings-panel.tsx
+++ b/apps/frontend-admin/src/components/settings/dashboard-person-card-sort-settings-panel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
   closestCenter,
   DndContext,
@@ -19,7 +19,16 @@ import {
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { useQuery } from '@tanstack/react-query'
-import { GripVertical, Plus, Save, X, PencilLine } from 'lucide-react'
+import {
+  ChevronDown,
+  ChevronUp,
+  GripVertical,
+  Layers,
+  PencilLine,
+  Plus,
+  Save,
+  X,
+} from 'lucide-react'
 import { toast } from 'sonner'
 import type { EnumResponse, TagResponse } from '@sentinel/contracts'
 import {
@@ -29,6 +38,7 @@ import {
   AppCardHeader,
   AppCardTitle,
 } from '@/components/ui/AppCard'
+import { Chip, type ChipColor, type ChipVariant } from '@/components/ui/chip'
 import { ButtonSpinner } from '@/components/ui/loading-spinner'
 import {
   useDashboardPersonCardSort,
@@ -45,6 +55,244 @@ import {
   type DashboardSortCriterionType,
 } from '@/lib/dashboard-person-card-sort'
 import { cn } from '@/lib/utils'
+
+type DashboardSortCriterionOption = (typeof DASHBOARD_SORT_CRITERIA_OPTIONS)[number]
+type CriterionLibraryCategory = 'grouping' | 'sorting' | 'special'
+
+const VISITOR_OR_SPECIAL_CRITERIA = new Set<DashboardSortCriterionType>([
+  'active_dds',
+  'scheduled_dds',
+  'scheduled_duty_watch',
+  'visitor',
+  'visit_type',
+])
+
+const STANDARD_WITHIN_GROUP_SORT_TYPES = [
+  'rank',
+  'last_name',
+  'first_name',
+] as const satisfies readonly DashboardSortCriterionType[]
+
+const CRITERION_LIBRARY_SECTIONS: Array<{
+  category: CriterionLibraryCategory
+  title: string
+  description: string
+}> = [
+  {
+    category: 'grouping',
+    title: 'Grouping rules',
+    description: 'Create dashboard groups and can sort cards within each group.',
+  },
+  {
+    category: 'sorting',
+    title: 'Sorting rules',
+    description: 'Order cards without creating a separate dashboard group.',
+  },
+  {
+    category: 'special',
+    title: 'Visitor / special rules',
+    description: 'Handle visitor cards, duty roles, and daily responsibility groups.',
+  },
+]
+
+function getCriterionOption(type: DashboardSortCriterionType): DashboardSortCriterionOption | null {
+  return DASHBOARD_SORT_CRITERIA_OPTIONS.find((candidate) => candidate.type === type) ?? null
+}
+
+function getCriterionLibraryCategory(
+  option: DashboardSortCriterionOption
+): CriterionLibraryCategory {
+  if (VISITOR_OR_SPECIAL_CRITERIA.has(option.type)) {
+    return 'special'
+  }
+
+  return option.allowChildren ? 'grouping' : 'sorting'
+}
+
+function getCriterionCapabilityLabel(option: DashboardSortCriterionOption): string {
+  const category = getCriterionLibraryCategory(option)
+
+  if (category === 'special') {
+    return 'Special'
+  }
+
+  return option.allowChildren ? 'Can group' : 'Sort only'
+}
+
+function hasStandardWithinGroupSort(children: DashboardSortCriterion[]): boolean {
+  return (
+    children.length === STANDARD_WITHIN_GROUP_SORT_TYPES.length &&
+    STANDARD_WITHIN_GROUP_SORT_TYPES.every((type, index) => children[index]?.type === type)
+  )
+}
+
+function getConfiguredValueLabel(input: {
+  criterion: DashboardSortCriterion
+  selectedTag: TagResponse | undefined
+  selectedVisitType: EnumResponse | undefined
+}): string | null {
+  const { criterion, selectedTag, selectedVisitType } = input
+
+  if (criterion.type === 'specific_tag') {
+    return selectedTag?.name ?? 'No tag selected'
+  }
+
+  if (criterion.type === 'visit_type') {
+    return selectedVisitType?.name ?? 'unavailable'
+  }
+
+  return null
+}
+
+function getCriterionDisplayName(input: {
+  criterion: DashboardSortCriterion
+  option: DashboardSortCriterionOption | null
+  selectedTag: TagResponse | undefined
+  selectedVisitType: EnumResponse | undefined
+}): string {
+  const configuredValue = getConfiguredValueLabel(input)
+  const label = input.option?.label ?? input.criterion.type
+
+  return configuredValue ? `${label}: ${configuredValue}` : label
+}
+
+function getSortRuleLabel(
+  criterion: DashboardSortCriterion,
+  allTags: TagResponse[],
+  visitTypes: EnumResponse[]
+): string {
+  return getCriterionDisplayName({
+    criterion,
+    option: getCriterionOption(criterion.type),
+    selectedTag: allTags.find((tag) => tag.id === criterion.config?.tagId),
+    selectedVisitType: visitTypes.find(
+      (visitType) => visitType.id === criterion.config?.visitTypeId
+    ),
+  })
+}
+
+function getChildSortReviewDescription(
+  criterion: DashboardSortCriterion,
+  option: DashboardSortCriterionOption | null,
+  position: number | undefined
+): string {
+  const prefix = position && position > 1 ? 'Then sorts' : 'Sorts'
+
+  switch (criterion.type) {
+    case 'rank':
+      return `${prefix} matching cards by rank seniority from highest to lowest.`
+    case 'last_name':
+      return `${prefix} matching cards alphabetically by last name.`
+    case 'first_name':
+      return `${prefix} matching cards alphabetically by first name.`
+    case 'department':
+      return `${prefix} matching cards alphabetically by division or department.`
+    case 'specific_tag':
+      return `${prefix} matching cards by the selected tag.`
+    case 'visit_type':
+      return `${prefix} matching visitor cards by the selected visit type.`
+    default:
+      return option?.description ?? `${prefix} matching cards with this rule.`
+  }
+}
+
+function buildSortSequence(input: {
+  criteria: DashboardSortCriterion[]
+  allTags: TagResponse[]
+  visitTypes: EnumResponse[]
+}): string[] {
+  return input.criteria.map((criterion) =>
+    getSortRuleLabel(criterion, input.allTags, input.visitTypes)
+  )
+}
+
+function buildDashboardOrderSteps(input: {
+  criteria: DashboardSortCriterion[]
+  allTags: TagResponse[]
+  visitTypes: EnumResponse[]
+}): string[] {
+  return input.criteria
+    .filter((criterion) => getCriterionOption(criterion.type)?.allowChildren)
+    .map((criterion) => getSortRuleLabel(criterion, input.allTags, input.visitTypes))
+}
+
+function renderConfiguredValue(input: {
+  criterion: DashboardSortCriterion
+  selectedTag: TagResponse | undefined
+  selectedVisitType: EnumResponse | undefined
+}) {
+  const { criterion, selectedTag, selectedVisitType } = input
+
+  if (criterion.type === 'specific_tag') {
+    if (!selectedTag) {
+      return <span className="text-xs font-medium text-base-content/55">No tag selected</span>
+    }
+
+    return (
+      <Chip
+        size="sm"
+        variant="faded"
+        color={(selectedTag.chipColor as ChipColor) || 'default'}
+        className="chip-enhanced"
+      >
+        {selectedTag.name}
+      </Chip>
+    )
+  }
+
+  if (criterion.type === 'visit_type') {
+    if (!selectedVisitType) {
+      return (
+        <span className="text-xs font-medium text-base-content/55">Visit type unavailable</span>
+      )
+    }
+
+    return (
+      <Chip
+        size="sm"
+        variant={(selectedVisitType.chipVariant as ChipVariant) || 'faded'}
+        color={(selectedVisitType.chipColor as ChipColor) || 'default'}
+        className="chip-enhanced"
+      >
+        {selectedVisitType.name}
+      </Chip>
+    )
+  }
+
+  return null
+}
+
+function CriterionSummaryMeta({
+  criterion,
+  selectedTag,
+  selectedVisitType,
+}: {
+  criterion: DashboardSortCriterion
+  selectedTag: TagResponse | undefined
+  selectedVisitType: EnumResponse | undefined
+}) {
+  const configuredValue = renderConfiguredValue({ criterion, selectedTag, selectedVisitType })
+  const hasNote = criterion.note.trim().length > 0
+  const metadataParts = [
+    criterion.children.length > 0
+      ? `${criterion.children.length} ${criterion.children.length === 1 ? 'Rule' : 'Rules'} within`
+      : null,
+    hasNote ? 'Note' : null,
+  ].filter((part): part is string => part !== null)
+
+  if (!configuredValue && criterion.children.length === 0 && !hasNote) {
+    return null
+  }
+
+  return (
+    <div className="flex w-full flex-wrap items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center gap-2">{configuredValue}</div>
+      <div className="ml-auto flex flex-wrap items-center justify-end gap-2 text-xs font-medium text-base-content/55">
+        {metadataParts.length > 0 ? <span>{metadataParts.join(' + ')}</span> : null}
+      </div>
+    </div>
+  )
+}
 
 function createCriterionId(): string {
   if (
@@ -157,6 +405,7 @@ function SortableCriterionCard({
   allTags,
   visitTypes,
   depth,
+  position,
   collapsedCriterionIds,
   onChange,
   onRemove,
@@ -168,6 +417,7 @@ function SortableCriterionCard({
   allTags: TagResponse[]
   visitTypes: EnumResponse[]
   depth: number
+  position?: number
   collapsedCriterionIds: Set<string>
   onChange: (
     criterionId: string,
@@ -182,9 +432,7 @@ function SortableCriterionCard({
     transform: CSS.Transform.toString(sortable.transform),
     transition: sortable.transition,
   }
-  const option = DASHBOARD_SORT_CRITERIA_OPTIONS.find(
-    (candidate) => candidate.type === criterion.type
-  )
+  const option = getCriterionOption(criterion.type)
   const selectedTag = allTags.find((tag) => tag.id === criterion.config?.tagId)
   const selectedVisitType = visitTypes.find(
     (visitType) => visitType.id === criterion.config?.visitTypeId
@@ -194,38 +442,200 @@ function SortableCriterionCard({
   const canAddChildren = editable && option?.allowChildren && depth === 0
   const showNoteField = depth === 0
   const showSubSorting = depth === 0
+  const displayName = getCriterionDisplayName({
+    criterion,
+    option,
+    selectedTag,
+    selectedVisitType,
+  })
+  const configuredValue = renderConfiguredValue({ criterion, selectedTag, selectedVisitType })
+  const note = criterion.note.trim()
+  const isGroupingRule = Boolean(option?.allowChildren)
+  const contentId = `${criterion.id}-dashboard-sort-content`
+  const sortSequence = buildSortSequence({ criteria: criterion.children, allTags, visitTypes })
+  const usesStandardWithinGroupSort = hasStandardWithinGroupSort(criterion.children)
+  const canToggleStandardWithinGroupSort =
+    editable && (criterion.children.length === 0 || usesStandardWithinGroupSort)
+
+  if (!isTopLevel) {
+    return (
+      <div
+        ref={sortable.setNodeRef}
+        style={style}
+        className="border-t border-base-300/70 first:border-t-0"
+      >
+        <div className="flex items-start gap-(--space-3) px-(--space-3) py-(--space-2)">
+          {typeof position === 'number' ? (
+            <span
+              className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-box bg-base-200/65 text-xs font-bold text-base-content/60"
+              aria-hidden="true"
+            >
+              {position}
+            </span>
+          ) : null}
+          {editable ? (
+            <button
+              type="button"
+              className="btn btn-ghost btn-xs btn-square mt-0.5 shrink-0"
+              {...sortable.attributes}
+              {...sortable.listeners}
+              aria-label={`Reorder ${displayName}`}
+            >
+              <GripVertical className="h-3.5 w-3.5" />
+            </button>
+          ) : null}
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-(--space-2)">
+              <p className="text-sm font-semibold leading-tight text-base-content">{displayName}</p>
+              {configuredValue}
+            </div>
+            <p className="mt-0.5 text-xs leading-snug text-base-content/62">
+              {editable
+                ? (option?.description ?? criterion.type)
+                : getChildSortReviewDescription(criterion, option, position)}
+            </p>
+
+            {editable && (criterion.type === 'specific_tag' || criterion.type === 'visit_type') ? (
+              <div className="mt-(--space-2) grid gap-(--space-2) xl:max-w-sm">
+                {criterion.type === 'specific_tag' ? (
+                  <select
+                    className="select select-sm"
+                    value={criterion.config?.tagId ?? ''}
+                    onChange={(event) =>
+                      onChange(criterion.id, (current) => ({
+                        ...current,
+                        config: {
+                          ...current.config,
+                          tagId: event.target.value || undefined,
+                        },
+                      }))
+                    }
+                  >
+                    <option value="">Select tag</option>
+                    {allTags.map((tag) => (
+                      <option key={tag.id} value={tag.id}>
+                        {tag.name}
+                      </option>
+                    ))}
+                  </select>
+                ) : null}
+
+                {criterion.type === 'visit_type' ? (
+                  <select
+                    className="select select-sm"
+                    value={criterion.config?.visitTypeId ?? ''}
+                    onChange={(event) =>
+                      onChange(criterion.id, (current) => ({
+                        ...current,
+                        config: {
+                          ...current.config,
+                          visitTypeId: event.target.value || undefined,
+                        },
+                      }))
+                    }
+                  >
+                    <option value="">Select visit type</option>
+                    {visitTypes.map((visitType) => (
+                      <option key={visitType.id} value={visitType.id}>
+                        {visitType.name}
+                      </option>
+                    ))}
+                  </select>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+          {editable ? (
+            <button
+              type="button"
+              className="btn btn-ghost btn-xs shrink-0 text-error"
+              onClick={() => onRemove(criterion.id)}
+            >
+              Remove
+            </button>
+          ) : null}
+        </div>
+      </div>
+    )
+  }
 
   const content = (
-    <div className="grid gap-3 p-3">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="flex items-start gap-3">
-          <button
-            type="button"
-            className={cn(
-              'btn btn-ghost btn-sm btn-square',
-              !editable && 'pointer-events-none opacity-40'
-            )}
-            {...sortable.attributes}
-            {...sortable.listeners}
-            aria-label={`Reorder ${option?.label ?? criterion.type}`}
-          >
-            <GripVertical className="h-4 w-4" />
-          </button>
-          <div>
-            <p className="font-medium">{option?.label ?? criterion.type}</p>
-            <p className="text-sm text-base-content/60">{option?.description}</p>
-          </div>
-        </div>
-        <div className="flex items-center gap-2">
+    <div className="grid gap-3 p-(--space-3)">
+      <div className="flex flex-wrap items-start justify-between gap-(--space-3)">
+        <div className="flex min-w-0 flex-1 items-start gap-(--space-3)">
+          {isTopLevel && typeof position === 'number' ? (
+            <span
+              className={cn(
+                'flex h-8 w-8 shrink-0 items-center justify-center rounded-box border text-sm font-bold',
+                isGroupingRule
+                  ? 'border-primary/30 bg-primary/10 text-primary'
+                  : 'border-base-300 bg-base-200/65 text-base-content/65'
+              )}
+              aria-hidden="true"
+            >
+              {position}
+            </span>
+          ) : null}
+          {editable ? (
+            <button
+              type="button"
+              className="btn btn-ghost btn-sm btn-square shrink-0"
+              {...sortable.attributes}
+              {...sortable.listeners}
+              aria-label={`Reorder ${displayName}`}
+            >
+              <GripVertical className="h-4 w-4" />
+            </button>
+          ) : null}
           {isTopLevel ? (
             <button
               type="button"
-              className="btn btn-ghost btn-xs"
+              className="group grid min-w-0 flex-1 grid-cols-[minmax(0,1fr)_auto] items-start gap-(--space-3) rounded-box text-left transition-colors duration-(--duration-fast) hover:bg-base-200/65 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
               onClick={() => onToggleCollapse(criterion.id)}
+              aria-controls={contentId}
+              aria-expanded={!isCollapsed}
+              aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${displayName} rule`}
             >
-              {isCollapsed ? 'Expand' : 'Collapse'}
+              <span className="min-w-0 p-(--space-2)">
+                <span className="block font-semibold leading-tight text-base-content">
+                  {displayName}
+                </span>
+                <span className="mt-0.5 block text-sm leading-snug text-base-content/62">
+                  {option?.description ?? criterion.type}
+                </span>
+                <span className="mt-(--space-2) block">
+                  <CriterionSummaryMeta
+                    criterion={criterion}
+                    selectedTag={selectedTag}
+                    selectedVisitType={selectedVisitType}
+                  />
+                </span>
+              </span>
+              <span className="flex h-8 w-8 items-center justify-center p-(--space-2) text-base-content/55 group-hover:text-base-content">
+                {isCollapsed ? (
+                  <ChevronDown className="h-4 w-4" />
+                ) : (
+                  <ChevronUp className="h-4 w-4" />
+                )}
+              </span>
             </button>
-          ) : null}
+          ) : (
+            <div className="min-w-0">
+              <p className="font-semibold leading-tight text-base-content">{displayName}</p>
+              <p className="mt-0.5 text-sm leading-snug text-base-content/62">
+                {option?.description ?? criterion.type}
+              </p>
+              <div className="mt-(--space-2)">
+                <CriterionSummaryMeta
+                  criterion={criterion}
+                  selectedTag={selectedTag}
+                  selectedVisitType={selectedVisitType}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
           {editable ? (
             <button
               type="button"
@@ -239,11 +649,25 @@ function SortableCriterionCard({
       </div>
 
       {!isCollapsed ? (
-        <>
-          {criterion.type === 'specific_tag' || criterion.type === 'visit_type' || showNoteField ? (
+        <div id={contentId} className="grid gap-(--space-3)">
+          {!editable && note ? (
+            <div className="grid gap-(--space-2) rounded-box bg-base-200/45 p-(--space-3)">
+              <div className="rounded-box border border-success/20 bg-success/10 px-(--space-3) py-(--space-2)">
+                <p className="text-xs font-semibold uppercase tracking-wide text-base-content/45">
+                  Note
+                </p>
+                <p className="mt-1 text-sm leading-relaxed text-base-content/75">{note}</p>
+              </div>
+            </div>
+          ) : null}
+
+          {editable &&
+          (criterion.type === 'specific_tag' ||
+            criterion.type === 'visit_type' ||
+            showNoteField) ? (
             <div
               className={cn(
-                'grid gap-3',
+                'grid gap-(--space-3) rounded-box border border-base-300 bg-base-200/45 p-(--space-3)',
                 showNoteField ? 'xl:grid-cols-[minmax(0,14rem)_minmax(0,1fr)]' : 'xl:grid-cols-1'
               )}
             >
@@ -309,11 +733,10 @@ function SortableCriterionCard({
 
               {showNoteField ? (
                 <fieldset className="fieldset">
-                  <legend className="fieldset-legend">Note</legend>
+                  <legend className="fieldset-legend">Optional note</legend>
                   <textarea
                     className="textarea textarea-sm min-h-20"
                     value={criterion.note}
-                    disabled={!editable}
                     onChange={(event) =>
                       onChange(criterion.id, (current) => ({
                         ...current,
@@ -327,36 +750,77 @@ function SortableCriterionCard({
             </div>
           ) : null}
 
-          {showSubSorting ? (
-            <div className="grid gap-2 border-t border-base-300 pt-3">
-              <div className="flex flex-wrap items-center justify-between gap-2">
+          {showSubSorting && (editable || criterion.children.length > 0) ? (
+            <div className="ml-(--space-6) grid gap-(--space-3) rounded-box border border-l-2 border-base-300 border-l-primary/40 bg-base-200/65 p-(--space-3)">
+              <div className="flex flex-wrap items-center justify-between gap-(--space-2)">
                 <div>
-                  <p className="text-sm font-medium">Sub-sorting</p>
+                  <p className="text-sm font-semibold">Sort cards within this group</p>
                   <p className="text-xs text-base-content/60">
-                    Criteria added here sort only cards that matched this row.
+                    These rules decide the order of cards after they match {displayName}.
                   </p>
+                  {sortSequence.length > 0 ? (
+                    <p className="mt-(--space-2) text-xs font-semibold text-base-content/70">
+                      Sort sequence: {sortSequence.join(' → ')}
+                    </p>
+                  ) : null}
                 </div>
-                {canAddChildren ? (
-                  <select
-                    className="select select-sm"
-                    defaultValue=""
-                    onChange={(event) => {
-                      const value = event.target.value as DashboardSortCriterionType
-                      if (value) {
-                        onAddChild(criterion.id, value)
-                        event.target.value = ''
+                {editable ? (
+                  <div className="flex flex-wrap items-center justify-end gap-(--space-2)">
+                    <label
+                      className={cn(
+                        'flex items-center gap-(--space-2) rounded-box bg-base-100 px-(--space-3) py-(--space-2) text-xs font-semibold text-base-content/75',
+                        !canToggleStandardWithinGroupSort && 'opacity-55'
+                      )}
+                      title={
+                        canToggleStandardWithinGroupSort
+                          ? 'Enable the standard within-group sort order'
+                          : 'Remove custom within-group rules before applying the standard sequence'
                       }
-                    }}
-                  >
-                    <option value="">Add sub-sort</option>
-                    {DASHBOARD_SORT_CRITERIA_OPTIONS.filter(
-                      (candidate) => candidate.type !== criterion.type
-                    ).map((candidate) => (
-                      <option key={candidate.type} value={candidate.type}>
-                        {candidate.label}
-                      </option>
-                    ))}
-                  </select>
+                    >
+                      <input
+                        type="checkbox"
+                        className="checkbox checkbox-sm"
+                        checked={usesStandardWithinGroupSort}
+                        disabled={!canToggleStandardWithinGroupSort}
+                        onChange={(event) => {
+                          const checked = event.target.checked
+                          onChange(criterion.id, (current) => ({
+                            ...current,
+                            children: checked
+                              ? STANDARD_WITHIN_GROUP_SORT_TYPES.map((type) =>
+                                  createCriterion(type)
+                                )
+                              : hasStandardWithinGroupSort(current.children)
+                                ? []
+                                : current.children,
+                          }))
+                        }}
+                      />
+                      Rank → Last Name → First Name
+                    </label>
+                    {canAddChildren ? (
+                      <select
+                        className="select select-sm"
+                        defaultValue=""
+                        onChange={(event) => {
+                          const value = event.target.value as DashboardSortCriterionType
+                          if (value) {
+                            onAddChild(criterion.id, value)
+                            event.target.value = ''
+                          }
+                        }}
+                      >
+                        <option value="">Add sub-sort</option>
+                        {DASHBOARD_SORT_CRITERIA_OPTIONS.filter(
+                          (candidate) => candidate.type !== criterion.type
+                        ).map((candidate) => (
+                          <option key={candidate.type} value={candidate.type}>
+                            {candidate.label}
+                          </option>
+                        ))}
+                      </select>
+                    ) : null}
+                  </div>
                 ) : null}
               </div>
 
@@ -366,7 +830,7 @@ function SortableCriterionCard({
                   strategy={verticalListSortingStrategy}
                 >
                   <div className="grid gap-2">
-                    {criterion.children.map((child) => (
+                    {criterion.children.map((child, index) => (
                       <SortableCriterionCard
                         key={child.id}
                         criterion={child}
@@ -374,6 +838,7 @@ function SortableCriterionCard({
                         allTags={allTags}
                         visitTypes={visitTypes}
                         depth={depth + 1}
+                        position={index + 1}
                         collapsedCriterionIds={collapsedCriterionIds}
                         onChange={onChange}
                         onRemove={onRemove}
@@ -383,14 +848,14 @@ function SortableCriterionCard({
                     ))}
                   </div>
                 </SortableContext>
-              ) : (
-                <div className="border border-dashed border-base-300 bg-base-200/40 px-3 py-3 text-sm text-base-content/60">
-                  No sub-sorting defined for this criterion.
+              ) : editable ? (
+                <div className="border border-dashed border-base-300 bg-base-100 px-(--space-3) py-(--space-3) text-sm text-base-content/60">
+                  No within-group sorting has been added yet.
                 </div>
-              )}
+              ) : null}
             </div>
           ) : null}
-        </>
+        </div>
       ) : null}
     </div>
   )
@@ -400,19 +865,23 @@ function SortableCriterionCard({
       <div
         ref={sortable.setNodeRef}
         style={style}
-        tabIndex={0}
         className={cn(
-          'collapse collapse-arrow border border-base-300 bg-base-100',
-          isCollapsed ? 'collapse-close' : 'collapse-open'
+          'border border-base-300 bg-base-100 shadow-[var(--shadow-1)]',
+          isGroupingRule && 'border-l-4 border-l-primary',
+          isCollapsed ? 'bg-base-100' : 'bg-base-100'
         )}
       >
-        <div className="collapse-title min-h-0 px-0 py-0">{content}</div>
+        {content}
       </div>
     )
   }
 
   return (
-    <div ref={sortable.setNodeRef} style={style} className="border border-base-300 bg-base-100">
+    <div
+      ref={sortable.setNodeRef}
+      style={style}
+      className="border border-base-300 bg-base-100 shadow-[var(--shadow-1)]"
+    >
       {content}
     </div>
   )
@@ -429,6 +898,7 @@ export function DashboardPersonCardSortSettingsPanel() {
   )
   const [isEditing, setIsEditing] = useState(false)
   const [collapsedCriterionIds, setCollapsedCriterionIds] = useState<string[]>([])
+  const [hasInitializedCollapsedState, setHasInitializedCollapsedState] = useState(false)
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
@@ -462,6 +932,15 @@ export function DashboardPersonCardSortSettingsPanel() {
     () => new Set(collapsedCriterionIds),
     [collapsedCriterionIds]
   )
+
+  useEffect(() => {
+    if (hasInitializedCollapsedState || isLoading || isError) {
+      return
+    }
+
+    setCollapsedCriterionIds(effectiveConfig.criteria.map((criterion) => criterion.id))
+    setHasInitializedCollapsedState(true)
+  }, [effectiveConfig.criteria, hasInitializedCollapsedState, isError, isLoading])
 
   const beginEdit = () => {
     setDraft(cloneDashboardSortConfig(effectiveConfig))
@@ -563,6 +1042,25 @@ export function DashboardPersonCardSortSettingsPanel() {
   }
 
   const activeConfig = isEditing ? draft : effectiveConfig
+  const dashboardOrderSteps = buildDashboardOrderSteps({
+    criteria: activeConfig.criteria,
+    allTags: nonPositionalTags,
+    visitTypes,
+  })
+  const groupedCriteriaOptions = CRITERION_LIBRARY_SECTIONS.map((section) => ({
+    ...section,
+    options: DASHBOARD_SORT_CRITERIA_OPTIONS.filter(
+      (option) => getCriterionLibraryCategory(option) === section.category
+    ),
+  })).filter((section) => section.options.length > 0)
+  const activeTopLevelIds = activeConfig.criteria.map((criterion) => criterion.id)
+  const topLevelCriterionCount = activeTopLevelIds.length
+  const collapsedTopLevelCount = activeTopLevelIds.filter((id) =>
+    collapsedCriterionIdSet.has(id)
+  ).length
+  const allTopLevelCollapsed =
+    topLevelCriterionCount > 0 && collapsedTopLevelCount === topLevelCriterionCount
+  const allTopLevelExpanded = collapsedTopLevelCount === 0
 
   const toggleCriterionCollapsed = (criterionId: string) => {
     setCollapsedCriterionIds((current) =>
@@ -572,35 +1070,73 @@ export function DashboardPersonCardSortSettingsPanel() {
     )
   }
 
+  const expandAllTopLevelCriteria = () => {
+    setCollapsedCriterionIds((current) => current.filter((id) => !activeTopLevelIds.includes(id)))
+  }
+
+  const collapseAllTopLevelCriteria = () => {
+    setCollapsedCriterionIds((current) => {
+      const next = new Set(current)
+      for (const id of activeTopLevelIds) {
+        next.add(id)
+      }
+      return Array.from(next)
+    })
+  }
+
   return (
-    <div className="grid gap-4 xl:grid-cols-[18rem_minmax(0,1fr)]">
+    <div className="grid gap-4 xl:grid-cols-[24rem_minmax(0,1fr)]">
       <AppCard className="self-start">
         <AppCardHeader>
           <AppCardTitle>Criteria Library</AppCardTitle>
           <AppCardDescription>
-            Add criteria to the dashboard order. Rank preview:{' '}
-            {rankPreview || 'No rank data loaded'}.
+            {isEditing
+              ? 'Add criteria to the dashboard order.'
+              : 'Available rules for the dashboard order.'}{' '}
+            Rank preview: {rankPreview || 'No rank data loaded'}.
           </AppCardDescription>
         </AppCardHeader>
-        <AppCardContent className="grid gap-3">
-          {DASHBOARD_SORT_CRITERIA_OPTIONS.map((option) => (
-            <div key={option.type} className="border border-base-300 bg-base-200/40 p-3">
-              <div className="flex items-start justify-between gap-3">
-                <div>
-                  <p className="font-medium">{option.label}</p>
-                  <p className="text-sm text-base-content/60">{option.description}</p>
-                </div>
-                <button
-                  type="button"
-                  className="btn btn-sm btn-outline"
-                  onClick={() => addTopLevelCriterion(option.type)}
-                  disabled={!isEditing}
-                >
-                  <Plus className="h-4 w-4" />
-                  Add
-                </button>
+        <AppCardContent className="grid gap-(--space-4)">
+          {groupedCriteriaOptions.map((section) => (
+            <section key={section.category} className="grid gap-(--space-2)">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-base-content/50">
+                  {section.title}
+                </p>
+                <p className="text-xs leading-snug text-base-content/55">{section.description}</p>
               </div>
-            </div>
+              <div className="grid gap-(--space-2)">
+                {section.options.map((option) => (
+                  <div key={option.type} className="border border-base-300 bg-base-200/45">
+                    <div className="grid gap-(--space-3) p-(--space-3)">
+                      <div className="min-w-0">
+                        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-(--space-2)">
+                          <p className="text-sm font-semibold leading-tight text-base-content">
+                            {option.label}
+                          </p>
+                          <Chip size="sm" variant="faded" color="neutral">
+                            {getCriterionCapabilityLabel(option)}
+                          </Chip>
+                        </div>
+                        <p className="mt-(--space-2) text-sm leading-snug text-base-content/65">
+                          {option.description}
+                        </p>
+                      </div>
+                      {isEditing ? (
+                        <button
+                          type="button"
+                          className="btn btn-sm btn-outline justify-self-start"
+                          onClick={() => addTopLevelCriterion(option.type)}
+                        >
+                          <Plus className="h-4 w-4" />
+                          Add
+                        </button>
+                      ) : null}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
           ))}
         </AppCardContent>
       </AppCard>
@@ -611,7 +1147,9 @@ export function DashboardPersonCardSortSettingsPanel() {
             <div>
               <AppCardTitle>Dashboard Card Sorting</AppCardTitle>
               <AppCardDescription>
-                Drag criteria into order, add notes, and nest sub-sorts inside grouping criteria.
+                {isEditing
+                  ? 'Drag criteria into order, add notes, and nest sorting rules inside grouping criteria.'
+                  : 'Review the dashboard grouping order and the rules inside each group.'}
               </AppCardDescription>
             </div>
             <div className="flex flex-wrap gap-2">
@@ -641,11 +1179,61 @@ export function DashboardPersonCardSortSettingsPanel() {
           </div>
         </AppCardHeader>
         <AppCardContent className="grid gap-3">
-          <div className="flex flex-wrap items-center gap-2 text-sm text-base-content/65">
-            <span className="badge badge-ghost badge-sm">Grouping rule</span>
-            <span>
-              Bucket criteria create groups, and child criteria sort only within that parent row.
-            </span>
+          <div className="grid gap-(--space-3) rounded-box border border-base-300 bg-base-200/45 p-(--space-3)">
+            <div className="flex flex-wrap items-start justify-between gap-(--space-3)">
+              <div className="flex min-w-0 items-start gap-(--space-2)">
+                <Layers className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                <div>
+                  <p className="text-sm font-semibold text-base-content">Current dashboard order</p>
+                  {dashboardOrderSteps.length > 0 ? (
+                    <div className="mt-(--space-2) flex flex-wrap items-center gap-(--space-1)">
+                      {dashboardOrderSteps.map((step, index) => (
+                        <span
+                          key={`${step}-${index}`}
+                          className="inline-flex items-center gap-(--space-1)"
+                        >
+                          {index > 0 ? (
+                            <span
+                              className="text-xs font-semibold text-base-content/35"
+                              aria-hidden="true"
+                            >
+                              →
+                            </span>
+                          ) : null}
+                          <span className="rounded-box border border-base-300 bg-base-100 px-(--space-2) py-0.5 text-xs font-semibold text-base-content/75 shadow-[var(--shadow-1)]">
+                            {step}
+                          </span>
+                        </span>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="mt-0.5 text-sm leading-snug text-base-content/68">
+                      No grouping rules configured.
+                    </p>
+                  )}
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-(--space-2)">
+                <button
+                  type="button"
+                  className="btn btn-outline btn-xs"
+                  onClick={expandAllTopLevelCriteria}
+                  disabled={topLevelCriterionCount === 0 || allTopLevelExpanded}
+                >
+                  <ChevronUp className="h-3.5 w-3.5" />
+                  Expand all
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-outline btn-xs"
+                  onClick={collapseAllTopLevelCriteria}
+                  disabled={topLevelCriterionCount === 0 || allTopLevelCollapsed}
+                >
+                  <ChevronDown className="h-3.5 w-3.5" />
+                  Collapse all
+                </button>
+              </div>
+            </div>
           </div>
 
           <DndContext
@@ -659,7 +1247,7 @@ export function DashboardPersonCardSortSettingsPanel() {
             >
               <div className="grid gap-3">
                 {activeConfig.criteria.length > 0 ? (
-                  activeConfig.criteria.map((criterion) => (
+                  activeConfig.criteria.map((criterion, index) => (
                     <SortableCriterionCard
                       key={criterion.id}
                       criterion={criterion}
@@ -667,20 +1255,24 @@ export function DashboardPersonCardSortSettingsPanel() {
                       allTags={nonPositionalTags}
                       visitTypes={visitTypes}
                       depth={0}
+                      position={index + 1}
                       collapsedCriterionIds={collapsedCriterionIdSet}
                       onChange={updateDraftCriterion}
-                      onRemove={(criterionId) =>
+                      onRemove={(criterionId) => {
                         setDraft((current) => ({
                           ...current,
                           criteria: removeCriterion(current.criteria, criterionId),
                         }))
-                      }
+                        setCollapsedCriterionIds((current) =>
+                          current.filter((id) => id !== criterionId)
+                        )
+                      }}
                       onAddChild={addChildCriterion}
                       onToggleCollapse={toggleCriterionCollapsed}
                     />
                   ))
                 ) : (
-                  <div className="border border-dashed border-base-300 bg-base-200/30 px-4 py-8 text-center text-base-content/60">
+                  <div className="border border-dashed border-base-300 bg-base-200/45 px-4 py-8 text-center text-base-content/60">
                     No criteria configured yet. Add one from the sidebar, then save to apply it on
                     the dashboard.
                   </div>

--- a/apps/frontend-admin/src/help/help-registry.ts
+++ b/apps/frontend-admin/src/help/help-registry.ts
@@ -97,12 +97,12 @@ const HELP_REGISTRY: HelpRegistryEntry[] = [
     roleScopes: ['admin', 'developer'],
     fallbackMode: 'wiki',
     localFallback: {
-      title: 'Admin Control Center Quick Help',
+      title: 'Admin Control Centre Quick Help',
       summary: 'Start here for appliance status, issues, and system-control tasks.',
       quickSteps: [
         'Review Recent issues before routine configuration.',
         'Use quick actions for updates, logs, badges, and network work.',
-        'Open System Definitions for shared lists and operational defaults.',
+        'Open Lists & Types for shared record lists, or use Settings pages for timings and access.',
       ],
     },
   },

--- a/apps/frontend-admin/src/lib/admin-routes.test.ts
+++ b/apps/frontend-admin/src/lib/admin-routes.test.ts
@@ -8,6 +8,7 @@ import {
   ADMIN_SIDEBAR_GROUP_LIMIT,
   ADMIN_SIDEBAR_LINK_LIMIT_PER_GROUP,
   getAdminCapabilities,
+  getAdminRouteById,
   getAdminRouteGroups,
   getAdminSidebarRoutes,
   isAdminNavPath,
@@ -39,6 +40,12 @@ describe('ADMIN_NAV_ROUTES', () => {
     const groups = getAdminRouteGroups(sidebarRoutes)
 
     expect(groups.length).toBeLessThanOrEqual(ADMIN_SIDEBAR_GROUP_LIMIT)
+    expect(groups.slice(0, 4)).toEqual([
+      'Overview',
+      'Settings',
+      'Access Control',
+      'System Operations',
+    ])
 
     for (const group of groups) {
       const routesInGroup = sidebarRoutes.filter((route) => route.group === group)
@@ -67,6 +74,14 @@ describe('ADMIN_NAV_ROUTES', () => {
     expect(getAdminCapabilities(6)).toContain('database:view')
   })
 
+  it('keeps logs visible to every admin account without an extra capability gate', () => {
+    expect(getAdminRouteById('logs').requiredCapabilities).toEqual(['admin:view'])
+    expect(getAdminSidebarRoutes(5).map((route) => route.id)).toContain('logs')
+    expect(
+      ADMIN_QUICK_ACTIONS.find((action) => action.id === 'view-logs')?.requiredCapabilities
+    ).toEqual(['admin:view'])
+  })
+
   it('preserves legacy route intent', () => {
     expect(resolveLegacyAdminPath('/badges', new URLSearchParams('page=2'))).toBe(
       '/admin/badges?page=2'
@@ -80,6 +95,15 @@ describe('ADMIN_NAV_ROUTES', () => {
     )
     expect(resolveLegacyAdminPath('/settings', new URLSearchParams('tab=network'))).toBe(
       '/admin/network'
+    )
+    expect(resolveLegacyAdminPath('/settings', new URLSearchParams('tab=timings'))).toBe(
+      '/admin/timings'
+    )
+    expect(resolveLegacyAdminPath('/settings', new URLSearchParams('tab=account-levels'))).toBe(
+      '/admin/account-levels'
+    )
+    expect(resolveLegacyAdminPath('/settings', new URLSearchParams('tab=dashboard-sorting'))).toBe(
+      '/admin/dashboard-sorting'
     )
     expect(resolveLegacyAdminPath('/settings', new URLSearchParams('tab=tags'))).toBe(
       '/admin/config?tab=tags'

--- a/apps/frontend-admin/src/lib/admin-routes.ts
+++ b/apps/frontend-admin/src/lib/admin-routes.ts
@@ -7,7 +7,6 @@ export type AdminCapability =
   | 'admin:view'
   | 'updates:manage'
   | 'network:manage'
-  | 'logs:view'
   | 'database:view'
   | 'badges:manage'
   | 'config:manage'
@@ -20,6 +19,9 @@ export type AdminRouteId =
   | 'database'
   | 'badges'
   | 'config'
+  | 'timings'
+  | 'account-levels'
+  | 'dashboard-sorting'
 
 export type AdminRouteGroup =
   | 'Overview'
@@ -27,7 +29,7 @@ export type AdminRouteGroup =
   | 'Infrastructure'
   | 'Diagnostics'
   | 'Access Control'
-  | 'System Definitions'
+  | 'Settings'
 
 export type AdminRouteTier = 1 | 2
 export type AdminNavVisibility = 'sidebar' | 'hidden'
@@ -35,8 +37,10 @@ export type AdminFeatureStatus = 'available' | 'future'
 
 export type AdminIconKey =
   | 'activity'
+  | 'arrow-up-down'
   | 'badge'
   | 'book-open'
+  | 'clock'
   | 'database'
   | 'download'
   | 'list'
@@ -120,7 +124,7 @@ export const ADMIN_NAV_ROUTES = [
     id: 'network',
     label: 'Network',
     href: '/admin/network',
-    group: 'Infrastructure',
+    group: 'System Operations',
     tier: 1,
     icon: 'network',
     description: 'Manage approved Wi-Fi, remote systems, hotspot recovery, and host network state.',
@@ -144,7 +148,7 @@ export const ADMIN_NAV_ROUTES = [
     keywords: ['logs', 'audit', 'activity', 'diagnostics', 'history'],
     searchWeight: 85,
     requiredRole: ADMIN_ROLE_LEVEL.ADMIN,
-    requiredCapabilities: ['admin:view', 'logs:view'],
+    requiredCapabilities: ['admin:view'],
     navVisibility: 'sidebar',
     featureStatus: 'available',
   },
@@ -182,16 +186,64 @@ export const ADMIN_NAV_ROUTES = [
   },
   {
     id: 'config',
-    label: 'System Definitions',
+    label: 'Lists & Types',
     href: '/admin/config',
-    group: 'System Definitions',
+    group: 'Settings',
     tier: 1,
     icon: 'list',
     description:
-      'Manage member types, statuses, visit types, event types, qualifications, and tags.',
-    aliases: ['settings', 'definitions', 'lists', 'types', 'configuration'],
-    keywords: ['definitions', 'settings', 'types', 'statuses', 'tags', 'qualifications'],
+      'Manage member types, statuses, visit types, event types, qualifications, tags, and holidays.',
+    aliases: ['settings', 'definitions', 'lists', 'types', 'configuration', 'system definitions'],
+    keywords: ['lists', 'types', 'settings', 'statuses', 'tags', 'qualifications', 'holidays'],
     searchWeight: 80,
+    requiredRole: ADMIN_ROLE_LEVEL.ADMIN,
+    requiredCapabilities: ['admin:view', 'config:manage'],
+    navVisibility: 'sidebar',
+    featureStatus: 'available',
+  },
+  {
+    id: 'timings',
+    label: 'Timings',
+    href: '/admin/timings',
+    group: 'Settings',
+    tier: 1,
+    icon: 'clock',
+    description: 'Manage scheduler cutoffs, duty timing, working hours, and alert limits.',
+    aliases: ['operational timings', 'working hours', 'cutoffs', 'alert limits'],
+    keywords: ['timings', 'schedule', 'cutoffs', 'working hours', 'alerts'],
+    searchWeight: 79,
+    requiredRole: ADMIN_ROLE_LEVEL.ADMIN,
+    requiredCapabilities: ['admin:view', 'config:manage'],
+    navVisibility: 'sidebar',
+    featureStatus: 'available',
+  },
+  {
+    id: 'account-levels',
+    label: 'Account Levels',
+    href: '/admin/account-levels',
+    group: 'Access Control',
+    tier: 1,
+    icon: 'shield',
+    description: 'Review access levels and reassign member account levels.',
+    aliases: ['access levels', 'permissions', 'roles', 'admin levels'],
+    keywords: ['account levels', 'access', 'permissions', 'roles', 'admin'],
+    searchWeight: 78,
+    requiredRole: ADMIN_ROLE_LEVEL.ADMIN,
+    requiredCapabilities: ['admin:view', 'config:manage'],
+    navVisibility: 'sidebar',
+    featureStatus: 'available',
+  },
+  {
+    id: 'dashboard-sorting',
+    label: 'Dashboard Sorting',
+    href: '/admin/dashboard-sorting',
+    group: 'Settings',
+    tier: 1,
+    icon: 'arrow-up-down',
+    description: 'Control how member cards are sorted on the dashboard.',
+    aliases: ['dashboard sort', 'card sorting', 'member card order'],
+    keywords: ['dashboard', 'sorting', 'cards', 'order', 'criteria'],
+    searchWeight: 77,
     requiredRole: ADMIN_ROLE_LEVEL.ADMIN,
     requiredCapabilities: ['admin:view', 'config:manage'],
     navVisibility: 'sidebar',
@@ -216,7 +268,7 @@ export const ADMIN_QUICK_ACTIONS = [
     href: '/admin/logs',
     icon: 'logs',
     description: 'Inspect recent administrative and operational activity.',
-    requiredCapabilities: ['admin:view', 'logs:view'],
+    requiredCapabilities: ['admin:view'],
     defaultPinned: true,
     featureStatus: 'available',
   },
@@ -252,10 +304,10 @@ export const ADMIN_QUICK_ACTIONS = [
   },
   {
     id: 'open-config',
-    label: 'System definitions',
+    label: 'Lists & Types',
     href: '/admin/config',
     icon: 'list',
-    description: 'Manage operational dictionaries and default definitions.',
+    description: 'Manage shared lists, categories, and types.',
     requiredCapabilities: ['admin:view', 'config:manage'],
     defaultPinned: false,
     featureStatus: 'available',
@@ -285,12 +337,20 @@ export const ADMIN_QUICK_ACTIONS = [
 export const ADMIN_SIDEBAR_GROUP_LIMIT = 6
 export const ADMIN_SIDEBAR_LINK_LIMIT_PER_GROUP = 7
 
+const ADMIN_ROUTE_GROUP_ORDER = [
+  'Overview',
+  'Settings',
+  'Access Control',
+  'System Operations',
+  'Infrastructure',
+  'Diagnostics',
+] as const satisfies readonly AdminRouteGroup[]
+
 const capabilityByMinimumRole: Record<number, readonly AdminCapability[]> = {
   [ADMIN_ROLE_LEVEL.ADMIN]: [
     'admin:view',
     'updates:manage',
     'network:manage',
-    'logs:view',
     'database:view',
     'badges:manage',
     'config:manage',
@@ -299,7 +359,6 @@ const capabilityByMinimumRole: Record<number, readonly AdminCapability[]> = {
     'admin:view',
     'updates:manage',
     'network:manage',
-    'logs:view',
     'database:view',
     'badges:manage',
     'config:manage',
@@ -389,7 +448,9 @@ export function getAdminSidebarRoutes(
 }
 
 export function getAdminRouteGroups(routes: readonly AdminNavRoute[]): readonly AdminRouteGroup[] {
-  return Array.from(new Set(routes.map((route) => route.group)))
+  const routeGroups = new Set(routes.map((route) => route.group))
+
+  return ADMIN_ROUTE_GROUP_ORDER.filter((group) => routeGroups.has(group))
 }
 
 export function isAdminNavPath(pathname: string): boolean {
@@ -428,6 +489,21 @@ export function resolveLegacyAdminPath(
   if (requestedTab === 'network') {
     query.delete('tab')
     return withQuery('/admin/network', query)
+  }
+
+  if (requestedTab === 'timings') {
+    query.delete('tab')
+    return withQuery('/admin/timings', query)
+  }
+
+  if (requestedTab === 'account-levels') {
+    query.delete('tab')
+    return withQuery('/admin/account-levels', query)
+  }
+
+  if (requestedTab === 'dashboard-sorting') {
+    query.delete('tab')
+    return withQuery('/admin/dashboard-sorting', query)
   }
 
   return withQuery('/admin/config', query)

--- a/apps/frontend-admin/src/lib/dds-content.ts
+++ b/apps/frontend-admin/src/lib/dds-content.ts
@@ -205,7 +205,7 @@ export const DEFAULT_DDS_PAGE_CONTENT: DdsPageContent = {
     },
     {
       id: 'wing-ops',
-      label: '17 Wing Ops Center',
+      label: '17 Wing Ops Centre',
       phone: '<update required>',
       notes: 'Confirm correct line with chain of command.',
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.0.10",
+  "version": "3.1.0",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.0.10",
+  "version": "3.1.0",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/contracts/src/schemas/admin-navigation.schema.ts
+++ b/packages/contracts/src/schemas/admin-navigation.schema.ts
@@ -16,6 +16,9 @@ export const AdminNavigationRouteIdValues = [
   'database',
   'badges',
   'config',
+  'timings',
+  'account-levels',
+  'dashboard-sorting',
   'legacy',
   'unknown',
 ] as const

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.0.10",
+  "version": "3.1.0",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.0.10",
+  "version": "3.1.0",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Promotes Timings, Account Levels, and Dashboard Sorting into first-class Admin sidebar pages.
- Renames the remaining System Definitions page to Lists & Types while keeping `/admin/config` and legacy settings redirects working.
- Polishes Dashboard Sorting so Admin users can review rule order, configured values, notes, and within-group sorting without reading disabled form controls.
- Reorganizes the Control Centre sidebar, uses Canadian spelling in visible copy, and keeps route descriptions available through DaisyUI tooltips.
- Prepares Sentinel `v3.1.0` by syncing the root and workspace package versions.

## Why this change was needed

The Admin settings area had grown into a crowded tab set, and Dashboard Sorting was difficult to review because the default page looked like a disabled form. Admin users needed clearer navigation, better grouping, and easier scanning before making changes.

## What changed

### User-facing

- Dashboard Sorting now opens in a collapsed review state with clearer row titles, configured value chips, order numbers, and compact note indicators.
- Criteria library entries are grouped by purpose so Admin users can tell grouping rules, sort-only rules, and special rules apart.
- Empty notes are de-emphasized, and saved notes use a light green note card.
- Control Centre sidebar descriptions moved into DaisyUI tooltips to keep the sidebar compact.

### Admin/operator-facing

- Timings, Account Levels, and Dashboard Sorting are now permanent Admin sidebar pages.
- Account Levels is grouped under Access Control.
- Network is grouped with Updates under System Operations.
- Logs are visible to every Admin account through the base `admin:view` permission instead of an extra frontend-only `logs:view` gate.
- Visible Admin copy uses Canadian spelling such as Control Centre.

### Backend/API

- No backend API changes.
- No sort algorithm changes.
- Existing backend Admin-level protection for logs remains in place.

### Database

- No database migration is required.

### Deployment/update

- Package versions are synced to `3.1.0` for the minor release.

### Documentation

- Frontend Admin README copy now uses Control Centre wording.

### Tests

- Admin route tests now cover the new route entrypoints, legacy redirects, sidebar order, and Admin-visible Logs metadata.

## User impact

Normal dashboard users are not affected. Admin users will see clearer Admin navigation and a more readable Dashboard Sorting page.

## Operator impact

Operators get a cleaner Control Centre layout and can find Settings, Access Control, System Operations, and Logs more predictably. Logs remain available to any Admin-level account.

## Upgrade or migration notes

No upgrade action required. No database migration or configuration change is required.

## Risk and rollback notes

The main risk is visual or workflow regression in the Admin settings UI. Rollback is safe because this does not change persistence format, schemas, backend APIs, or the dashboard sort algorithm.

## Testing performed

- `pnpm --filter frontend-admin exec vitest run src/lib/admin-routes.test.ts`
- `pnpm --filter frontend-admin typecheck`
- `pnpm --filter frontend-admin lint` (passes with existing warnings)
- `pnpm version:check`

## Changelog candidates

- Promoted Timings, Account Levels, and Dashboard Sorting to first-class Admin sidebar pages so settings are easier to find.
- Renamed System Definitions to Lists & Types while preserving existing `/admin/config` and legacy settings links.
- Improved Dashboard Sorting with review-first collapsed rows, configured value chips, current order preview, and clearer within-group sorting controls.
- Reorganized the Control Centre sidebar and moved descriptions into DaisyUI tooltips for a more compact Admin navigation.
- Kept Logs visible to every Admin account through the base Admin permission.
- Prepared Sentinel `v3.1.0` with synced workspace package versions.