### PR TITLE
fix(admin): restore logs route for v3.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ apps/backend/*.png
 
 # Logs
 logs/
+!apps/frontend-admin/src/app/admin/logs/
+!apps/frontend-admin/src/app/admin/logs/**
 !apps/frontend-admin/src/app/logs/
 !apps/frontend-admin/src/app/logs/**
 !apps/frontend-admin/src/components/logs/

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/app/admin/logs/page.tsx
+++ b/apps/frontend-admin/src/app/admin/logs/page.tsx
@@ -1,0 +1,5 @@
+import { LogsPage } from '@/components/logs/logs-page'
+
+export default function AdminLogsRoute() {
+  return <LogsPage />
+}

--- a/apps/frontend-admin/src/components/admin/admin-shell.tsx
+++ b/apps/frontend-admin/src/components/admin/admin-shell.tsx
@@ -85,19 +85,16 @@ function AdminSidebarLink({
   currentRouteId: AdminNavRoute['id']
   active: boolean
 }) {
-  const descriptionId = `admin-sidebar-${route.id}-description`
-
   return (
     <li>
       <Link
         href={route.href}
         className={cn(
-          'tooltip tooltip-right grid min-h-12 grid-cols-[1.1rem_minmax(0,1fr)] items-center gap-(--space-3) rounded-box border-l-4 border-l-transparent px-(--space-3) py-(--space-2) text-left text-base-content/90 transition-colors duration-(--duration-fast) hover:z-(--z-tooltip) hover:bg-base-200 hover:text-base-content focus-visible:z-(--z-tooltip)',
+          'grid min-h-12 grid-cols-[1.1rem_minmax(0,1fr)] items-center gap-(--space-3) rounded-box border-l-4 border-l-transparent px-(--space-3) py-(--space-2) text-left text-base-content/90 transition-colors duration-(--duration-fast) hover:z-(--z-tooltip) hover:bg-base-200 hover:text-base-content focus-visible:z-(--z-tooltip)',
           active && 'border-l-primary bg-base-200 text-base-content shadow-[var(--shadow-1)]'
         )}
         aria-current={active ? 'page' : undefined}
-        aria-describedby={descriptionId}
-        data-tip={route.description}
+        aria-label={`${route.label}: ${route.description}`}
         onClick={() => {
           recordAdminNavigationTelemetry({
             eventType: 'nav_click',
@@ -114,9 +111,6 @@ function AdminSidebarLink({
         <span className="min-w-0">
           <span className={cn('block truncate text-sm font-semibold', active && 'font-bold')}>
             {route.label}
-          </span>
-          <span id={descriptionId} className="sr-only">
-            {route.description}
           </span>
         </span>
       </Link>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Restores the missing Admin Logs route at /admin/logs so the deployed Admin navigation matches the local Git version.
- Bumps Sentinel workspace packages from 3.1.0 to 3.1.1 for the patch release.
- Keeps Admin sidebar labels accessible while removing the tooltip styling that could change the deployed navigation presentation.

## Why this change was needed

Sentinel v3.1.0 included navigation that pointed Admin users to /admin/logs, but the route file itself was still only present locally. Production builds therefore did not include the same Admin Logs page that local Git showed.

## What changed

### User-facing

- Admin users can open Logs from the Admin shell at /admin/logs.
- The Admin sidebar avoids the deployed tooltip treatment while retaining descriptive accessible labels.

### Admin/operator-facing

- The patch release is versioned as 3.1.1 across the monorepo packages.

### Backend/API

- No backend API behavior changed.

### Database

- No database schema change.

### Deployment/update

- Deploying v3.1.1 should publish the frontend route that was missing from v3.1.0.

### Tests

- pnpm version:check
- pnpm --filter frontend-admin lint
- pnpm --filter frontend-admin typecheck
- pnpm --filter frontend-admin build
- pnpm --filter frontend-admin exec vitest run src/lib/admin-routes.test.ts
- playwright-cli sanity check at 1920x1080 for http://localhost:3001/admin/logs

## User impact

Admin users should see the deployed Admin page match the local Git version, including the Logs entry resolving to the Activity log page.

## Operator impact

Operators can update to v3.1.1 to pick up the frontend route correction. No service configuration changes are required beyond the normal release update.

## Upgrade or migration notes

No upgrade action required beyond deploying Sentinel v3.1.1. No database migration is required.

## Risk and rollback notes

Risk is low and limited to Admin frontend navigation. Rollback to v3.1.0 is safe for data, but it would reintroduce the missing /admin/logs production route.

## Testing performed

- Verified production build includes /admin/logs in the Next.js route output.
- Verified /admin/logs renders Activity log after bootstrap login in local browser sanity check.
- Verified no horizontal overflow at 1920x1080.

## Changelog candidates

- Fixed the deployed Admin Logs route so Admin navigation matches the local 3.1.x frontend.
- Released Sentinel v3.1.1 as a patch correction for the v3.1.0 frontend deployment gap.