### PR TITLE
feat(admin): add operational reports for v3.2.0

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/repositories/operational-report-repository.ts
+++ b/apps/backend/src/repositories/operational-report-repository.ts
@@ -1,0 +1,329 @@
+import type { PrismaClientInstance } from '@sentinel/database'
+import { Prisma, prisma as defaultPrisma } from '@sentinel/database'
+
+const reportMemberInclude = {
+  division: {
+    select: {
+      id: true,
+      code: true,
+      name: true,
+    },
+  },
+  memberTypeRef: {
+    select: {
+      id: true,
+      code: true,
+      name: true,
+    },
+  },
+  memberStatusRef: {
+    select: {
+      id: true,
+      code: true,
+      name: true,
+    },
+  },
+  memberTags: {
+    include: {
+      tag: true,
+    },
+  },
+  qualifications: {
+    where: {
+      status: 'active',
+    },
+    include: {
+      qualificationType: {
+        include: {
+          tag: true,
+        },
+      },
+    },
+  },
+} satisfies Prisma.MemberInclude
+
+const unitEventInclude = {
+  eventType: {
+    select: {
+      id: true,
+      name: true,
+      category: true,
+      defaultDurationMinutes: true,
+    },
+  },
+} satisfies Prisma.UnitEventInclude
+
+const visitorInclude = {
+  event: {
+    select: {
+      id: true,
+      name: true,
+    },
+  },
+  hostMember: {
+    select: {
+      id: true,
+      rank: true,
+      firstName: true,
+      lastName: true,
+      displayName: true,
+    },
+  },
+} satisfies Prisma.VisitorInclude
+
+export type OperationalReportMemberRecord = Prisma.MemberGetPayload<{
+  include: typeof reportMemberInclude
+}>
+
+export interface OperationalReportCheckinRecord {
+  id: string
+  memberId: string | null
+  direction: string
+  timestamp: Date
+}
+
+export type OperationalReportUnitEventRecord = Prisma.UnitEventGetPayload<{
+  include: typeof unitEventInclude
+}>
+
+export type OperationalReportVisitorRecord = Prisma.VisitorGetPayload<{
+  include: typeof visitorInclude
+}>
+
+export interface OperationalReportMemberFilters {
+  divisionId?: string
+  tagId?: string
+}
+
+export interface OperationalReportVisitorFilters {
+  start: Date
+  end: Date
+  visitType?: string
+  visitorPurpose?: string
+  eventLinked?: boolean
+  hostMemberId?: string
+  organization?: string
+}
+
+export class OperationalReportRepository {
+  private prisma: PrismaClientInstance
+
+  constructor(prismaClient?: PrismaClientInstance) {
+    this.prisma = prismaClient || defaultPrisma
+  }
+
+  async findDivisionById(
+    divisionId: string
+  ): Promise<{ id: string; code: string; name: string } | null> {
+    return this.prisma.division.findUnique({
+      where: { id: divisionId },
+      select: {
+        id: true,
+        code: true,
+        name: true,
+      },
+    })
+  }
+
+  async findTagById(
+    tagId: string
+  ): Promise<{ id: string; name: string; chipVariant: string; chipColor: string } | null> {
+    return this.prisma.tag.findUnique({
+      where: { id: tagId },
+      select: {
+        id: true,
+        name: true,
+        chipVariant: true,
+        chipColor: true,
+      },
+    })
+  }
+
+  async findTagShortcut(
+    shortcut: 'fts' | 'geo'
+  ): Promise<{ id: string; name: string; chipVariant: string; chipColor: string } | null> {
+    return this.prisma.tag.findFirst({
+      where: {
+        name: {
+          equals: shortcut.toUpperCase(),
+          mode: 'insensitive',
+        },
+      },
+      select: {
+        id: true,
+        name: true,
+        chipVariant: true,
+        chipColor: true,
+      },
+    })
+  }
+
+  async findActiveMembers(
+    filters: OperationalReportMemberFilters = {}
+  ): Promise<OperationalReportMemberRecord[]> {
+    const where: Prisma.MemberWhereInput = {
+      status: 'active',
+    }
+
+    if (filters.divisionId) {
+      where.divisionId = filters.divisionId
+    }
+
+    if (filters.tagId) {
+      where.OR = [
+        {
+          memberTags: {
+            some: {
+              tagId: filters.tagId,
+            },
+          },
+        },
+        {
+          qualifications: {
+            some: {
+              status: 'active',
+              qualificationType: {
+                tagId: filters.tagId,
+              },
+            },
+          },
+        },
+      ]
+    }
+
+    return this.prisma.member.findMany({
+      where,
+      include: reportMemberInclude,
+      orderBy: [
+        { division: { name: 'asc' } },
+        { rank: 'asc' },
+        { lastName: 'asc' },
+        { firstName: 'asc' },
+      ],
+    })
+  }
+
+  async findCheckinsForMembers(
+    memberIds: string[],
+    start: Date,
+    end: Date
+  ): Promise<OperationalReportCheckinRecord[]> {
+    if (memberIds.length === 0) {
+      return []
+    }
+
+    return this.prisma.checkin.findMany({
+      where: {
+        memberId: {
+          in: memberIds,
+        },
+        timestamp: {
+          gte: start,
+          lt: end,
+        },
+      },
+      select: {
+        id: true,
+        memberId: true,
+        direction: true,
+        timestamp: true,
+      },
+      orderBy: [{ memberId: 'asc' }, { timestamp: 'asc' }],
+    })
+  }
+
+  async findUnitEvents(
+    start: Date,
+    end: Date,
+    categories: Array<'training' | 'administrative'>
+  ): Promise<OperationalReportUnitEventRecord[]> {
+    return this.prisma.unitEvent.findMany({
+      where: {
+        eventDate: {
+          gte: start,
+          lt: end,
+        },
+        status: {
+          notIn: ['cancelled', 'postponed'],
+        },
+        eventType: {
+          is: {
+            category: {
+              in: categories,
+            },
+          },
+        },
+      },
+      include: unitEventInclude,
+      orderBy: [{ eventDate: 'asc' }, { startTime: 'asc' }, { title: 'asc' }],
+    })
+  }
+
+  async findReportSettingValue(key: string): Promise<unknown | null> {
+    const setting = await this.prisma.reportSetting.findUnique({
+      where: { key },
+      select: { value: true },
+    })
+
+    return setting?.value ?? null
+  }
+
+  async findVisitors(
+    filters: OperationalReportVisitorFilters
+  ): Promise<OperationalReportVisitorRecord[]> {
+    const where: Prisma.VisitorWhereInput = {
+      checkInTime: {
+        gte: filters.start,
+        lt: filters.end,
+      },
+    }
+
+    if (filters.visitType) {
+      where.visitType = filters.visitType
+    }
+
+    if (filters.visitorPurpose) {
+      where.OR = [
+        {
+          visitPurpose: {
+            contains: filters.visitorPurpose,
+            mode: 'insensitive',
+          },
+        },
+        {
+          visitReason: {
+            contains: filters.visitorPurpose,
+            mode: 'insensitive',
+          },
+        },
+        {
+          purposeDetails: {
+            contains: filters.visitorPurpose,
+            mode: 'insensitive',
+          },
+        },
+      ]
+    }
+
+    if (filters.eventLinked !== undefined) {
+      where.eventId = filters.eventLinked ? { not: null } : null
+    }
+
+    if (filters.hostMemberId) {
+      where.hostMemberId = filters.hostMemberId
+    }
+
+    if (filters.organization) {
+      where.organization = {
+        contains: filters.organization,
+        mode: 'insensitive',
+      }
+    }
+
+    return this.prisma.visitor.findMany({
+      where,
+      include: visitorInclude,
+      orderBy: [{ checkInTime: 'asc' }, { name: 'asc' }],
+    })
+  }
+}

--- a/apps/backend/src/routes/reports.ts
+++ b/apps/backend/src/routes/reports.ts
@@ -1,4 +1,5 @@
 import { initServer } from '@ts-rest/express'
+import type { Request } from 'express'
 import { reportContract } from '@sentinel/contracts'
 import type {
   DailyCheckinConfig,
@@ -8,9 +9,48 @@ import type {
   VisitorSummaryConfig,
 } from '@sentinel/contracts'
 import { getPrismaClient } from '../lib/database.js'
+import { AccountLevel } from '../middleware/roles.js'
+import {
+  OperationalReportService,
+  type OperationalReportActor,
+} from '../services/operational-report-service.js'
 
 const s = initServer()
 const prisma = getPrismaClient()
+const operationalReportService = new OperationalReportService(getPrismaClient())
+
+function requireAdminOrDeveloper(req: Request) {
+  if (!req.member) {
+    return {
+      status: 401 as const,
+      body: {
+        error: 'UNAUTHORIZED',
+        message: 'Authentication required',
+      },
+    }
+  }
+
+  if ((req.member.accountLevel ?? 0) < AccountLevel.ADMIN) {
+    return {
+      status: 403 as const,
+      body: {
+        error: 'FORBIDDEN',
+        message: 'Admin or Developer access required',
+      },
+    }
+  }
+
+  return null
+}
+
+function getReportActor(req: Request): OperationalReportActor {
+  return {
+    id: req.member?.id ?? 'unknown',
+    rank: req.member?.rank,
+    firstName: req.member?.firstName,
+    lastName: req.member?.lastName,
+  }
+}
 
 /**
  * Report generation routes
@@ -18,6 +58,126 @@ const prisma = getPrismaClient()
  * Generates various attendance and personnel reports with complex aggregations
  */
 export const reportsRouter = s.router(reportContract, {
+  generateDailyPresence: async ({ body, req }) => {
+    const auth = requireAdminOrDeveloper(req)
+    if (auth) {
+      return auth
+    }
+
+    try {
+      return {
+        status: 200 as const,
+        body: await operationalReportService.generateDailyPresence(body, getReportActor(req)),
+      }
+    } catch (error) {
+      return {
+        status: 500 as const,
+        body: {
+          error: 'INTERNAL_ERROR',
+          message:
+            error instanceof Error ? error.message : 'Failed to generate daily presence report',
+        },
+      }
+    }
+  },
+
+  generateWeeklyPresence: async ({ body, req }) => {
+    const auth = requireAdminOrDeveloper(req)
+    if (auth) {
+      return auth
+    }
+
+    try {
+      return {
+        status: 200 as const,
+        body: await operationalReportService.generateWeeklyPresence(body, getReportActor(req)),
+      }
+    } catch (error) {
+      return {
+        status: 500 as const,
+        body: {
+          error: 'INTERNAL_ERROR',
+          message:
+            error instanceof Error ? error.message : 'Failed to generate weekly presence report',
+        },
+      }
+    }
+  },
+
+  generateMonthlyPresence: async ({ body, req }) => {
+    const auth = requireAdminOrDeveloper(req)
+    if (auth) {
+      return auth
+    }
+
+    try {
+      return {
+        status: 200 as const,
+        body: await operationalReportService.generateMonthlyPresence(body, getReportActor(req)),
+      }
+    } catch (error) {
+      return {
+        status: 500 as const,
+        body: {
+          error: 'INTERNAL_ERROR',
+          message:
+            error instanceof Error ? error.message : 'Failed to generate monthly presence report',
+        },
+      }
+    }
+  },
+
+  generateTrainingNightMonthly: async ({ body, req }) => {
+    const auth = requireAdminOrDeveloper(req)
+    if (auth) {
+      return auth
+    }
+
+    try {
+      return {
+        status: 200 as const,
+        body: await operationalReportService.generateTrainingNightMonthly(
+          body,
+          getReportActor(req)
+        ),
+      }
+    } catch (error) {
+      return {
+        status: 500 as const,
+        body: {
+          error: 'INTERNAL_ERROR',
+          message:
+            error instanceof Error
+              ? error.message
+              : 'Failed to generate training night monthly report',
+        },
+      }
+    }
+  },
+
+  generateVisitorActivity: async ({ body, req }) => {
+    const auth = requireAdminOrDeveloper(req)
+    if (auth) {
+      return auth
+    }
+
+    try {
+      return {
+        status: 200 as const,
+        body: await operationalReportService.generateVisitorActivity(body, getReportActor(req)),
+      }
+    } catch (error) {
+      return {
+        status: 500 as const,
+        body: {
+          error: 'INTERNAL_ERROR',
+          message:
+            error instanceof Error ? error.message : 'Failed to generate visitor activity report',
+        },
+      }
+    }
+  },
+
   /**
    * POST /api/reports/daily-checkin - Generate daily check-in summary
    */

--- a/apps/backend/src/services/operational-report-service.test.ts
+++ b/apps/backend/src/services/operational-report-service.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import {
+  pairOperationalPresenceSessions,
+  type PresenceSessionInternal,
+} from './operational-report-service.js'
+import type { OperationalReportCheckinRecord } from '../repositories/operational-report-repository.js'
+
+function checkin(
+  id: string,
+  memberId: string,
+  direction: 'in' | 'out',
+  timestamp: string
+): OperationalReportCheckinRecord {
+  return {
+    id,
+    memberId,
+    direction,
+    timestamp: new Date(timestamp),
+  }
+}
+
+function getSessions(
+  sessionsByMember: Map<string, PresenceSessionInternal[]>,
+  memberId: string
+): PresenceSessionInternal[] {
+  return sessionsByMember.get(memberId) ?? []
+}
+
+describe('pairOperationalPresenceSessions', () => {
+  it('pairs each check-in with the next valid checkout for the same member', () => {
+    const warnings = new Set<string>()
+    const sessionsByMember = pairOperationalPresenceSessions(
+      [
+        checkin('1', 'member-1', 'in', '2026-05-05T08:00:00.000Z'),
+        checkin('2', 'member-1', 'out', '2026-05-05T12:00:00.000Z'),
+        checkin('3', 'member-1', 'in', '2026-05-05T13:00:00.000Z'),
+        checkin('4', 'member-1', 'out', '2026-05-05T16:00:00.000Z'),
+      ],
+      warnings
+    )
+
+    const sessions = getSessions(sessionsByMember, 'member-1')
+    expect(sessions).toHaveLength(2)
+    expect(sessions.map((session) => session.status)).toEqual(['complete', 'complete'])
+    expect(sessions[0]?.inAt.toISOString()).toBe('2026-05-05T08:00:00.000Z')
+    expect(sessions[0]?.outAt?.toISOString()).toBe('2026-05-05T12:00:00.000Z')
+    expect(warnings.size).toBe(0)
+  })
+
+  it('marks repeated check-ins without checkout as degraded and keeps the latest session open', () => {
+    const warnings = new Set<string>()
+    const sessionsByMember = pairOperationalPresenceSessions(
+      [
+        checkin('1', 'member-1', 'in', '2026-05-05T08:00:00.000Z'),
+        checkin('2', 'member-1', 'in', '2026-05-05T09:00:00.000Z'),
+      ],
+      warnings
+    )
+
+    const sessions = getSessions(sessionsByMember, 'member-1')
+    expect(sessions).toHaveLength(2)
+    expect(sessions.map((session) => session.status)).toEqual(['degraded', 'open'])
+    expect(sessions[0]?.outAt).toBeNull()
+    expect(Array.from(warnings)).toContain(
+      'Some members have multiple check-ins without an intervening checkout; affected sessions are marked as degraded.'
+    )
+  })
+
+  it('warns and ignores unmatched checkouts', () => {
+    const warnings = new Set<string>()
+    const sessionsByMember = pairOperationalPresenceSessions(
+      [checkin('1', 'member-1', 'out', '2026-05-05T12:00:00.000Z')],
+      warnings
+    )
+
+    expect(getSessions(sessionsByMember, 'member-1')).toHaveLength(0)
+    expect(Array.from(warnings)).toContain(
+      'Some checkout records could not be paired with a prior check-in and were ignored.'
+    )
+  })
+})

--- a/apps/backend/src/services/operational-report-service.ts
+++ b/apps/backend/src/services/operational-report-service.ts
@@ -1,0 +1,1151 @@
+import * as v from 'valibot'
+import { DateTime } from 'luxon'
+import type {
+  DailyPresenceReportConfig,
+  DailyPresenceReportResponse,
+  KeyNight,
+  MonthlyPresenceReportConfig,
+  MonthlyPresenceReportResponse,
+  PresenceMarker,
+  PresenceSession,
+  ReportMemberSummary,
+  ReportTagSummary,
+  TrainingNightMonthlyReportConfig,
+  TrainingNightMonthlyReportResponse,
+  VisitorActivityReportConfig,
+  VisitorActivityReportResponse,
+  WeeklyPresenceReportConfig,
+  WeeklyPresenceReportResponse,
+} from '@sentinel/contracts'
+import { ScheduleSettingsValueSchema } from '@sentinel/contracts'
+import type { PrismaClientInstance } from '@sentinel/database'
+import { DEFAULT_TIMEZONE } from '../utils/operational-date.js'
+import {
+  OperationalReportRepository,
+  type OperationalReportCheckinRecord,
+  type OperationalReportMemberRecord,
+  type OperationalReportUnitEventRecord,
+  type OperationalReportVisitorRecord,
+} from '../repositories/operational-report-repository.js'
+
+const UNIT_NAME = 'HMCS Chippawa'
+const REPORT_LOOKBACK_DAYS = 1
+
+type ReportScopeType = 'everyone' | 'department' | 'tag' | 'fts' | 'geo'
+type KeyNightCategory = 'training' | 'administrative'
+
+export interface OperationalReportActor {
+  id: string
+  rank?: string
+  firstName?: string
+  lastName?: string
+}
+
+interface DateRange {
+  start: Date
+  end: Date
+  startDate: string
+  endDate: string
+  label: string
+}
+
+interface EffectiveScope {
+  divisionId?: string
+  tagId?: string
+  scopeLabel: string
+  warnings: string[]
+  noResults: boolean
+}
+
+export interface PresenceSessionInternal {
+  memberId: string
+  inAt: Date
+  outAt: Date | null
+  status: 'complete' | 'open' | 'degraded'
+}
+
+interface KeyNightWindow extends KeyNight {
+  start: Date | null
+  end: Date | null
+}
+
+interface PresenceStats {
+  present: boolean
+  firstIn: string | null
+  lastOut: string | null
+  sessionCount: number
+  note: string | null
+}
+
+export function pairOperationalPresenceSessions(
+  checkins: OperationalReportCheckinRecord[],
+  warnings: Set<string>
+): Map<string, PresenceSessionInternal[]> {
+  const grouped = new Map<string, OperationalReportCheckinRecord[]>()
+  for (const checkin of checkins) {
+    if (!checkin.memberId) {
+      continue
+    }
+    const items = grouped.get(checkin.memberId) ?? []
+    items.push(checkin)
+    grouped.set(checkin.memberId, items)
+  }
+
+  const sessionsByMember = new Map<string, PresenceSessionInternal[]>()
+
+  for (const [memberId, records] of grouped) {
+    const sorted = [...records].sort(
+      (left, right) => left.timestamp.getTime() - right.timestamp.getTime()
+    )
+    const sessions: PresenceSessionInternal[] = []
+    let openIn: OperationalReportCheckinRecord | null = null
+
+    for (const record of sorted) {
+      const direction = record.direction.toLowerCase()
+
+      if (direction === 'in') {
+        if (openIn) {
+          warnings.add(
+            'Some members have multiple check-ins without an intervening checkout; affected sessions are marked as degraded.'
+          )
+          sessions.push({
+            memberId,
+            inAt: openIn.timestamp,
+            outAt: null,
+            status: 'degraded',
+          })
+        }
+        openIn = record
+        continue
+      }
+
+      if (direction === 'out') {
+        if (!openIn) {
+          warnings.add(
+            'Some checkout records could not be paired with a prior check-in and were ignored.'
+          )
+          continue
+        }
+
+        if (record.timestamp < openIn.timestamp) {
+          warnings.add(
+            'Some checkout records were earlier than their paired check-in and were ignored.'
+          )
+          openIn = null
+          continue
+        }
+
+        sessions.push({
+          memberId,
+          inAt: openIn.timestamp,
+          outAt: record.timestamp,
+          status: 'complete',
+        })
+        openIn = null
+        continue
+      }
+
+      warnings.add('Some check-in records used an unknown direction and were ignored.')
+    }
+
+    if (openIn) {
+      sessions.push({
+        memberId,
+        inAt: openIn.timestamp,
+        outAt: null,
+        status: 'open',
+      })
+    }
+
+    sessionsByMember.set(memberId, sessions)
+  }
+
+  return sessionsByMember
+}
+
+export class OperationalReportService {
+  private repository: OperationalReportRepository
+
+  constructor(prismaClient?: PrismaClientInstance, repository?: OperationalReportRepository) {
+    this.repository = repository ?? new OperationalReportRepository(prismaClient)
+  }
+
+  async generateDailyPresence(
+    config: DailyPresenceReportConfig,
+    actor: OperationalReportActor
+  ): Promise<DailyPresenceReportResponse> {
+    const range = this.getDayRange(config.date)
+    const warnings = new Set<string>()
+    const scope = await this.resolveScope(config, warnings)
+    const members = scope.noResults
+      ? []
+      : await this.repository.findActiveMembers({
+          divisionId: scope.divisionId,
+          tagId: scope.tagId,
+        })
+    const sessionsByMember = await this.getSessionsByMember(members, range, warnings)
+
+    const rows = members
+      .map((member) => {
+        const memberSessions = sessionsByMember.get(member.id) ?? []
+        const overlappingSessions = memberSessions.filter((session) =>
+          this.sessionOverlaps(session, range.start, range.end)
+        )
+
+        if (overlappingSessions.length === 0) {
+          return null
+        }
+
+        const stats = this.getPresenceStats(overlappingSessions, range.start, range.end)
+
+        return {
+          member: this.toMemberSummary(member),
+          firstIn: stats.firstIn,
+          lastOut: stats.lastOut,
+          sessionCount: stats.sessionCount,
+          leftAndReturned: stats.sessionCount > 1,
+          sessions: overlappingSessions.map((session) =>
+            this.toPresenceSession(session, range.start, range.end)
+          ),
+        }
+      })
+      .filter((row): row is NonNullable<typeof row> => row !== null)
+
+    return {
+      ...this.getEnvelopeBase('daily_presence', 'Daily Presence Report', actor, range, {
+        scopeLabel: scope.scopeLabel,
+        divisionId: scope.divisionId,
+        tagId: scope.tagId,
+      }),
+      warnings: Array.from(warnings),
+      data: {
+        summary: {
+          totalScopedMembers: members.length,
+          presentMembers: rows.length,
+          totalSessions: rows.reduce((total, row) => total + row.sessionCount, 0),
+          leftAndReturnedCount: rows.filter((row) => row.leftAndReturned).length,
+          openSessionCount: rows.reduce(
+            (total, row) =>
+              total + row.sessions.filter((session) => session.status !== 'complete').length,
+            0
+          ),
+        },
+        rows,
+      },
+    }
+  }
+
+  async generateWeeklyPresence(
+    config: WeeklyPresenceReportConfig,
+    actor: OperationalReportActor
+  ): Promise<WeeklyPresenceReportResponse> {
+    const range = this.getWeekRange(config.weekStartDate)
+    const warnings = new Set<string>()
+    const scope = await this.resolveScope(config, warnings)
+    const members = scope.noResults
+      ? []
+      : await this.repository.findActiveMembers({
+          divisionId: scope.divisionId,
+          tagId: scope.tagId,
+        })
+    const sessionsByMember = await this.getSessionsByMember(members, range, warnings)
+    const keyNights = await this.getKeyNights(range, ['training', 'administrative'], warnings)
+    const days = this.getDatesInRange(range).map((date) => ({
+      date,
+      label: this.formatShortDate(date),
+      isTrainingNight: keyNights.some(
+        (night) => night.category === 'training' && night.date === date
+      ),
+      isAdminNight: keyNights.some(
+        (night) => night.category === 'administrative' && night.date === date
+      ),
+    }))
+
+    const rows = members.map((member) => {
+      const memberSessions = sessionsByMember.get(member.id) ?? []
+      const dayMarkers = days.map((day) =>
+        this.getPresenceMarker(day.date, memberSessions, this.formatShortDate(day.date))
+      )
+      const keyNightMarkers = keyNights.map((night) =>
+        this.getKeyNightPresenceMarker(night, memberSessions)
+      )
+
+      return {
+        member: this.toMemberSummary(member),
+        days: dayMarkers,
+        trainingNightPresent: this.getCategoryPresence('training', keyNights, keyNightMarkers),
+        adminNightPresent: this.getCategoryPresence('administrative', keyNights, keyNightMarkers),
+        keyNights: keyNightMarkers,
+        totalDaysPresent: dayMarkers.filter((marker) => marker.present).length,
+        totalSessions: memberSessions.filter((session) =>
+          this.sessionOverlaps(session, range.start, range.end)
+        ).length,
+      }
+    })
+
+    return {
+      ...this.getEnvelopeBase('weekly_presence', 'Weekly Presence Report', actor, range, {
+        scopeLabel: scope.scopeLabel,
+        divisionId: scope.divisionId,
+        tagId: scope.tagId,
+      }),
+      warnings: Array.from(warnings),
+      data: {
+        summary: {
+          totalMembers: members.length,
+          membersWithPresence: rows.filter((row) => row.totalDaysPresent > 0).length,
+          trainingNightCount: keyNights.filter((night) => night.category === 'training').length,
+          adminNightCount: keyNights.filter((night) => night.category === 'administrative').length,
+        },
+        days,
+        keyNights: keyNights.map(this.toApiKeyNight),
+        rows,
+      },
+    }
+  }
+
+  async generateMonthlyPresence(
+    config: MonthlyPresenceReportConfig,
+    actor: OperationalReportActor
+  ): Promise<MonthlyPresenceReportResponse> {
+    const range = this.getMonthRange(config.month)
+    const warnings = new Set<string>()
+    const scope = await this.resolveScope(config, warnings)
+    const members = scope.noResults
+      ? []
+      : await this.repository.findActiveMembers({
+          divisionId: scope.divisionId,
+          tagId: scope.tagId,
+        })
+    const sessionsByMember = await this.getSessionsByMember(members, range, warnings)
+    const keyNights = await this.getKeyNights(range, ['training', 'administrative'], warnings)
+    const days = this.getDatesInRange(range).map((date) => ({
+      date,
+      label: DateTime.fromISO(date, { zone: DEFAULT_TIMEZONE }).toFormat('d'),
+      isTrainingNight: keyNights.some(
+        (night) => night.category === 'training' && night.date === date
+      ),
+      isAdminNight: keyNights.some(
+        (night) => night.category === 'administrative' && night.date === date
+      ),
+    }))
+
+    const rows = members.map((member) => {
+      const memberSessions = sessionsByMember.get(member.id) ?? []
+      const dayMarkers = days.map((day) =>
+        this.getPresenceMarker(day.date, memberSessions, day.label)
+      )
+      const keyNightMarkers = keyNights.map((night) =>
+        this.getKeyNightPresenceMarker(night, memberSessions)
+      )
+
+      return {
+        member: this.toMemberSummary(member),
+        days: dayMarkers,
+        keyNights: keyNightMarkers,
+        totalDaysPresent: dayMarkers.filter((marker) => marker.present).length,
+        totalSessions: memberSessions.filter((session) =>
+          this.sessionOverlaps(session, range.start, range.end)
+        ).length,
+        trainingNightsPresent: this.countCategoryPresence('training', keyNights, keyNightMarkers),
+        adminNightsPresent: this.countCategoryPresence(
+          'administrative',
+          keyNights,
+          keyNightMarkers
+        ),
+      }
+    })
+
+    return {
+      ...this.getEnvelopeBase('monthly_presence', 'Monthly Presence Report', actor, range, {
+        scopeLabel: scope.scopeLabel,
+        divisionId: scope.divisionId,
+        tagId: scope.tagId,
+      }),
+      warnings: Array.from(warnings),
+      data: {
+        summary: {
+          totalMembers: members.length,
+          membersWithPresence: rows.filter((row) => row.totalDaysPresent > 0).length,
+          totalMemberDaysPresent: rows.reduce((total, row) => total + row.totalDaysPresent, 0),
+          trainingNightCount: keyNights.filter((night) => night.category === 'training').length,
+          adminNightCount: keyNights.filter((night) => night.category === 'administrative').length,
+        },
+        days,
+        keyNights: keyNights.map(this.toApiKeyNight),
+        rows,
+      },
+    }
+  }
+
+  async generateTrainingNightMonthly(
+    config: TrainingNightMonthlyReportConfig,
+    actor: OperationalReportActor
+  ): Promise<TrainingNightMonthlyReportResponse> {
+    const range = this.getMonthRange(config.month)
+    const warnings = new Set<string>()
+    const division = await this.repository.findDivisionById(config.divisionId)
+    if (!division) {
+      warnings.add('Selected department was not found. The report has no department members.')
+    }
+    const members = division
+      ? await this.repository.findActiveMembers({ divisionId: config.divisionId })
+      : []
+    const sessionsByMember = await this.getSessionsByMember(members, range, warnings)
+    const keyNights = await this.getKeyNights(range, ['training'], warnings)
+    const trainingNights = keyNights.filter((night) => night.category === 'training')
+
+    if (trainingNights.length === 0) {
+      warnings.add('No Training Nights were found for the selected month.')
+    }
+
+    const rows = members.map((member) => {
+      const memberSessions = sessionsByMember.get(member.id) ?? []
+      const nightMarkers = trainingNights.map((night) =>
+        this.getKeyNightPresenceMarker(night, memberSessions)
+      )
+      const attended = nightMarkers.filter((marker) => marker.present).length
+      const possible = trainingNights.length
+
+      return {
+        member: this.toMemberSummary(member),
+        nights: nightMarkers,
+        attended,
+        possible,
+        percentage: possible > 0 ? Math.round((attended / possible) * 100) : 0,
+      }
+    })
+
+    return {
+      ...this.getEnvelopeBase(
+        'training_night_monthly',
+        'Training Night Monthly Report',
+        actor,
+        range,
+        {
+          scopeLabel: division ? division.name : 'Selected department',
+          divisionId: config.divisionId,
+        }
+      ),
+      warnings: Array.from(warnings),
+      data: {
+        department: division
+          ? {
+              id: division.id,
+              code: division.code,
+              name: division.name,
+            }
+          : null,
+        trainingNights: trainingNights.map(this.toApiKeyNight),
+        rows,
+        summary: {
+          totalMembers: members.length,
+          trainingNightCount: trainingNights.length,
+          averageAttendancePercentage:
+            rows.length > 0
+              ? Math.round(rows.reduce((total, row) => total + row.percentage, 0) / rows.length)
+              : 0,
+        },
+      },
+    }
+  }
+
+  async generateVisitorActivity(
+    config: VisitorActivityReportConfig,
+    actor: OperationalReportActor
+  ): Promise<VisitorActivityReportResponse> {
+    const range = this.getCustomRange(config.startDate, config.endDate)
+    const visitors = await this.repository.findVisitors({
+      start: range.start,
+      end: range.end,
+      visitType: this.blankToUndefined(config.visitType),
+      visitorPurpose: this.blankToUndefined(config.visitorPurpose),
+      eventLinked: config.eventLinked,
+      hostMemberId: config.hostMemberId,
+      organization: this.blankToUndefined(config.organization),
+    })
+
+    const rows = visitors.map((visitor) => this.toVisitorActivityRow(visitor))
+
+    return {
+      ...this.getEnvelopeBase('visitor_activity', 'Visitor Activity Report', actor, range, {
+        scopeLabel: 'Visitor activity',
+        visitorType: this.blankToUndefined(config.visitType),
+        visitorPurpose: this.blankToUndefined(config.visitorPurpose),
+        eventCategory:
+          config.eventLinked === undefined
+            ? undefined
+            : config.eventLinked
+              ? 'Event-linked visitors'
+              : 'Visitors without event link',
+      }),
+      warnings: [],
+      data: {
+        summary: {
+          totalVisitors: rows.length,
+          activeAtEnd: visitors.filter(
+            (visitor) => !visitor.checkOutTime || visitor.checkOutTime >= range.end
+          ).length,
+          byVisitType: this.countByLabel(rows.map((row) => row.visitType)),
+          byPurpose: this.countByLabel(rows.map((row) => row.visitPurpose ?? 'Unspecified')),
+          byEvent: this.countByLabel(rows.map((row) => row.event?.name ?? 'No event link')),
+        },
+        rows,
+      },
+    }
+  }
+
+  private getEnvelopeBase<
+    TReportType extends
+      | 'daily_presence'
+      | 'weekly_presence'
+      | 'monthly_presence'
+      | 'training_night_monthly'
+      | 'visitor_activity',
+  >(
+    reportType: TReportType,
+    title: string,
+    actor: OperationalReportActor,
+    range: DateRange,
+    filters: {
+      scopeLabel: string
+      divisionId?: string
+      tagId?: string
+      visitorType?: string
+      visitorPurpose?: string
+      eventCategory?: string
+    }
+  ) {
+    return {
+      reportType,
+      title,
+      generatedAt: new Date().toISOString(),
+      generatedBy: {
+        id: actor.id,
+        displayName: this.formatActorName(actor),
+      },
+      unitName: UNIT_NAME,
+      dateRange: {
+        startDate: range.startDate,
+        endDate: range.endDate,
+        label: range.label,
+      },
+      filters,
+    }
+  }
+
+  private async resolveScope(
+    config: {
+      scopeType?: ReportScopeType
+      divisionId?: string
+      tagId?: string
+    },
+    warnings: Set<string>
+  ): Promise<EffectiveScope> {
+    const scopeType = config.scopeType ?? 'everyone'
+
+    if (scopeType === 'department') {
+      if (!config.divisionId) {
+        warnings.add('Department scope was selected, but no department was provided.')
+        return {
+          scopeLabel: 'Department',
+          warnings: Array.from(warnings),
+          noResults: true,
+        }
+      }
+
+      const division = await this.repository.findDivisionById(config.divisionId)
+      if (!division) {
+        warnings.add('Selected department was not found.')
+        return {
+          divisionId: config.divisionId,
+          scopeLabel: 'Selected department',
+          warnings: Array.from(warnings),
+          noResults: true,
+        }
+      }
+
+      return {
+        divisionId: division.id,
+        scopeLabel: division.name,
+        warnings: Array.from(warnings),
+        noResults: false,
+      }
+    }
+
+    if (scopeType === 'tag') {
+      if (!config.tagId) {
+        warnings.add('Tag scope was selected, but no tag was provided.')
+        return {
+          scopeLabel: 'Specific tag',
+          warnings: Array.from(warnings),
+          noResults: true,
+        }
+      }
+
+      const tag = await this.repository.findTagById(config.tagId)
+      if (!tag) {
+        warnings.add('Selected tag was not found.')
+        return {
+          tagId: config.tagId,
+          scopeLabel: 'Specific tag',
+          warnings: Array.from(warnings),
+          noResults: true,
+        }
+      }
+
+      return {
+        tagId: tag.id,
+        scopeLabel: tag.name,
+        warnings: Array.from(warnings),
+        noResults: false,
+      }
+    }
+
+    if (scopeType === 'fts' || scopeType === 'geo') {
+      const tag = await this.repository.findTagShortcut(scopeType)
+      if (!tag) {
+        warnings.add(`${scopeType.toUpperCase()} tag was not found. No tag IDs were hardcoded.`)
+        return {
+          scopeLabel: `${scopeType.toUpperCase()} tag shortcut`,
+          warnings: Array.from(warnings),
+          noResults: true,
+        }
+      }
+
+      return {
+        tagId: tag.id,
+        scopeLabel: tag.name,
+        warnings: Array.from(warnings),
+        noResults: false,
+      }
+    }
+
+    return {
+      scopeLabel: 'Everyone',
+      warnings: Array.from(warnings),
+      noResults: false,
+    }
+  }
+
+  private async getSessionsByMember(
+    members: OperationalReportMemberRecord[],
+    range: DateRange,
+    warnings: Set<string>
+  ): Promise<Map<string, PresenceSessionInternal[]>> {
+    const memberIds = members.map((member) => member.id)
+    const queryStart = DateTime.fromJSDate(range.start, { zone: DEFAULT_TIMEZONE })
+      .minus({ days: REPORT_LOOKBACK_DAYS })
+      .toJSDate()
+    const checkins = await this.repository.findCheckinsForMembers(memberIds, queryStart, range.end)
+    return this.pairSessions(checkins, warnings)
+  }
+
+  private pairSessions(
+    checkins: OperationalReportCheckinRecord[],
+    warnings: Set<string>
+  ): Map<string, PresenceSessionInternal[]> {
+    return pairOperationalPresenceSessions(checkins, warnings)
+  }
+
+  private getPresenceMarker(
+    date: string,
+    sessions: PresenceSessionInternal[],
+    label: string
+  ): PresenceMarker {
+    const range = this.getDayRange(date)
+    const overlapping = sessions.filter((session) =>
+      this.sessionOverlaps(session, range.start, range.end)
+    )
+    const stats = this.getPresenceStats(overlapping, range.start, range.end)
+
+    return {
+      date,
+      label,
+      present: stats.present,
+      firstIn: stats.firstIn,
+      lastOut: stats.lastOut,
+      sessionCount: stats.sessionCount,
+      note: stats.note,
+    }
+  }
+
+  private getPresenceStats(
+    sessions: PresenceSessionInternal[],
+    start: Date,
+    end: Date
+  ): PresenceStats {
+    const overlapping = sessions.filter((session) => this.sessionOverlaps(session, start, end))
+    const firstIn = this.minDate(
+      overlapping.map((session) => session.inAt).filter((date) => date >= start && date < end)
+    )
+    const lastOut = this.maxDate(
+      overlapping
+        .map((session) => session.outAt)
+        .filter((date): date is Date => date !== null && date >= start && date < end)
+    )
+    const hasOpen = overlapping.some((session) => session.outAt === null)
+
+    return {
+      present: overlapping.length > 0,
+      firstIn: firstIn?.toISOString() ?? null,
+      lastOut: lastOut?.toISOString() ?? null,
+      sessionCount: overlapping.length,
+      note: hasOpen ? 'Still present / no checkout recorded' : null,
+    }
+  }
+
+  private getKeyNightPresenceMarker(night: KeyNightWindow, sessions: PresenceSessionInternal[]) {
+    const range =
+      night.start && night.end
+        ? { start: night.start, end: night.end }
+        : this.getDayRange(night.date)
+    const stats = this.getPresenceStats(sessions, range.start, range.end)
+
+    return {
+      keyNightId: night.id,
+      present: stats.present,
+      firstIn: stats.firstIn,
+      lastOut: stats.lastOut,
+    }
+  }
+
+  private async getKeyNights(
+    range: DateRange,
+    categories: KeyNightCategory[],
+    warnings: Set<string>
+  ): Promise<KeyNightWindow[]> {
+    const events = await this.repository.findUnitEvents(range.start, range.end, categories)
+    const eventNights = events.map((event) => this.toKeyNightFromEvent(event))
+    const scheduleNights = await this.getScheduleKeyNights(range, categories, warnings)
+    const deduped = new Map<string, KeyNightWindow>()
+
+    for (const night of scheduleNights) {
+      deduped.set(`${night.category}:${night.date}`, night)
+    }
+
+    for (const night of eventNights) {
+      deduped.set(`${night.category}:${night.date}`, night)
+    }
+
+    const result = Array.from(deduped.values()).sort((left, right) =>
+      `${left.date}:${left.category}`.localeCompare(`${right.date}:${right.category}`)
+    )
+
+    for (const category of categories) {
+      if (!result.some((night) => night.category === category)) {
+        warnings.add(
+          `No ${category === 'training' ? 'Training' : 'Admin'} Nights were found from Unit Events or report schedule settings.`
+        )
+      }
+    }
+
+    return result
+  }
+
+  private async getScheduleKeyNights(
+    range: DateRange,
+    categories: KeyNightCategory[],
+    warnings: Set<string>
+  ): Promise<KeyNightWindow[]> {
+    const value = await this.repository.findReportSettingValue('schedule')
+    if (!value) {
+      return []
+    }
+
+    const parsed = v.safeParse(ScheduleSettingsValueSchema, value)
+    if (!parsed.success) {
+      warnings.add(
+        'Report schedule settings are present but invalid; schedule nights were omitted.'
+      )
+      return []
+    }
+
+    const schedule = parsed.output
+    const nights: KeyNightWindow[] = []
+    const dates = this.getDatesInRange(range)
+
+    for (const date of dates) {
+      const weekday = DateTime.fromISO(date, { zone: DEFAULT_TIMEZONE }).weekday
+
+      if (
+        categories.includes('training') &&
+        weekday === this.dayNameToIsoWeekday(schedule.trainingNightDay)
+      ) {
+        nights.push(
+          this.toScheduleKeyNight(
+            'training',
+            date,
+            'Training Night',
+            schedule.trainingNightStart,
+            schedule.trainingNightEnd
+          )
+        )
+      }
+
+      if (
+        categories.includes('administrative') &&
+        weekday === this.dayNameToIsoWeekday(schedule.adminNightDay)
+      ) {
+        nights.push(
+          this.toScheduleKeyNight(
+            'administrative',
+            date,
+            'Admin Night',
+            schedule.adminNightStart,
+            schedule.adminNightEnd
+          )
+        )
+      }
+    }
+
+    return nights
+  }
+
+  private toKeyNightFromEvent(event: OperationalReportUnitEventRecord): KeyNightWindow {
+    const date = event.eventDate.toISOString().substring(0, 10)
+    const category = event.eventType?.category === 'administrative' ? 'administrative' : 'training'
+    const startTime = event.startTime ? event.startTime.toISOString().substring(11, 16) : null
+    const endTime = event.endTime ? event.endTime.toISOString().substring(11, 16) : null
+    const start = startTime ? this.dateTimeFromLocalDateAndTime(date, startTime) : null
+    const end = start
+      ? endTime
+        ? this.ensureEndAfterStart(start, this.dateTimeFromLocalDateAndTime(date, endTime))
+        : DateTime.fromJSDate(start, { zone: DEFAULT_TIMEZONE })
+            .plus({ minutes: event.eventType?.defaultDurationMinutes ?? 120 })
+            .toJSDate()
+      : null
+
+    return {
+      id: `unit-event:${event.id}`,
+      category,
+      source: 'unit_event',
+      date,
+      label: this.formatShortDate(date),
+      title: event.title,
+      startAt: start?.toISOString() ?? null,
+      endAt: end?.toISOString() ?? null,
+      start,
+      end,
+    }
+  }
+
+  private toScheduleKeyNight(
+    category: KeyNightCategory,
+    date: string,
+    title: string,
+    startTime: string,
+    endTime: string
+  ): KeyNightWindow {
+    const start = this.dateTimeFromLocalDateAndTime(date, startTime)
+    const end = this.ensureEndAfterStart(start, this.dateTimeFromLocalDateAndTime(date, endTime))
+
+    return {
+      id: `report-settings:${category}:${date}`,
+      category,
+      source: 'report_settings',
+      date,
+      label: this.formatShortDate(date),
+      title,
+      startAt: start.toISOString(),
+      endAt: end.toISOString(),
+      start,
+      end,
+    }
+  }
+
+  private toApiKeyNight(night: KeyNightWindow): KeyNight {
+    return {
+      id: night.id,
+      category: night.category,
+      source: night.source,
+      date: night.date,
+      label: night.label,
+      title: night.title,
+      startAt: night.startAt,
+      endAt: night.endAt,
+    }
+  }
+
+  private toMemberSummary(member: OperationalReportMemberRecord): ReportMemberSummary {
+    const directTags = member.memberTags.map<ReportTagSummary>((memberTag) => ({
+      id: memberTag.tag.id,
+      name: memberTag.tag.name,
+      chipVariant: memberTag.tag.chipVariant,
+      chipColor: memberTag.tag.chipColor,
+      isPositional: memberTag.tag.isPositional,
+      source: 'direct',
+    }))
+    const qualificationTags = member.qualifications
+      .map((qualification) => qualification.qualificationType.tag)
+      .filter((tag): tag is NonNullable<typeof tag> => tag !== null)
+      .map<ReportTagSummary>((tag) => ({
+        id: tag.id,
+        name: tag.name,
+        chipVariant: tag.chipVariant,
+        chipColor: tag.chipColor,
+        isPositional: tag.isPositional,
+        source: 'qualification',
+      }))
+    const tags = this.dedupeTags([...directTags, ...qualificationTags])
+
+    return {
+      id: member.id,
+      displayName:
+        member.displayName ??
+        [member.rank, member.firstName, member.lastName].filter(Boolean).join(' '),
+      rank: member.rank,
+      status: member.memberStatusRef?.name ?? member.status,
+      division: member.division
+        ? {
+            id: member.division.id,
+            code: member.division.code,
+            name: member.division.name,
+          }
+        : null,
+      memberType: member.memberTypeRef?.name ?? member.memberType,
+      tags,
+    }
+  }
+
+  private toPresenceSession(
+    session: PresenceSessionInternal,
+    start: Date,
+    end: Date
+  ): PresenceSession {
+    const clippedIn = session.inAt < start ? start : session.inAt
+    const rawOut = session.outAt && session.outAt > end ? end : session.outAt
+    const clippedOut = rawOut && rawOut < start ? start : rawOut
+
+    return {
+      inAt: clippedIn.toISOString(),
+      outAt: clippedOut?.toISOString() ?? null,
+      durationMinutes: clippedOut
+        ? Math.max(0, Math.round((clippedOut.getTime() - clippedIn.getTime()) / 60_000))
+        : null,
+      status: session.status,
+    }
+  }
+
+  private toVisitorActivityRow(visitor: OperationalReportVisitorRecord) {
+    const displayName = visitor.displayName ?? visitor.name
+    const hostName = visitor.hostMember
+      ? (visitor.hostMember.displayName ??
+        [visitor.hostMember.rank, visitor.hostMember.firstName, visitor.hostMember.lastName]
+          .filter(Boolean)
+          .join(' '))
+      : null
+
+    return {
+      id: visitor.id,
+      displayName,
+      organization: visitor.organization,
+      visitType: visitor.visitType,
+      visitPurpose: visitor.visitPurpose,
+      visitReason: visitor.visitReason,
+      checkInTime: visitor.checkInTime.toISOString(),
+      checkOutTime: visitor.checkOutTime?.toISOString() ?? null,
+      durationMinutes: visitor.checkOutTime
+        ? Math.max(
+            0,
+            Math.round((visitor.checkOutTime.getTime() - visitor.checkInTime.getTime()) / 60_000)
+          )
+        : null,
+      event: visitor.event
+        ? {
+            id: visitor.event.id,
+            name: visitor.event.name,
+          }
+        : null,
+      host:
+        visitor.hostMember && hostName
+          ? {
+              id: visitor.hostMember.id,
+              displayName: hostName,
+            }
+          : null,
+    }
+  }
+
+  private sessionOverlaps(session: PresenceSessionInternal, start: Date, end: Date): boolean {
+    const effectiveOut = session.outAt ?? end
+    return session.inAt < end && effectiveOut > start
+  }
+
+  private getCategoryPresence(
+    category: KeyNightCategory,
+    keyNights: KeyNightWindow[],
+    markers: Array<{ keyNightId: string; present: boolean }>
+  ): boolean | null {
+    const categoryNights = keyNights.filter((night) => night.category === category)
+    if (categoryNights.length === 0) {
+      return null
+    }
+
+    return categoryNights.some((night) =>
+      markers.some((marker) => marker.keyNightId === night.id && marker.present)
+    )
+  }
+
+  private countCategoryPresence(
+    category: KeyNightCategory,
+    keyNights: KeyNightWindow[],
+    markers: Array<{ keyNightId: string; present: boolean }>
+  ): number {
+    const categoryNightIds = new Set(
+      keyNights.filter((night) => night.category === category).map((night) => night.id)
+    )
+    return markers.filter((marker) => categoryNightIds.has(marker.keyNightId) && marker.present)
+      .length
+  }
+
+  private dedupeTags(tags: ReportTagSummary[]): ReportTagSummary[] {
+    const seen = new Set<string>()
+    const result: ReportTagSummary[] = []
+
+    for (const tag of tags) {
+      if (seen.has(tag.id)) {
+        continue
+      }
+      seen.add(tag.id)
+      result.push(tag)
+    }
+
+    return result.sort((left, right) => left.name.localeCompare(right.name))
+  }
+
+  private countByLabel(labels: string[]) {
+    const counts = new Map<string, number>()
+    for (const label of labels) {
+      counts.set(label, (counts.get(label) ?? 0) + 1)
+    }
+    return Array.from(counts.entries())
+      .map(([label, count]) => ({ label, count }))
+      .sort((left, right) => right.count - left.count || left.label.localeCompare(right.label))
+  }
+
+  private minDate(dates: Date[]): Date | null {
+    if (dates.length === 0) {
+      return null
+    }
+    return new Date(Math.min(...dates.map((date) => date.getTime())))
+  }
+
+  private maxDate(dates: Date[]): Date | null {
+    if (dates.length === 0) {
+      return null
+    }
+    return new Date(Math.max(...dates.map((date) => date.getTime())))
+  }
+
+  private getDayRange(date: string): DateRange {
+    const start = DateTime.fromISO(date, { zone: DEFAULT_TIMEZONE }).startOf('day')
+    const end = start.plus({ days: 1 })
+    return {
+      start: start.toJSDate(),
+      end: end.toJSDate(),
+      startDate: start.toISODate() ?? date,
+      endDate: start.toISODate() ?? date,
+      label: start.toFormat('cccc, LLL d, yyyy'),
+    }
+  }
+
+  private getWeekRange(weekStartDate: string): DateRange {
+    const start = DateTime.fromISO(weekStartDate, { zone: DEFAULT_TIMEZONE })
+      .startOf('week')
+      .startOf('day')
+    const end = start.plus({ days: 7 })
+    const endInclusive = end.minus({ days: 1 })
+    return {
+      start: start.toJSDate(),
+      end: end.toJSDate(),
+      startDate: start.toISODate() ?? weekStartDate,
+      endDate: endInclusive.toISODate() ?? weekStartDate,
+      label: `${start.toFormat('LLL d')} - ${endInclusive.toFormat('LLL d, yyyy')}`,
+    }
+  }
+
+  private getMonthRange(month: string): DateRange {
+    const start = DateTime.fromISO(`${month}-01`, { zone: DEFAULT_TIMEZONE }).startOf('month')
+    const end = start.plus({ months: 1 })
+    const endInclusive = end.minus({ days: 1 })
+    return {
+      start: start.toJSDate(),
+      end: end.toJSDate(),
+      startDate: start.toISODate() ?? `${month}-01`,
+      endDate: endInclusive.toISODate() ?? `${month}-01`,
+      label: start.toFormat('LLLL yyyy'),
+    }
+  }
+
+  private getCustomRange(startDate: string, endDate: string): DateRange {
+    const start = DateTime.fromISO(startDate, { zone: DEFAULT_TIMEZONE }).startOf('day')
+    const endInclusive = DateTime.fromISO(endDate, { zone: DEFAULT_TIMEZONE }).startOf('day')
+    const end = endInclusive.plus({ days: 1 })
+    return {
+      start: start.toJSDate(),
+      end: end.toJSDate(),
+      startDate: start.toISODate() ?? startDate,
+      endDate: endInclusive.toISODate() ?? endDate,
+      label:
+        start.toISODate() === endInclusive.toISODate()
+          ? start.toFormat('cccc, LLL d, yyyy')
+          : `${start.toFormat('LLL d, yyyy')} - ${endInclusive.toFormat('LLL d, yyyy')}`,
+    }
+  }
+
+  private getDatesInRange(range: DateRange): string[] {
+    const dates: string[] = []
+    let cursor = DateTime.fromJSDate(range.start, { zone: DEFAULT_TIMEZONE }).startOf('day')
+    const end = DateTime.fromJSDate(range.end, { zone: DEFAULT_TIMEZONE }).startOf('day')
+
+    while (cursor < end) {
+      const date = cursor.toISODate()
+      if (date) {
+        dates.push(date)
+      }
+      cursor = cursor.plus({ days: 1 })
+    }
+
+    return dates
+  }
+
+  private dateTimeFromLocalDateAndTime(date: string, time: string): Date {
+    return DateTime.fromISO(`${date}T${time}:00`, { zone: DEFAULT_TIMEZONE }).toJSDate()
+  }
+
+  private ensureEndAfterStart(start: Date, end: Date): Date {
+    if (end > start) {
+      return end
+    }
+
+    return DateTime.fromJSDate(end, { zone: DEFAULT_TIMEZONE }).plus({ days: 1 }).toJSDate()
+  }
+
+  private formatShortDate(date: string): string {
+    return DateTime.fromISO(date, { zone: DEFAULT_TIMEZONE }).toFormat('ccc LLL d')
+  }
+
+  private dayNameToIsoWeekday(dayName: string): number {
+    const map: Record<string, number> = {
+      monday: 1,
+      tuesday: 2,
+      wednesday: 3,
+      thursday: 4,
+      friday: 5,
+      saturday: 6,
+      sunday: 7,
+    }
+
+    return map[dayName] ?? 1
+  }
+
+  private formatActorName(actor: OperationalReportActor): string {
+    return [actor.rank, actor.firstName, actor.lastName].filter(Boolean).join(' ') || actor.id
+  }
+
+  private blankToUndefined(value: string | undefined): string | undefined {
+    const trimmed = value?.trim()
+    return trimmed ? trimmed : undefined
+  }
+}

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/app/admin/reports/page.tsx
+++ b/apps/frontend-admin/src/app/admin/reports/page.tsx
@@ -1,0 +1,17 @@
+import { Suspense } from 'react'
+import { AdminReportsPage } from '@/components/admin/reports/AdminReportsPage'
+import { LoadingSpinner } from '@/components/ui/loading-spinner'
+
+export default function AdminReportsRoute() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center py-12">
+          <LoadingSpinner size="lg" className="text-base-content/60" />
+        </div>
+      }
+    >
+      <AdminReportsPage />
+    </Suspense>
+  )
+}

--- a/apps/frontend-admin/src/app/globals.css
+++ b/apps/frontend-admin/src/app/globals.css
@@ -258,6 +258,85 @@
   color: oklch(21% 0.006 285.885);
 }
 
+/* ========================================
+   ADMIN REPORT PRINT OUTPUT
+   Keep printed reports document-like and hide app chrome.
+   ======================================== */
+
+.reports-print-inline {
+  display: none;
+}
+
+@page {
+  margin: 0.45in;
+}
+
+@page reports-landscape {
+  size: landscape;
+  margin: 0.35in;
+}
+
+@media print {
+  html,
+  body {
+    background: white !important;
+  }
+
+  body * {
+    visibility: hidden !important;
+  }
+
+  .reports-print-document,
+  .reports-print-document * {
+    visibility: visible !important;
+  }
+
+  .reports-screen-only {
+    display: none !important;
+  }
+
+  .reports-print-inline {
+    display: inline !important;
+  }
+
+  .reports-print-document {
+    position: absolute !important;
+    inset: 0 auto auto 0 !important;
+    width: 100% !important;
+    border: 0 !important;
+    border-radius: 0 !important;
+    box-shadow: none !important;
+    color: black !important;
+    background: white !important;
+  }
+
+  .reports-print-landscape {
+    page: reports-landscape;
+  }
+
+  .reports-summary-grid,
+  .reports-print-document section,
+  .reports-print-document tr {
+    break-inside: avoid;
+  }
+
+  .reports-table {
+    border-collapse: collapse !important;
+    width: 100% !important;
+    font-size: 10pt !important;
+  }
+
+  .reports-table thead {
+    display: table-header-group;
+  }
+
+  .reports-table th,
+  .reports-table td {
+    border-bottom: 1px solid oklch(86% 0.005 56.366) !important;
+    padding: 0.18rem 0.25rem !important;
+  }
+}
+
 .kiosk-simple-keyboard.hg-theme-default .hg-button[data-skbtn='{continue}'] {
   background: oklch(60.5% 0.216 257.16);
   color: oklch(97% 0.014 254.604);

--- a/apps/frontend-admin/src/components/admin/admin-icons.tsx
+++ b/apps/frontend-admin/src/components/admin/admin-icons.tsx
@@ -7,6 +7,7 @@ import {
   Clock3,
   Database,
   Download,
+  FileText,
   ListChecks,
   Network,
   ScrollText,
@@ -35,6 +36,8 @@ export function AdminIcon({ icon, ...props }: AdminIconProps) {
       return <Database {...props} />
     case 'download':
       return <Download {...props} />
+    case 'file-text':
+      return <FileText {...props} />
     case 'list':
       return <ListChecks {...props} />
     case 'logs':

--- a/apps/frontend-admin/src/components/admin/reports/AdminReportsPage.tsx
+++ b/apps/frontend-admin/src/components/admin/reports/AdminReportsPage.tsx
@@ -1,0 +1,586 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { FileText, Play, Printer, RotateCcw } from 'lucide-react'
+import {
+  AppCard,
+  AppCardContent,
+  AppCardDescription,
+  AppCardHeader,
+  AppCardTitle,
+} from '@/components/ui/AppCard'
+import { AppBadge } from '@/components/ui/AppBadge'
+import {
+  useAdminReportRunner,
+  useVisitTypesForReports,
+  type AdminReportResponse,
+  type RunAdminReportInput,
+} from '@/hooks/use-admin-reports'
+import { useDivisions } from '@/hooks/use-divisions'
+import { useMembers } from '@/hooks/use-members'
+import { useTags } from '@/hooks/use-member-tags'
+import { cn } from '@/lib/utils'
+import {
+  getBaseReportFilters,
+  getReportDefinition,
+  REPORT_DEFINITIONS,
+  type AdminReportType,
+  type ReportFilters,
+  type ReportScopeType,
+} from './report-definitions'
+import { ReportPreview } from './report-preview'
+
+function optionalString(value: string): string | undefined {
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+function scopeRequiresDepartment(scopeType: ReportScopeType): boolean {
+  return scopeType === 'department'
+}
+
+function scopeRequiresTag(scopeType: ReportScopeType): boolean {
+  return scopeType === 'tag'
+}
+
+function buildRunInput(filters: ReportFilters): RunAdminReportInput {
+  const scopeType = filters.scopeType
+  const divisionId = scopeRequiresDepartment(scopeType)
+    ? optionalString(filters.divisionId)
+    : undefined
+  const tagId = scopeRequiresTag(scopeType) ? optionalString(filters.tagId) : undefined
+
+  switch (filters.reportType) {
+    case 'daily_presence':
+      return {
+        reportType: 'daily_presence',
+        body: {
+          date: filters.date,
+          scopeType,
+          divisionId,
+          tagId,
+        },
+      }
+    case 'weekly_presence':
+      return {
+        reportType: 'weekly_presence',
+        body: {
+          weekStartDate: filters.weekStartDate,
+          scopeType,
+          divisionId,
+          tagId,
+        },
+      }
+    case 'monthly_presence':
+      return {
+        reportType: 'monthly_presence',
+        body: {
+          month: filters.month,
+          scopeType,
+          divisionId,
+          tagId,
+        },
+      }
+    case 'training_night_monthly':
+      return {
+        reportType: 'training_night_monthly',
+        body: {
+          month: filters.month,
+          divisionId: filters.divisionId,
+        },
+      }
+    case 'visitor_activity':
+      return {
+        reportType: 'visitor_activity',
+        body: {
+          startDate: filters.startDate,
+          endDate: filters.endDate,
+          visitType: optionalString(filters.visitType),
+          visitorPurpose: optionalString(filters.visitorPurpose),
+          eventLinked: filters.eventLinked === 'all' ? undefined : filters.eventLinked === 'linked',
+          hostMemberId: optionalString(filters.hostMemberId),
+          organization: optionalString(filters.organization),
+        },
+      }
+  }
+}
+
+export function AdminReportsPage() {
+  const [filters, setFilters] = useState<ReportFilters>(() =>
+    getBaseReportFilters('daily_presence')
+  )
+  const [lastReport, setLastReport] = useState<AdminReportResponse | null>(null)
+  const divisionsQuery = useDivisions()
+  const tagsQuery = useTags()
+  const visitTypesQuery = useVisitTypesForReports()
+  const membersQuery = useMembers({ limit: 500, scope: 'all', status: 'active' })
+  const reportRunner = useAdminReportRunner()
+  const definition = getReportDefinition(filters.reportType)
+  const tags = tagsQuery.data ?? []
+  const ftsTag = tags.find((tag) => tag.name.toLowerCase() === 'fts')
+  const geoTag = tags.find((tag) => tag.name.toLowerCase() === 'geo')
+  const shortcutWarning =
+    filters.scopeType === 'fts' && !ftsTag
+      ? 'FTS tag was not found. The shortcut is disabled until the tag exists.'
+      : filters.scopeType === 'geo' && !geoTag
+        ? 'GEO tag was not found. The shortcut is disabled until the tag exists.'
+        : null
+
+  const validationMessages = useMemo(() => {
+    const messages: string[] = []
+    for (const key of definition.requiredFilters) {
+      if (!filters[key]) {
+        messages.push(`Select ${key.replace(/([A-Z])/g, ' $1').toLowerCase()}.`)
+      }
+    }
+
+    if (scopeRequiresDepartment(filters.scopeType) && !filters.divisionId) {
+      messages.push('Select a department for the department scope.')
+    }
+
+    if (scopeRequiresTag(filters.scopeType) && !filters.tagId) {
+      messages.push('Select a tag for the specific tag scope.')
+    }
+
+    if (shortcutWarning) {
+      messages.push(shortcutWarning)
+    }
+
+    return messages
+  }, [definition.requiredFilters, filters, shortcutWarning])
+
+  const isRunDisabled = validationMessages.length > 0 || reportRunner.isPending
+  const errorMessage = reportRunner.error?.message ?? null
+
+  function updateFilters(next: Partial<ReportFilters>) {
+    setFilters((current) => ({ ...current, ...next }))
+  }
+
+  function handleReportTypeChange(reportType: AdminReportType) {
+    setFilters(getReportDefinition(reportType).defaultFilters())
+  }
+
+  function handleReset() {
+    setFilters(definition.defaultFilters())
+  }
+
+  async function handleRunReport() {
+    const report = await reportRunner.mutateAsync(buildRunInput(filters))
+    setLastReport(report)
+  }
+
+  function handlePrint() {
+    globalThis.window.print()
+  }
+
+  return (
+    <div className="space-y-(--space-4)">
+      <header className="flex flex-wrap items-start justify-between gap-(--space-4)">
+        <div>
+          <h1 id="admin-page-title" className="font-display text-3xl font-bold tracking-normal">
+            Reports
+          </h1>
+          <p className="mt-(--space-1) text-sm text-base-content/65">
+            Generate printable attendance, presence, and visitor reports.
+          </p>
+        </div>
+        <div className="rounded-box border border-base-300 bg-base-100 px-(--space-3) py-(--space-2) text-sm text-base-content/65 shadow-[var(--shadow-1)]">
+          <span className="font-semibold text-base-content">V1 export:</span> browser print
+        </div>
+      </header>
+
+      <AppCard className="reports-screen-only">
+        <AppCardHeader>
+          <div className="flex flex-wrap items-start justify-between gap-(--space-4)">
+            <div>
+              <AppCardTitle className="flex items-center gap-(--space-2)">
+                <FileText className="h-5 w-5 text-info" aria-hidden="true" />
+                Report setup
+              </AppCardTitle>
+              <AppCardDescription>
+                Choose a report, set only the relevant filters, then preview it below.
+              </AppCardDescription>
+            </div>
+            <AppBadge status="info" size="sm">
+              Admin / Developer
+            </AppBadge>
+          </div>
+        </AppCardHeader>
+        <AppCardContent className="space-y-(--space-4)">
+          <div className="grid gap-(--space-4) xl:grid-cols-[minmax(18rem,0.7fr)_minmax(0,1.3fr)]">
+            <ReportTypeSelector value={filters.reportType} onChange={handleReportTypeChange} />
+
+            <ReportsFilterPanel
+              filters={filters}
+              updateFilters={updateFilters}
+              divisions={divisionsQuery.data?.divisions ?? []}
+              tags={tags}
+              visitTypes={visitTypesQuery.data ?? []}
+              hostMembers={membersQuery.data?.members ?? []}
+              shortcutWarning={shortcutWarning}
+            />
+          </div>
+
+          {validationMessages.length > 0 && (
+            <div className="rounded-box border border-warning/40 bg-warning-fadded p-(--space-3) text-sm text-warning-fadded-content">
+              <p className="font-semibold">Required before running</p>
+              <ul className="mt-(--space-1) list-disc pl-(--space-4)">
+                {validationMessages.map((message) => (
+                  <li key={message}>{message}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <ReportActionBar
+            isRunDisabled={isRunDisabled}
+            isRunning={reportRunner.isPending}
+            hasReport={lastReport !== null}
+            onRun={() => {
+              void handleRunReport()
+            }}
+            onPrint={handlePrint}
+            onReset={handleReset}
+          />
+        </AppCardContent>
+      </AppCard>
+
+      <ReportPreview
+        report={lastReport}
+        isLoading={reportRunner.isPending}
+        errorMessage={errorMessage}
+      />
+    </div>
+  )
+}
+
+function ReportTypeSelector({
+  value,
+  onChange,
+}: {
+  value: AdminReportType
+  onChange: (reportType: AdminReportType) => void
+}) {
+  const selected = getReportDefinition(value)
+
+  return (
+    <div className="space-y-(--space-2)">
+      <label className="form-control w-full">
+        <span className="label pb-(--space-1)">
+          <span className="label-text font-semibold">Report type</span>
+        </span>
+        <select
+          className="select select-bordered w-full"
+          value={value}
+          onChange={(event) => onChange(event.target.value as AdminReportType)}
+        >
+          {REPORT_DEFINITIONS.map((definition) => (
+            <option key={definition.reportType} value={definition.reportType}>
+              {definition.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      <p className="text-sm text-base-content/65">{selected.description}</p>
+    </div>
+  )
+}
+
+function ReportsFilterPanel({
+  filters,
+  updateFilters,
+  divisions,
+  tags,
+  visitTypes,
+  hostMembers,
+  shortcutWarning,
+}: {
+  filters: ReportFilters
+  updateFilters: (next: Partial<ReportFilters>) => void
+  divisions: Array<{ id: string; code: string; name: string }>
+  tags: Array<{ id: string; name: string }>
+  visitTypes: Array<{ id: string; code: string; name: string }>
+  hostMembers: Array<{
+    id: string
+    displayName: string
+    rank: string
+    firstName: string
+    lastName: string
+  }>
+  shortcutWarning: string | null
+}) {
+  const definition = getReportDefinition(filters.reportType)
+  const visible = new Set(definition.visibleFilters)
+  const showScope = visible.has('scopeType')
+  const showDepartment =
+    visible.has('divisionId') &&
+    (filters.reportType === 'training_night_monthly' || filters.scopeType === 'department')
+  const showTag = visible.has('tagId') && filters.scopeType === 'tag'
+
+  return (
+    <div className="grid gap-(--space-3) md:grid-cols-2 xl:grid-cols-3">
+      {visible.has('date') && (
+        <DateInput label="Day" value={filters.date} onChange={(date) => updateFilters({ date })} />
+      )}
+      {visible.has('weekStartDate') && (
+        <DateInput
+          label="Week of"
+          value={filters.weekStartDate}
+          onChange={(weekStartDate) => updateFilters({ weekStartDate })}
+        />
+      )}
+      {visible.has('month') && (
+        <label className="form-control w-full">
+          <span className="label pb-(--space-1)">
+            <span className="label-text font-semibold">Month</span>
+          </span>
+          <input
+            type="month"
+            className="input input-bordered w-full"
+            value={filters.month}
+            onChange={(event) => updateFilters({ month: event.target.value })}
+          />
+        </label>
+      )}
+      {visible.has('startDate') && (
+        <DateInput
+          label="Start date"
+          value={filters.startDate}
+          onChange={(startDate) => updateFilters({ startDate })}
+        />
+      )}
+      {visible.has('endDate') && (
+        <DateInput
+          label="End date"
+          value={filters.endDate}
+          onChange={(endDate) => updateFilters({ endDate })}
+        />
+      )}
+      {showScope && (
+        <label className="form-control w-full">
+          <span className="label pb-(--space-1)">
+            <span className="label-text font-semibold">Scope</span>
+          </span>
+          <select
+            className="select select-bordered w-full"
+            value={filters.scopeType}
+            onChange={(event) =>
+              updateFilters({
+                scopeType: event.target.value as ReportScopeType,
+                divisionId: '',
+                tagId: '',
+              })
+            }
+          >
+            <option value="everyone">Everyone</option>
+            <option value="department">Department</option>
+            <option value="tag">Specific tag</option>
+            <option value="fts">FTS tag shortcut</option>
+            <option value="geo">GEO tag shortcut</option>
+          </select>
+          {shortcutWarning && (
+            <span className="label pt-(--space-1)">
+              <span className="label-text-alt text-warning-fadded-content">{shortcutWarning}</span>
+            </span>
+          )}
+        </label>
+      )}
+      {showDepartment && (
+        <label className="form-control w-full">
+          <span className="label pb-(--space-1)">
+            <span className="label-text font-semibold">Department</span>
+          </span>
+          <select
+            className="select select-bordered w-full"
+            value={filters.divisionId}
+            onChange={(event) => updateFilters({ divisionId: event.target.value })}
+          >
+            <option value="">Select department</option>
+            {divisions.map((division) => (
+              <option key={division.id} value={division.id}>
+                {division.code} — {division.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+      {showTag && (
+        <label className="form-control w-full">
+          <span className="label pb-(--space-1)">
+            <span className="label-text font-semibold">Tag</span>
+          </span>
+          <select
+            className="select select-bordered w-full"
+            value={filters.tagId}
+            onChange={(event) => updateFilters({ tagId: event.target.value })}
+          >
+            <option value="">Select tag</option>
+            {tags.map((tag) => (
+              <option key={tag.id} value={tag.id}>
+                {tag.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+      {visible.has('visitType') && (
+        <label className="form-control w-full">
+          <span className="label pb-(--space-1)">
+            <span className="label-text font-semibold">Visit type</span>
+          </span>
+          <select
+            className="select select-bordered w-full"
+            value={filters.visitType}
+            onChange={(event) => updateFilters({ visitType: event.target.value })}
+          >
+            <option value="">All visit types</option>
+            {visitTypes.map((visitType) => (
+              <option key={visitType.id} value={visitType.code}>
+                {visitType.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+      {visible.has('visitorPurpose') && (
+        <label className="form-control w-full">
+          <span className="label pb-(--space-1)">
+            <span className="label-text font-semibold">Purpose / reason</span>
+          </span>
+          <input
+            className="input input-bordered w-full"
+            value={filters.visitorPurpose}
+            onChange={(event) => updateFilters({ visitorPurpose: event.target.value })}
+            placeholder="Museum, contractor, meeting"
+          />
+        </label>
+      )}
+      {visible.has('eventLinked') && (
+        <label className="form-control w-full">
+          <span className="label pb-(--space-1)">
+            <span className="label-text font-semibold">Event link</span>
+          </span>
+          <select
+            className="select select-bordered w-full"
+            value={filters.eventLinked}
+            onChange={(event) =>
+              updateFilters({ eventLinked: event.target.value as ReportFilters['eventLinked'] })
+            }
+          >
+            <option value="all">All visitors</option>
+            <option value="linked">Event-linked visitors</option>
+            <option value="unlinked">No event link</option>
+          </select>
+        </label>
+      )}
+      {visible.has('hostMemberId') && (
+        <label className="form-control w-full">
+          <span className="label pb-(--space-1)">
+            <span className="label-text font-semibold">Host</span>
+          </span>
+          <select
+            className="select select-bordered w-full"
+            value={filters.hostMemberId}
+            onChange={(event) => updateFilters({ hostMemberId: event.target.value })}
+          >
+            <option value="">Any host</option>
+            {hostMembers.map((member) => (
+              <option key={member.id} value={member.id}>
+                {member.displayName || `${member.rank} ${member.firstName} ${member.lastName}`}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+      {visible.has('organization') && (
+        <label className="form-control w-full">
+          <span className="label pb-(--space-1)">
+            <span className="label-text font-semibold">Organization</span>
+          </span>
+          <input
+            className="input input-bordered w-full"
+            value={filters.organization}
+            onChange={(event) => updateFilters({ organization: event.target.value })}
+            placeholder="Organization or unit"
+          />
+        </label>
+      )}
+    </div>
+  )
+}
+
+function DateInput({
+  label,
+  value,
+  onChange,
+}: {
+  label: string
+  value: string
+  onChange: (value: string) => void
+}) {
+  return (
+    <label className="form-control w-full">
+      <span className="label pb-(--space-1)">
+        <span className="label-text font-semibold">{label}</span>
+      </span>
+      <input
+        type="date"
+        className="input input-bordered w-full"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+      />
+    </label>
+  )
+}
+
+function ReportActionBar({
+  isRunDisabled,
+  isRunning,
+  hasReport,
+  onRun,
+  onPrint,
+  onReset,
+}: {
+  isRunDisabled: boolean
+  isRunning: boolean
+  hasReport: boolean
+  onRun: () => void
+  onPrint: () => void
+  onReset: () => void
+}) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-(--space-3) border-t border-base-300 pt-(--space-4)">
+      <p className="max-w-2xl text-sm text-base-content/62">
+        Uses your browser print dialog. Choose “Save to PDF” to create a PDF file.
+      </p>
+      <div className="flex flex-wrap items-center gap-(--space-2)">
+        <button type="button" className="btn btn-ghost btn-sm" onClick={onReset}>
+          <RotateCcw className="h-4 w-4" aria-hidden="true" />
+          Reset filters
+        </button>
+        <button
+          type="button"
+          className="btn btn-outline btn-sm"
+          disabled={!hasReport}
+          onClick={onPrint}
+        >
+          <Printer className="h-4 w-4" aria-hidden="true" />
+          Print / Save PDF
+        </button>
+        <button
+          type="button"
+          className={cn('btn btn-primary btn-sm', isRunning && 'btn-disabled')}
+          disabled={isRunDisabled}
+          onClick={onRun}
+        >
+          {isRunning ? (
+            <span className="loading loading-spinner loading-xs" aria-hidden="true" />
+          ) : (
+            <Play className="h-4 w-4" aria-hidden="true" />
+          )}
+          Run report
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend-admin/src/components/admin/reports/report-definitions.ts
+++ b/apps/frontend-admin/src/components/admin/reports/report-definitions.ts
@@ -1,0 +1,176 @@
+import { addDays, endOfMonth, format, startOfMonth, startOfWeek } from 'date-fns'
+
+export type AdminReportType =
+  | 'daily_presence'
+  | 'weekly_presence'
+  | 'monthly_presence'
+  | 'training_night_monthly'
+  | 'visitor_activity'
+
+export type ReportScopeType = 'everyone' | 'department' | 'tag' | 'fts' | 'geo'
+
+export type ReportFilterKey =
+  | 'date'
+  | 'weekStartDate'
+  | 'month'
+  | 'startDate'
+  | 'endDate'
+  | 'scopeType'
+  | 'divisionId'
+  | 'tagId'
+  | 'visitType'
+  | 'visitorPurpose'
+  | 'eventLinked'
+  | 'hostMemberId'
+  | 'organization'
+
+export interface ReportFilters {
+  reportType: AdminReportType
+  date: string
+  weekStartDate: string
+  month: string
+  startDate: string
+  endDate: string
+  scopeType: ReportScopeType
+  divisionId: string
+  tagId: string
+  visitType: string
+  visitorPurpose: string
+  eventLinked: 'all' | 'linked' | 'unlinked'
+  hostMemberId: string
+  organization: string
+}
+
+export interface ReportDefinition {
+  reportType: AdminReportType
+  label: string
+  description: string
+  defaultFilters: () => ReportFilters
+  requiredFilters: readonly ReportFilterKey[]
+  visibleFilters: readonly ReportFilterKey[]
+  runMutation:
+    | 'generateDailyPresence'
+    | 'generateWeeklyPresence'
+    | 'generateMonthlyPresence'
+    | 'generateTrainingNightMonthly'
+    | 'generateVisitorActivity'
+  previewComponent:
+    | 'DailyPresenceReport'
+    | 'WeeklyPresenceReport'
+    | 'MonthlyPresenceReport'
+    | 'TrainingNightMonthlyReport'
+    | 'VisitorActivityReport'
+}
+
+function today(): Date {
+  return new Date()
+}
+
+function toDateInput(date: Date): string {
+  return format(date, 'yyyy-MM-dd')
+}
+
+function toMonthInput(date: Date): string {
+  return format(date, 'yyyy-MM')
+}
+
+export function getBaseReportFilters(reportType: AdminReportType): ReportFilters {
+  const now = today()
+  const weekStart = startOfWeek(now, { weekStartsOn: 1 })
+  const monthStart = startOfMonth(now)
+  const monthEnd = endOfMonth(now)
+
+  return {
+    reportType,
+    date: toDateInput(now),
+    weekStartDate: toDateInput(weekStart),
+    month: toMonthInput(now),
+    startDate: toDateInput(monthStart),
+    endDate: toDateInput(monthEnd < now ? monthEnd : now),
+    scopeType: 'everyone',
+    divisionId: '',
+    tagId: '',
+    visitType: '',
+    visitorPurpose: '',
+    eventLinked: 'all',
+    hostMemberId: '',
+    organization: '',
+  }
+}
+
+export const REPORT_DEFINITIONS = [
+  {
+    reportType: 'daily_presence',
+    label: 'Daily Presence',
+    description: 'Who was present on a selected day, including first arrival and final departure.',
+    defaultFilters: () => getBaseReportFilters('daily_presence'),
+    requiredFilters: ['date'],
+    visibleFilters: ['date', 'scopeType', 'divisionId', 'tagId'],
+    runMutation: 'generateDailyPresence',
+    previewComponent: 'DailyPresenceReport',
+  },
+  {
+    reportType: 'weekly_presence',
+    label: 'Weekly Presence',
+    description: 'Presence across a Monday-Sunday week with key night attendance markers.',
+    defaultFilters: () => getBaseReportFilters('weekly_presence'),
+    requiredFilters: ['weekStartDate'],
+    visibleFilters: ['weekStartDate', 'scopeType', 'divisionId', 'tagId'],
+    runMutation: 'generateWeeklyPresence',
+    previewComponent: 'WeeklyPresenceReport',
+  },
+  {
+    reportType: 'monthly_presence',
+    label: 'Monthly Presence',
+    description: 'Monthly attendance overview by member, department, or tag-backed group.',
+    defaultFilters: () => getBaseReportFilters('monthly_presence'),
+    requiredFilters: ['month'],
+    visibleFilters: ['month', 'scopeType', 'divisionId', 'tagId'],
+    runMutation: 'generateMonthlyPresence',
+    previewComponent: 'MonthlyPresenceReport',
+  },
+  {
+    reportType: 'training_night_monthly',
+    label: 'Training Night Monthly',
+    description: 'Department matrix showing attendance for each Training Night in the month.',
+    defaultFilters: () => ({
+      ...getBaseReportFilters('training_night_monthly'),
+      scopeType: 'department',
+    }),
+    requiredFilters: ['month', 'divisionId'],
+    visibleFilters: ['month', 'divisionId'],
+    runMutation: 'generateTrainingNightMonthly',
+    previewComponent: 'TrainingNightMonthlyReport',
+  },
+  {
+    reportType: 'visitor_activity',
+    label: 'Visitor Activity',
+    description:
+      'Visitor activity by date range, visit type, purpose, event link, host, or organization.',
+    defaultFilters: () => getBaseReportFilters('visitor_activity'),
+    requiredFilters: ['startDate', 'endDate'],
+    visibleFilters: [
+      'startDate',
+      'endDate',
+      'visitType',
+      'visitorPurpose',
+      'eventLinked',
+      'hostMemberId',
+      'organization',
+    ],
+    runMutation: 'generateVisitorActivity',
+    previewComponent: 'VisitorActivityReport',
+  },
+] as const satisfies readonly ReportDefinition[]
+
+export function getReportDefinition(reportType: AdminReportType): ReportDefinition {
+  const definition = REPORT_DEFINITIONS.find((item) => item.reportType === reportType)
+  if (!definition) {
+    throw new Error(`Unknown report type: ${reportType}`)
+  }
+  return definition
+}
+
+export function getNextWeekStart(weekStartDate: string, direction: -1 | 1): string {
+  return toDateInput(addDays(new Date(`${weekStartDate}T00:00:00`), direction * 7))
+}

--- a/apps/frontend-admin/src/components/admin/reports/report-formatters.ts
+++ b/apps/frontend-admin/src/components/admin/reports/report-formatters.ts
@@ -1,0 +1,59 @@
+export function formatReportDateTime(value: string | null | undefined): string {
+  if (!value) {
+    return '—'
+  }
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export function formatReportTime(value: string | null | undefined): string {
+  if (!value) {
+    return '—'
+  }
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+
+  return date.toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export function formatDuration(minutes: number | null | undefined): string {
+  if (minutes === null || minutes === undefined) {
+    return 'Open'
+  }
+
+  if (minutes < 60) {
+    return `${minutes} min`
+  }
+
+  const hours = Math.floor(minutes / 60)
+  const remainingMinutes = minutes % 60
+  return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`
+}
+
+export function formatBooleanPresence(value: boolean | null): string {
+  if (value === null) {
+    return 'Not configured'
+  }
+
+  return value ? 'Present' : 'Absent'
+}
+
+export function formatPercent(value: number): string {
+  return `${Math.round(value)}%`
+}

--- a/apps/frontend-admin/src/components/admin/reports/report-preview.tsx
+++ b/apps/frontend-admin/src/components/admin/reports/report-preview.tsx
@@ -1,0 +1,652 @@
+'use client'
+
+import type {
+  DailyPresenceReportResponse,
+  MonthlyPresenceReportResponse,
+  ReportMemberSummary,
+  ReportTagSummary,
+  TrainingNightMonthlyReportResponse,
+  VisitorActivityReportResponse,
+  WeeklyPresenceReportResponse,
+} from '@sentinel/contracts'
+import type { ReactNode } from 'react'
+import { AlertTriangle, FileText } from 'lucide-react'
+import { AppBadge } from '@/components/ui/AppBadge'
+import { Chip, type ChipColor, type ChipVariant } from '@/components/ui/chip'
+import { EmptyState } from '@/components/ui/empty-state'
+import { TableSkeleton } from '@/components/ui/loading-skeleton'
+import type { AdminReportResponse } from '@/hooks/use-admin-reports'
+import { cn } from '@/lib/utils'
+import {
+  formatBooleanPresence,
+  formatDuration,
+  formatPercent,
+  formatReportDateTime,
+  formatReportTime,
+} from './report-formatters'
+
+interface ReportPreviewProps {
+  report: AdminReportResponse | null
+  isLoading: boolean
+  errorMessage: string | null
+}
+
+const CHIP_VARIANTS = new Set<ChipVariant>([
+  'solid',
+  'bordered',
+  'light',
+  'flat',
+  'faded',
+  'shadow',
+  'dot',
+  'soft',
+])
+
+const CHIP_COLORS = new Set<ChipColor>([
+  'default',
+  'neutral',
+  'primary',
+  'secondary',
+  'accent',
+  'success',
+  'warning',
+  'info',
+  'error',
+  'danger',
+  'blue',
+  'green',
+  'pink',
+  'purple',
+  'red',
+  'yellow',
+  'cyan',
+  'zinc',
+])
+
+export function ReportPreview({ report, isLoading, errorMessage }: ReportPreviewProps) {
+  if (isLoading && !report) {
+    return (
+      <section className="reports-preview rounded-box border border-base-300 bg-base-100 shadow-[var(--shadow-1)]">
+        <div className="border-b border-base-300 p-(--space-4)">
+          <div className="h-6 w-64 skeleton" />
+          <div className="mt-(--space-2) h-4 w-96 skeleton" />
+        </div>
+        <TableSkeleton rows={8} cols={5} />
+      </section>
+    )
+  }
+
+  if (errorMessage && !report) {
+    return (
+      <section className="rounded-box border border-error/35 bg-error-fadded p-(--space-6) text-error-fadded-content shadow-[var(--shadow-1)]">
+        <div className="flex items-start gap-(--space-3)" role="alert">
+          <AlertTriangle className="mt-1 h-5 w-5 shrink-0" aria-hidden="true" />
+          <div>
+            <h2 className="font-semibold">Report could not be generated</h2>
+            <p className="mt-(--space-1) text-sm">{errorMessage}</p>
+          </div>
+        </div>
+      </section>
+    )
+  }
+
+  if (!report) {
+    return (
+      <section className="rounded-box border border-base-300 bg-base-100 shadow-[var(--shadow-1)]">
+        <EmptyState
+          icon={FileText}
+          title="No report run yet"
+          description="Choose a report type, set the filters, and run the report to preview it here."
+        />
+      </section>
+    )
+  }
+
+  return (
+    <ReportDocumentFrame report={report} isRefreshing={isLoading}>
+      {report.reportType === 'daily_presence' && <DailyPresenceReport report={report} />}
+      {report.reportType === 'weekly_presence' && <WeeklyPresenceReport report={report} />}
+      {report.reportType === 'monthly_presence' && <MonthlyPresenceReport report={report} />}
+      {report.reportType === 'training_night_monthly' && (
+        <TrainingNightMonthlyReport report={report} />
+      )}
+      {report.reportType === 'visitor_activity' && <VisitorActivityReport report={report} />}
+    </ReportDocumentFrame>
+  )
+}
+
+function ReportDocumentFrame({
+  report,
+  isRefreshing,
+  children,
+}: {
+  report: AdminReportResponse
+  isRefreshing: boolean
+  children: ReactNode
+}) {
+  const isMatrixReport =
+    report.reportType === 'weekly_presence' ||
+    report.reportType === 'monthly_presence' ||
+    report.reportType === 'training_night_monthly'
+
+  return (
+    <section
+      className={cn(
+        'reports-print-document rounded-box border border-base-300 bg-base-100 shadow-[var(--shadow-1)]',
+        isMatrixReport && 'reports-print-landscape'
+      )}
+      aria-live="polite"
+    >
+      <div className="border-b border-base-300 p-(--space-5)">
+        <div className="flex flex-wrap items-start justify-between gap-(--space-4)">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-base-content/55">
+              {report.unitName}
+            </p>
+            <h2 className="mt-(--space-1) font-display text-2xl font-bold leading-tight">
+              {report.title}
+            </h2>
+            <p className="mt-(--space-1) text-sm text-base-content/65">
+              {report.dateRange.label} · {report.filters.scopeLabel}
+            </p>
+          </div>
+          <dl className="grid gap-(--space-1) text-right text-xs text-base-content/65">
+            <div>
+              <dt className="font-semibold uppercase tracking-wide">Generated</dt>
+              <dd className="font-mono">{formatReportDateTime(report.generatedAt)}</dd>
+            </div>
+            <div>
+              <dt className="font-semibold uppercase tracking-wide">By</dt>
+              <dd>{report.generatedBy.displayName}</dd>
+            </div>
+          </dl>
+        </div>
+
+        <div className="mt-(--space-4) flex flex-wrap gap-(--space-2) text-xs text-base-content/65">
+          <span className="rounded-box bg-base-200 px-(--space-2) py-(--space-1)">
+            {report.dateRange.startDate} to {report.dateRange.endDate}
+          </span>
+          {report.filters.divisionId && (
+            <span className="rounded-box bg-base-200 px-(--space-2) py-(--space-1)">
+              Department filter
+            </span>
+          )}
+          {report.filters.tagId && (
+            <span className="rounded-box bg-base-200 px-(--space-2) py-(--space-1)">
+              Tag filter
+            </span>
+          )}
+          {report.filters.visitorType && (
+            <span className="rounded-box bg-base-200 px-(--space-2) py-(--space-1)">
+              Visit type: {report.filters.visitorType}
+            </span>
+          )}
+          {report.filters.visitorPurpose && (
+            <span className="rounded-box bg-base-200 px-(--space-2) py-(--space-1)">
+              Purpose: {report.filters.visitorPurpose}
+            </span>
+          )}
+          {isRefreshing && (
+            <AppBadge status="info" size="sm">
+              Refreshing
+            </AppBadge>
+          )}
+        </div>
+      </div>
+
+      {report.warnings.length > 0 && (
+        <div
+          className="mx-(--space-5) mt-(--space-4) rounded-box border border-warning/40 bg-warning-fadded p-(--space-3) text-sm text-warning-fadded-content"
+          role="status"
+        >
+          <div className="flex items-start gap-(--space-2)">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+            <div>
+              <p className="font-semibold">Report warnings</p>
+              <ul className="mt-(--space-1) list-disc space-y-1 pl-(--space-4)">
+                {report.warnings.map((warning) => (
+                  <li key={warning}>{warning}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="p-(--space-5)">{children}</div>
+    </section>
+  )
+}
+
+function SummaryGrid({ items }: { items: Array<{ label: string; value: string | number }> }) {
+  return (
+    <dl className="reports-summary-grid mb-(--space-4) grid grid-cols-2 gap-px overflow-hidden rounded-box border border-base-300 bg-base-300 md:grid-cols-4">
+      {items.map((item) => (
+        <div key={item.label} className="bg-base-100 p-(--space-3)">
+          <dt className="text-xs font-semibold uppercase tracking-wide text-base-content/50">
+            {item.label}
+          </dt>
+          <dd className="mt-(--space-1) text-2xl font-bold">{item.value}</dd>
+        </div>
+      ))}
+    </dl>
+  )
+}
+
+function DailyPresenceReport({ report }: { report: DailyPresenceReportResponse }) {
+  const { summary, rows } = report.data
+
+  return (
+    <>
+      <SummaryGrid
+        items={[
+          { label: 'Present', value: summary.presentMembers },
+          { label: 'Scoped members', value: summary.totalScopedMembers },
+          { label: 'Sessions', value: summary.totalSessions },
+          { label: 'Left and returned', value: summary.leftAndReturnedCount },
+        ]}
+      />
+
+      {rows.length === 0 ? (
+        <ReportEmptyMessage
+          title="No attendance records"
+          detail="No members matched the selected day and filters."
+        />
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="table table-sm reports-table">
+            <thead>
+              <tr>
+                <th>Member</th>
+                <th>Department</th>
+                <th>Tags</th>
+                <th>First in</th>
+                <th>Last out</th>
+                <th>Left / returned</th>
+                <th>Sessions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.member.id}>
+                  <td>
+                    <MemberName member={row.member} />
+                  </td>
+                  <td>{row.member.division?.code ?? row.member.division?.name ?? 'Unassigned'}</td>
+                  <td>
+                    <TagList tags={row.member.tags} />
+                  </td>
+                  <td className="font-mono">{formatReportTime(row.firstIn)}</td>
+                  <td className="font-mono">
+                    {row.lastOut ? formatReportTime(row.lastOut) : 'Still present'}
+                  </td>
+                  <td>
+                    <AppBadge status={row.leftAndReturned ? 'warning' : 'neutral'} size="sm">
+                      {row.leftAndReturned ? `Yes — ${row.sessionCount} sessions` : 'No'}
+                    </AppBadge>
+                  </td>
+                  <td>
+                    <details className="reports-screen-only">
+                      <summary className="cursor-pointer text-sm font-semibold text-info">
+                        {row.sessionCount}
+                      </summary>
+                      <div className="mt-(--space-2) space-y-(--space-1) text-xs text-base-content/70">
+                        {row.sessions.map((session) => (
+                          <p key={`${row.member.id}-${session.inAt}`}>
+                            {formatReportTime(session.inAt)} -{' '}
+                            {session.outAt ? formatReportTime(session.outAt) : 'Open'} ·{' '}
+                            {formatDuration(session.durationMinutes)}
+                          </p>
+                        ))}
+                      </div>
+                    </details>
+                    <span className="hidden reports-print-inline">{row.sessionCount}</span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </>
+  )
+}
+
+function WeeklyPresenceReport({ report }: { report: WeeklyPresenceReportResponse }) {
+  const { summary, rows, days } = report.data
+
+  return (
+    <>
+      <SummaryGrid
+        items={[
+          { label: 'Members', value: summary.totalMembers },
+          { label: 'With presence', value: summary.membersWithPresence },
+          { label: 'Training nights', value: summary.trainingNightCount },
+          { label: 'Admin nights', value: summary.adminNightCount },
+        ]}
+      />
+      {rows.length === 0 ? (
+        <ReportEmptyMessage
+          title="No matching members"
+          detail="No active members matched the selected filters."
+        />
+      ) : (
+        <PresenceMatrixTable
+          rows={rows.map((row) => ({
+            member: row.member,
+            days: row.days,
+            total: row.totalDaysPresent,
+            trailing: [
+              formatBooleanPresence(row.trainingNightPresent),
+              formatBooleanPresence(row.adminNightPresent),
+            ],
+          }))}
+          days={days}
+          trailingHeaders={['Training', 'Admin']}
+        />
+      )}
+    </>
+  )
+}
+
+function MonthlyPresenceReport({ report }: { report: MonthlyPresenceReportResponse }) {
+  const { summary, rows, days } = report.data
+
+  return (
+    <>
+      <SummaryGrid
+        items={[
+          { label: 'Members', value: summary.totalMembers },
+          { label: 'With presence', value: summary.membersWithPresence },
+          { label: 'Member-days', value: summary.totalMemberDaysPresent },
+          { label: 'Key nights', value: summary.trainingNightCount + summary.adminNightCount },
+        ]}
+      />
+      {rows.length === 0 ? (
+        <ReportEmptyMessage
+          title="No matching members"
+          detail="No active members matched the selected filters."
+        />
+      ) : (
+        <PresenceMatrixTable
+          rows={rows.map((row) => ({
+            member: row.member,
+            days: row.days,
+            total: row.totalDaysPresent,
+            trailing: [String(row.trainingNightsPresent), String(row.adminNightsPresent)],
+          }))}
+          days={days}
+          trailingHeaders={['Training', 'Admin']}
+          compactDays
+        />
+      )}
+    </>
+  )
+}
+
+function TrainingNightMonthlyReport({ report }: { report: TrainingNightMonthlyReportResponse }) {
+  const { summary, rows, trainingNights } = report.data
+
+  return (
+    <>
+      <SummaryGrid
+        items={[
+          { label: 'Department members', value: summary.totalMembers },
+          { label: 'Training nights', value: summary.trainingNightCount },
+          {
+            label: 'Average attendance',
+            value: formatPercent(summary.averageAttendancePercentage),
+          },
+          { label: 'Department', value: report.data.department?.code ?? 'Unassigned' },
+        ]}
+      />
+      {trainingNights.length === 0 ? (
+        <ReportEmptyMessage
+          title="No Training Nights found"
+          detail="No reliable Training Night dates were found for this month."
+        />
+      ) : rows.length === 0 ? (
+        <ReportEmptyMessage
+          title="No department members"
+          detail="No active members were found in the selected department."
+        />
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="table table-sm reports-table">
+            <thead>
+              <tr>
+                <th>Member</th>
+                {trainingNights.map((night) => (
+                  <th key={night.id} className="text-center">
+                    {night.label}
+                  </th>
+                ))}
+                <th className="text-right">Attended</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.member.id}>
+                  <td>
+                    <MemberName member={row.member} />
+                  </td>
+                  {trainingNights.map((night) => {
+                    const marker = row.nights.find((item) => item.keyNightId === night.id)
+                    return (
+                      <td key={night.id} className="text-center">
+                        <PresenceSymbol present={marker?.present ?? false} />
+                      </td>
+                    )
+                  })}
+                  <td className="text-right font-mono">
+                    {row.attended}/{row.possible} · {formatPercent(row.percentage)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </>
+  )
+}
+
+function VisitorActivityReport({ report }: { report: VisitorActivityReportResponse }) {
+  const { summary, rows } = report.data
+
+  return (
+    <>
+      <SummaryGrid
+        items={[
+          { label: 'Visitors', value: summary.totalVisitors },
+          { label: 'Active at end', value: summary.activeAtEnd },
+          { label: 'Visit types', value: summary.byVisitType.length },
+          {
+            label: 'Events',
+            value: summary.byEvent.filter((item) => item.label !== 'No event link').length,
+          },
+        ]}
+      />
+      {rows.length === 0 ? (
+        <ReportEmptyMessage
+          title="No visitor activity"
+          detail="No visitors matched the selected date range and filters."
+        />
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="table table-sm reports-table">
+            <thead>
+              <tr>
+                <th>Visitor</th>
+                <th>Type / purpose</th>
+                <th>Organization</th>
+                <th>In</th>
+                <th>Out</th>
+                <th>Event</th>
+                <th>Host</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.id}>
+                  <td className="font-semibold">{row.displayName}</td>
+                  <td>
+                    <div className="flex flex-wrap gap-(--space-1)">
+                      <Chip size="sm" variant="faded" color="blue">
+                        {row.visitType}
+                      </Chip>
+                      {(row.visitPurpose || row.visitReason) && (
+                        <span className="text-xs text-base-content/65">
+                          {row.visitPurpose ?? row.visitReason}
+                        </span>
+                      )}
+                    </div>
+                  </td>
+                  <td>{row.organization ?? '—'}</td>
+                  <td className="font-mono">{formatReportDateTime(row.checkInTime)}</td>
+                  <td className="font-mono">
+                    {row.checkOutTime ? formatReportDateTime(row.checkOutTime) : 'Still present'}
+                  </td>
+                  <td>{row.event?.name ?? '—'}</td>
+                  <td>{row.host?.displayName ?? '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </>
+  )
+}
+
+function PresenceMatrixTable({
+  rows,
+  days,
+  trailingHeaders,
+  compactDays = false,
+}: {
+  rows: Array<{
+    member: ReportMemberSummary
+    days: Array<{ date: string; label: string; present: boolean; note: string | null }>
+    total: number
+    trailing: string[]
+  }>
+  days: Array<{ date: string; label: string; isTrainingNight: boolean; isAdminNight: boolean }>
+  trailingHeaders: string[]
+  compactDays?: boolean
+}) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="table table-sm reports-table">
+        <thead>
+          <tr>
+            <th>Member</th>
+            {days.map((day) => (
+              <th key={day.date} className="text-center">
+                <span>{compactDays ? day.label : day.label.replace(' ', '\u00a0')}</span>
+                {(day.isTrainingNight || day.isAdminNight) && (
+                  <span className="ml-(--space-1) text-[0.65rem] font-semibold text-base-content/55">
+                    {day.isTrainingNight ? 'T' : 'A'}
+                  </span>
+                )}
+              </th>
+            ))}
+            <th className="text-right">Days</th>
+            {trailingHeaders.map((header) => (
+              <th key={header} className="text-right">
+                {header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.member.id}>
+              <td>
+                <MemberName member={row.member} />
+              </td>
+              {row.days.map((day) => (
+                <td key={day.date} className="text-center">
+                  <PresenceSymbol present={day.present} note={day.note} />
+                </td>
+              ))}
+              <td className="text-right font-mono">{row.total}</td>
+              {row.trailing.map((value, index) => (
+                <td key={`${row.member.id}-${trailingHeaders[index]}`} className="text-right">
+                  {value}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function PresenceSymbol({ present, note }: { present: boolean; note?: string | null }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex min-h-6 min-w-6 items-center justify-center rounded-full border px-(--space-1) text-xs font-bold',
+        present
+          ? 'border-success/40 bg-success-fadded text-success-fadded-content'
+          : 'border-base-300 bg-base-200 text-base-content/55'
+      )}
+      aria-label={present ? `Present${note ? `, ${note}` : ''}` : 'Absent'}
+      title={present ? (note ?? 'Present') : 'Absent'}
+    >
+      {present ? 'P' : '—'}
+    </span>
+  )
+}
+
+function MemberName({ member }: { member: ReportMemberSummary }) {
+  return (
+    <div>
+      <p className="font-semibold leading-tight">{member.displayName}</p>
+      <p className="text-xs text-base-content/55">
+        {member.memberType ?? 'Member'} · {member.status}
+      </p>
+    </div>
+  )
+}
+
+function TagList({ tags }: { tags: ReportTagSummary[] }) {
+  if (tags.length === 0) {
+    return <span className="text-xs text-base-content/45">No tags</span>
+  }
+
+  return (
+    <div className="flex max-w-72 flex-wrap gap-(--space-1)">
+      {tags.slice(0, 4).map((tag) => (
+        <Chip
+          key={`${tag.id}-${tag.source}`}
+          size="sm"
+          variant={getChipVariant(tag.chipVariant)}
+          color={getChipColor(tag.chipColor)}
+        >
+          {tag.name}
+        </Chip>
+      ))}
+      {tags.length > 4 && <span className="text-xs text-base-content/55">+{tags.length - 4}</span>}
+    </div>
+  )
+}
+
+function ReportEmptyMessage({ title, detail }: { title: string; detail: string }) {
+  return (
+    <div className="rounded-box border border-base-300 bg-base-200 p-(--space-6) text-center">
+      <p className="font-semibold">{title}</p>
+      <p className="mt-(--space-1) text-sm text-base-content/65">{detail}</p>
+    </div>
+  )
+}
+
+function getChipVariant(value: string | null): ChipVariant {
+  return value && CHIP_VARIANTS.has(value as ChipVariant) ? (value as ChipVariant) : 'faded'
+}
+
+function getChipColor(value: string | null): ChipColor {
+  return value && CHIP_COLORS.has(value as ChipColor) ? (value as ChipColor) : 'default'
+}

--- a/apps/frontend-admin/src/hooks/use-admin-reports.ts
+++ b/apps/frontend-admin/src/hooks/use-admin-reports.ts
@@ -1,0 +1,120 @@
+'use client'
+
+import { useMutation, useQuery } from '@tanstack/react-query'
+import type {
+  DailyPresenceReportConfig,
+  DailyPresenceReportResponse,
+  MonthlyPresenceReportConfig,
+  MonthlyPresenceReportResponse,
+  TrainingNightMonthlyReportConfig,
+  TrainingNightMonthlyReportResponse,
+  VisitorActivityReportConfig,
+  VisitorActivityReportResponse,
+  WeeklyPresenceReportConfig,
+  WeeklyPresenceReportResponse,
+} from '@sentinel/contracts'
+import { apiClient } from '@/lib/api-client'
+
+export type AdminReportResponse =
+  | DailyPresenceReportResponse
+  | WeeklyPresenceReportResponse
+  | MonthlyPresenceReportResponse
+  | TrainingNightMonthlyReportResponse
+  | VisitorActivityReportResponse
+
+export type RunAdminReportInput =
+  | {
+      reportType: 'daily_presence'
+      body: DailyPresenceReportConfig
+    }
+  | {
+      reportType: 'weekly_presence'
+      body: WeeklyPresenceReportConfig
+    }
+  | {
+      reportType: 'monthly_presence'
+      body: MonthlyPresenceReportConfig
+    }
+  | {
+      reportType: 'training_night_monthly'
+      body: TrainingNightMonthlyReportConfig
+    }
+  | {
+      reportType: 'visitor_activity'
+      body: VisitorActivityReportConfig
+    }
+
+function getApiErrorMessage(body: unknown, fallback: string): string {
+  if (
+    typeof body === 'object' &&
+    body !== null &&
+    'message' in body &&
+    typeof (body as { message?: unknown }).message === 'string'
+  ) {
+    return (body as { message: string }).message
+  }
+
+  return fallback
+}
+
+export function useAdminReportRunner() {
+  return useMutation<AdminReportResponse, Error, RunAdminReportInput>({
+    mutationFn: async (input) => {
+      switch (input.reportType) {
+        case 'daily_presence': {
+          const response = await apiClient.reports.generateDailyPresence({ body: input.body })
+          if (response.status !== 200) {
+            throw new Error(getApiErrorMessage(response.body, 'Failed to run daily report'))
+          }
+          return response.body
+        }
+        case 'weekly_presence': {
+          const response = await apiClient.reports.generateWeeklyPresence({ body: input.body })
+          if (response.status !== 200) {
+            throw new Error(getApiErrorMessage(response.body, 'Failed to run weekly report'))
+          }
+          return response.body
+        }
+        case 'monthly_presence': {
+          const response = await apiClient.reports.generateMonthlyPresence({ body: input.body })
+          if (response.status !== 200) {
+            throw new Error(getApiErrorMessage(response.body, 'Failed to run monthly report'))
+          }
+          return response.body
+        }
+        case 'training_night_monthly': {
+          const response = await apiClient.reports.generateTrainingNightMonthly({
+            body: input.body,
+          })
+          if (response.status !== 200) {
+            throw new Error(
+              getApiErrorMessage(response.body, 'Failed to run training night report')
+            )
+          }
+          return response.body
+        }
+        case 'visitor_activity': {
+          const response = await apiClient.reports.generateVisitorActivity({ body: input.body })
+          if (response.status !== 200) {
+            throw new Error(getApiErrorMessage(response.body, 'Failed to run visitor report'))
+          }
+          return response.body
+        }
+      }
+    },
+  })
+}
+
+export function useVisitTypesForReports() {
+  return useQuery({
+    queryKey: ['reports', 'visit-types'],
+    queryFn: async () => {
+      const response = await apiClient.enums.visitTypes.getVisitTypes()
+      if (response.status !== 200) {
+        throw new Error('Failed to fetch visit types')
+      }
+      return response.body.visitTypes
+    },
+    staleTime: 10 * 60 * 1000,
+  })
+}

--- a/apps/frontend-admin/src/lib/admin-routes.ts
+++ b/apps/frontend-admin/src/lib/admin-routes.ts
@@ -13,6 +13,7 @@ export type AdminCapability =
 
 export type AdminRouteId =
   | 'admin-home'
+  | 'reports'
   | 'updates'
   | 'network'
   | 'logs'
@@ -43,6 +44,7 @@ export type AdminIconKey =
   | 'clock'
   | 'database'
   | 'download'
+  | 'file-text'
   | 'list'
   | 'logs'
   | 'network'
@@ -117,6 +119,22 @@ export const ADMIN_NAV_ROUTES = [
     searchWeight: 95,
     requiredRole: ADMIN_ROLE_LEVEL.ADMIN,
     requiredCapabilities: ['admin:view', 'updates:manage'],
+    navVisibility: 'sidebar',
+    featureStatus: 'available',
+  },
+  {
+    id: 'reports',
+    label: 'Reports',
+    href: '/admin/reports',
+    group: 'Diagnostics',
+    tier: 1,
+    icon: 'file-text',
+    description: 'Generate printable attendance, presence, and visitor reports.',
+    aliases: ['attendance reports', 'presence reports', 'visitor reports', 'training reports'],
+    keywords: ['reports', 'attendance', 'presence', 'training', 'visitors', 'print', 'pdf'],
+    searchWeight: 86,
+    requiredRole: ADMIN_ROLE_LEVEL.ADMIN,
+    requiredCapabilities: ['admin:view'],
     navVisibility: 'sidebar',
     featureStatus: 'available',
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/contracts/src/contracts/api.contract.ts
+++ b/packages/contracts/src/contracts/api.contract.ts
@@ -36,13 +36,50 @@ import { adminNavigationContract } from './admin-navigation.contract.js'
 
 const c = initContract()
 
+export type ApiContract = {
+  members: typeof memberContract
+  checkins: typeof checkinContract
+  divisions: typeof divisionContract
+  badges: typeof badgeContract
+  auditLogs: typeof auditContract
+  enums: typeof enumContract
+  adminUsers: typeof adminUserContract
+  lists: typeof listContract
+  trainingYears: typeof trainingYearContract
+  bmqCourses: typeof bmqCourseContract
+  reportSettings: typeof reportSettingContract
+  alertConfigs: typeof alertConfigContract
+  reports: typeof reportContract
+  devTools: typeof devToolsContract
+  dev: typeof devContract
+  securityAlerts: typeof securityAlertContract
+  dds: typeof ddsContract
+  databaseExplorer: typeof databaseExplorerContract
+  ranks: typeof rankContract
+  qualifications: typeof qualificationContract
+  schedules: typeof scheduleContract
+  unitEvents: typeof unitEventContract
+  lockup: typeof lockupContract
+  visitors: typeof visitorContract
+  statHolidays: typeof statHolidayContract
+  tags: typeof tagContract
+  settings: typeof settingContract
+  operationalTimings: typeof operationalTimingContract
+  auth: typeof authContract
+  remoteSystems: typeof remoteSystemContract
+  networkSettings: typeof networkSettingContract
+  systemStatus: typeof systemStatusContract
+  systemUpdate: typeof systemUpdateContract
+  adminNavigation: typeof adminNavigationContract
+}
+
 /**
  * Main API contract
  *
  * Combines all route contracts into a single API contract
  * for use with ts-rest client and server
  */
-export const apiContract = c.router(
+export const apiContract: ApiContract = c.router(
   {
     members: memberContract,
     checkins: checkinContract,

--- a/packages/contracts/src/contracts/report.contract.ts
+++ b/packages/contracts/src/contracts/report.contract.ts
@@ -10,7 +10,19 @@ import {
   PersonnelRosterReportSchema,
   VisitorSummaryConfigSchema,
   VisitorSummaryReportSchema,
+  DailyPresenceReportConfigSchema,
+  WeeklyPresenceReportConfigSchema,
+  MonthlyPresenceReportConfigSchema,
+  TrainingNightMonthlyReportConfigSchema,
+  VisitorActivityReportConfigSchema,
   ReportErrorResponseSchema,
+} from '../schemas/report.schema.js'
+import type {
+  DailyPresenceReportResponse,
+  MonthlyPresenceReportResponse,
+  TrainingNightMonthlyReportResponse,
+  VisitorActivityReportResponse,
+  WeeklyPresenceReportResponse,
 } from '../schemas/report.schema.js'
 
 const c = initContract()
@@ -27,6 +39,96 @@ const c = initContract()
  */
 export const reportContract = c.router(
   {
+    generateDailyPresence: {
+      method: 'POST',
+      path: '/api/reports/presence/daily',
+      body: DailyPresenceReportConfigSchema,
+      responses: {
+        200: c.type<DailyPresenceReportResponse>(),
+        400: ReportErrorResponseSchema,
+        401: ReportErrorResponseSchema,
+        403: ReportErrorResponseSchema,
+        404: ReportErrorResponseSchema,
+        409: ReportErrorResponseSchema,
+        500: ReportErrorResponseSchema,
+      },
+      summary: 'Generate daily presence report',
+      description:
+        'Generate an operational daily presence report with first arrival, final departure, session count, leave-and-return state, and warning metadata.',
+    },
+
+    generateWeeklyPresence: {
+      method: 'POST',
+      path: '/api/reports/presence/weekly',
+      body: WeeklyPresenceReportConfigSchema,
+      responses: {
+        200: c.type<WeeklyPresenceReportResponse>(),
+        400: ReportErrorResponseSchema,
+        401: ReportErrorResponseSchema,
+        403: ReportErrorResponseSchema,
+        404: ReportErrorResponseSchema,
+        409: ReportErrorResponseSchema,
+        500: ReportErrorResponseSchema,
+      },
+      summary: 'Generate weekly presence report',
+      description:
+        'Generate an operational weekly presence report grouped around daily presence markers and Training/Admin night attendance.',
+    },
+
+    generateMonthlyPresence: {
+      method: 'POST',
+      path: '/api/reports/presence/monthly',
+      body: MonthlyPresenceReportConfigSchema,
+      responses: {
+        200: c.type<MonthlyPresenceReportResponse>(),
+        400: ReportErrorResponseSchema,
+        401: ReportErrorResponseSchema,
+        403: ReportErrorResponseSchema,
+        404: ReportErrorResponseSchema,
+        409: ReportErrorResponseSchema,
+        500: ReportErrorResponseSchema,
+      },
+      summary: 'Generate monthly presence report',
+      description:
+        'Generate an operational monthly presence overview with compact day markers, key-night attendance, and scoped member summaries.',
+    },
+
+    generateTrainingNightMonthly: {
+      method: 'POST',
+      path: '/api/reports/training-night/monthly',
+      body: TrainingNightMonthlyReportConfigSchema,
+      responses: {
+        200: c.type<TrainingNightMonthlyReportResponse>(),
+        400: ReportErrorResponseSchema,
+        401: ReportErrorResponseSchema,
+        403: ReportErrorResponseSchema,
+        404: ReportErrorResponseSchema,
+        409: ReportErrorResponseSchema,
+        500: ReportErrorResponseSchema,
+      },
+      summary: 'Generate monthly training night report',
+      description:
+        'Generate a department training night matrix for a selected month, including all active department members and each Training Night.',
+    },
+
+    generateVisitorActivity: {
+      method: 'POST',
+      path: '/api/reports/visitors/activity',
+      body: VisitorActivityReportConfigSchema,
+      responses: {
+        200: c.type<VisitorActivityReportResponse>(),
+        400: ReportErrorResponseSchema,
+        401: ReportErrorResponseSchema,
+        403: ReportErrorResponseSchema,
+        404: ReportErrorResponseSchema,
+        409: ReportErrorResponseSchema,
+        500: ReportErrorResponseSchema,
+      },
+      summary: 'Generate visitor activity report',
+      description:
+        'Generate an operational visitor report using existing visitor visit type, purpose/reason, event association, host, organization, and date range data.',
+    },
+
     /**
      * POST /api/reports/daily-checkin
      * Generate daily check-in summary with present/absent FT staff and reserve members

--- a/packages/contracts/src/schemas/admin-navigation.schema.ts
+++ b/packages/contracts/src/schemas/admin-navigation.schema.ts
@@ -10,6 +10,7 @@ export const AdminNavigationEventTypeValues = [
 
 export const AdminNavigationRouteIdValues = [
   'admin-home',
+  'reports',
   'updates',
   'network',
   'logs',

--- a/packages/contracts/src/schemas/report.schema.ts
+++ b/packages/contracts/src/schemas/report.schema.ts
@@ -27,6 +27,40 @@ export const ThresholdFlagEnum = v.picklist(['none', 'warning', 'critical'])
 
 export const TrendDirectionEnum = v.picklist(['up', 'down', 'stable', 'none'])
 
+export const OperationalReportTypeEnum = v.picklist([
+  'daily_presence',
+  'weekly_presence',
+  'monthly_presence',
+  'training_night_monthly',
+  'visitor_activity',
+])
+
+export const OperationalReportScopeEnum = v.picklist([
+  'everyone',
+  'department',
+  'tag',
+  'fts',
+  'geo',
+])
+
+export const PresenceSessionStatusEnum = v.picklist(['complete', 'open', 'degraded'])
+
+export const KeyNightCategoryEnum = v.picklist(['training', 'administrative'])
+
+export const KeyNightSourceEnum = v.picklist(['unit_event', 'report_settings'])
+
+const LocalDateSchema = v.pipe(
+  v.string('Date is required'),
+  v.regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format')
+)
+
+const LocalMonthSchema = v.pipe(
+  v.string('Month is required'),
+  v.regex(/^\d{4}-\d{2}$/, 'Month must be in YYYY-MM format')
+)
+
+const UuidSchema = v.pipe(v.string(), v.uuid('Invalid ID format'))
+
 // ============================================================================
 // Request Schemas
 // ============================================================================
@@ -46,9 +80,7 @@ export type DailyCheckinConfig = v.InferOutput<typeof DailyCheckinConfigSchema>
  */
 export const TrainingNightReportConfigSchema = v.pipe(
   v.object({
-    period: v.optional(
-      v.picklist(['current_year', 'last_quarter', 'last_month', 'custom'])
-    ),
+    period: v.optional(v.picklist(['current_year', 'last_quarter', 'last_month', 'custom'])),
     periodStart: v.optional(v.pipe(v.string(), v.regex(/^\d{4}-\d{2}-\d{2}$/))),
     periodEnd: v.optional(v.pipe(v.string(), v.regex(/^\d{4}-\d{2}-\d{2}$/))),
     organizationOption: OrganizationOptionEnum,
@@ -66,9 +98,7 @@ export const TrainingNightReportConfigSchema = v.pipe(
   }, 'Custom period requires both periodStart and periodEnd')
 )
 
-export type TrainingNightReportConfig = v.InferOutput<
-  typeof TrainingNightReportConfigSchema
->
+export type TrainingNightReportConfig = v.InferOutput<typeof TrainingNightReportConfigSchema>
 
 /**
  * BMQ attendance report configuration
@@ -108,6 +138,71 @@ export const VisitorSummaryConfigSchema = v.pipe(
 )
 
 export type VisitorSummaryConfig = v.InferOutput<typeof VisitorSummaryConfigSchema>
+
+/**
+ * Shared operational presence report request.
+ */
+export const PresenceReportConfigSchema = v.object({
+  scopeType: v.optional(OperationalReportScopeEnum, 'everyone'),
+  divisionId: v.optional(UuidSchema),
+  tagId: v.optional(UuidSchema),
+})
+
+export type PresenceReportConfig = v.InferOutput<typeof PresenceReportConfigSchema>
+
+export const DailyPresenceReportConfigSchema = v.object({
+  date: LocalDateSchema,
+  scopeType: v.optional(OperationalReportScopeEnum, 'everyone'),
+  divisionId: v.optional(UuidSchema),
+  tagId: v.optional(UuidSchema),
+})
+
+export type DailyPresenceReportConfig = v.InferOutput<typeof DailyPresenceReportConfigSchema>
+
+export const WeeklyPresenceReportConfigSchema = v.object({
+  weekStartDate: LocalDateSchema,
+  scopeType: v.optional(OperationalReportScopeEnum, 'everyone'),
+  divisionId: v.optional(UuidSchema),
+  tagId: v.optional(UuidSchema),
+})
+
+export type WeeklyPresenceReportConfig = v.InferOutput<typeof WeeklyPresenceReportConfigSchema>
+
+export const MonthlyPresenceReportConfigSchema = v.object({
+  month: LocalMonthSchema,
+  scopeType: v.optional(OperationalReportScopeEnum, 'everyone'),
+  divisionId: v.optional(UuidSchema),
+  tagId: v.optional(UuidSchema),
+})
+
+export type MonthlyPresenceReportConfig = v.InferOutput<typeof MonthlyPresenceReportConfigSchema>
+
+export const TrainingNightMonthlyReportConfigSchema = v.object({
+  month: LocalMonthSchema,
+  divisionId: UuidSchema,
+})
+
+export type TrainingNightMonthlyReportConfig = v.InferOutput<
+  typeof TrainingNightMonthlyReportConfigSchema
+>
+
+export const VisitorActivityReportConfigSchema = v.pipe(
+  v.object({
+    startDate: LocalDateSchema,
+    endDate: LocalDateSchema,
+    visitType: v.optional(v.string()),
+    visitorPurpose: v.optional(v.string()),
+    eventLinked: v.optional(v.boolean()),
+    hostMemberId: v.optional(UuidSchema),
+    organization: v.optional(v.string()),
+  }),
+  v.check(
+    (data) => new Date(data.startDate) <= new Date(data.endDate),
+    'Start date must be before or equal to end date'
+  )
+)
+
+export type VisitorActivityReportConfig = v.InferOutput<typeof VisitorActivityReportConfigSchema>
 
 // ============================================================================
 // Response Component Schemas
@@ -154,6 +249,333 @@ export const TrendIndicatorSchema = v.object({
 })
 
 export type TrendIndicator = v.InferOutput<typeof TrendIndicatorSchema>
+
+export const ReportGeneratedBySchema = v.object({
+  id: v.string(),
+  displayName: v.string(),
+})
+
+export type ReportGeneratedBy = v.InferOutput<typeof ReportGeneratedBySchema>
+
+export const ReportDateRangeSchema = v.object({
+  startDate: v.string(),
+  endDate: v.string(),
+  label: v.string(),
+})
+
+export type ReportDateRange = v.InferOutput<typeof ReportDateRangeSchema>
+
+export const ReportFilterSummarySchema = v.object({
+  scopeLabel: v.string(),
+  divisionId: v.optional(v.string()),
+  tagId: v.optional(v.string()),
+  visitorType: v.optional(v.string()),
+  visitorPurpose: v.optional(v.string()),
+  eventCategory: v.optional(v.string()),
+})
+
+export type ReportFilterSummary = v.InferOutput<typeof ReportFilterSummarySchema>
+
+const ReportEnvelopeBaseEntries = {
+  reportType: OperationalReportTypeEnum,
+  title: v.string(),
+  generatedAt: v.string(),
+  generatedBy: ReportGeneratedBySchema,
+  unitName: v.string(),
+  dateRange: ReportDateRangeSchema,
+  filters: ReportFilterSummarySchema,
+  warnings: v.array(v.string()),
+}
+
+export const ReportDivisionSummarySchema = v.object({
+  id: v.nullable(v.string()),
+  code: v.nullable(v.string()),
+  name: v.string(),
+})
+
+export type ReportDivisionSummary = v.InferOutput<typeof ReportDivisionSummarySchema>
+
+export const ReportTagSummarySchema = v.object({
+  id: v.string(),
+  name: v.string(),
+  chipVariant: v.nullable(v.string()),
+  chipColor: v.nullable(v.string()),
+  isPositional: v.boolean(),
+  source: v.picklist(['direct', 'qualification']),
+})
+
+export type ReportTagSummary = v.InferOutput<typeof ReportTagSummarySchema>
+
+export const ReportMemberSummarySchema = v.object({
+  id: v.string(),
+  displayName: v.string(),
+  rank: v.string(),
+  status: v.string(),
+  division: v.nullable(ReportDivisionSummarySchema),
+  memberType: v.nullable(v.string()),
+  tags: v.array(ReportTagSummarySchema),
+})
+
+export type ReportMemberSummary = v.InferOutput<typeof ReportMemberSummarySchema>
+
+export const PresenceSessionSchema = v.object({
+  inAt: v.string(),
+  outAt: v.nullable(v.string()),
+  durationMinutes: v.nullable(v.number()),
+  status: PresenceSessionStatusEnum,
+})
+
+export type PresenceSession = v.InferOutput<typeof PresenceSessionSchema>
+
+export const PresenceMarkerSchema = v.object({
+  date: v.string(),
+  label: v.string(),
+  present: v.boolean(),
+  firstIn: v.nullable(v.string()),
+  lastOut: v.nullable(v.string()),
+  sessionCount: v.number(),
+  note: v.nullable(v.string()),
+})
+
+export type PresenceMarker = v.InferOutput<typeof PresenceMarkerSchema>
+
+export const KeyNightSchema = v.object({
+  id: v.string(),
+  category: KeyNightCategoryEnum,
+  source: KeyNightSourceEnum,
+  date: v.string(),
+  label: v.string(),
+  title: v.string(),
+  startAt: v.nullable(v.string()),
+  endAt: v.nullable(v.string()),
+})
+
+export type KeyNight = v.InferOutput<typeof KeyNightSchema>
+
+export const KeyNightPresenceMarkerSchema = v.object({
+  keyNightId: v.string(),
+  present: v.boolean(),
+  firstIn: v.nullable(v.string()),
+  lastOut: v.nullable(v.string()),
+})
+
+export type KeyNightPresenceMarker = v.InferOutput<typeof KeyNightPresenceMarkerSchema>
+
+export const DailyPresenceRowSchema = v.object({
+  member: ReportMemberSummarySchema,
+  firstIn: v.nullable(v.string()),
+  lastOut: v.nullable(v.string()),
+  sessionCount: v.number(),
+  leftAndReturned: v.boolean(),
+  sessions: v.array(PresenceSessionSchema),
+})
+
+export type DailyPresenceRow = v.InferOutput<typeof DailyPresenceRowSchema>
+
+export const DailyPresenceReportDataSchema = v.object({
+  summary: v.object({
+    totalScopedMembers: v.number(),
+    presentMembers: v.number(),
+    totalSessions: v.number(),
+    leftAndReturnedCount: v.number(),
+    openSessionCount: v.number(),
+  }),
+  rows: v.array(DailyPresenceRowSchema),
+})
+
+export type DailyPresenceReportData = v.InferOutput<typeof DailyPresenceReportDataSchema>
+
+export const DailyPresenceReportResponseSchema = v.object({
+  ...ReportEnvelopeBaseEntries,
+  reportType: v.literal('daily_presence'),
+  data: DailyPresenceReportDataSchema,
+})
+
+export type DailyPresenceReportResponse = v.InferOutput<typeof DailyPresenceReportResponseSchema>
+
+export const WeeklyPresenceRowSchema = v.object({
+  member: ReportMemberSummarySchema,
+  days: v.array(PresenceMarkerSchema),
+  trainingNightPresent: v.nullable(v.boolean()),
+  adminNightPresent: v.nullable(v.boolean()),
+  keyNights: v.array(KeyNightPresenceMarkerSchema),
+  totalDaysPresent: v.number(),
+  totalSessions: v.number(),
+})
+
+export type WeeklyPresenceRow = v.InferOutput<typeof WeeklyPresenceRowSchema>
+
+export const WeeklyPresenceReportDataSchema = v.object({
+  summary: v.object({
+    totalMembers: v.number(),
+    membersWithPresence: v.number(),
+    trainingNightCount: v.number(),
+    adminNightCount: v.number(),
+  }),
+  days: v.array(
+    v.object({
+      date: v.string(),
+      label: v.string(),
+      isTrainingNight: v.boolean(),
+      isAdminNight: v.boolean(),
+    })
+  ),
+  keyNights: v.array(KeyNightSchema),
+  rows: v.array(WeeklyPresenceRowSchema),
+})
+
+export type WeeklyPresenceReportData = v.InferOutput<typeof WeeklyPresenceReportDataSchema>
+
+export const WeeklyPresenceReportResponseSchema = v.object({
+  ...ReportEnvelopeBaseEntries,
+  reportType: v.literal('weekly_presence'),
+  data: WeeklyPresenceReportDataSchema,
+})
+
+export type WeeklyPresenceReportResponse = v.InferOutput<typeof WeeklyPresenceReportResponseSchema>
+
+export const MonthlyPresenceRowSchema = v.object({
+  member: ReportMemberSummarySchema,
+  days: v.array(PresenceMarkerSchema),
+  keyNights: v.array(KeyNightPresenceMarkerSchema),
+  totalDaysPresent: v.number(),
+  totalSessions: v.number(),
+  trainingNightsPresent: v.number(),
+  adminNightsPresent: v.number(),
+})
+
+export type MonthlyPresenceRow = v.InferOutput<typeof MonthlyPresenceRowSchema>
+
+export const MonthlyPresenceReportDataSchema = v.object({
+  summary: v.object({
+    totalMembers: v.number(),
+    membersWithPresence: v.number(),
+    totalMemberDaysPresent: v.number(),
+    trainingNightCount: v.number(),
+    adminNightCount: v.number(),
+  }),
+  days: v.array(
+    v.object({
+      date: v.string(),
+      label: v.string(),
+      isTrainingNight: v.boolean(),
+      isAdminNight: v.boolean(),
+    })
+  ),
+  keyNights: v.array(KeyNightSchema),
+  rows: v.array(MonthlyPresenceRowSchema),
+})
+
+export type MonthlyPresenceReportData = v.InferOutput<typeof MonthlyPresenceReportDataSchema>
+
+export const MonthlyPresenceReportResponseSchema = v.object({
+  ...ReportEnvelopeBaseEntries,
+  reportType: v.literal('monthly_presence'),
+  data: MonthlyPresenceReportDataSchema,
+})
+
+export type MonthlyPresenceReportResponse = v.InferOutput<
+  typeof MonthlyPresenceReportResponseSchema
+>
+
+export const TrainingNightMonthlyRowSchema = v.object({
+  member: ReportMemberSummarySchema,
+  nights: v.array(KeyNightPresenceMarkerSchema),
+  attended: v.number(),
+  possible: v.number(),
+  percentage: v.number(),
+})
+
+export type TrainingNightMonthlyRow = v.InferOutput<typeof TrainingNightMonthlyRowSchema>
+
+export const TrainingNightMonthlyReportDataSchema = v.object({
+  department: v.nullable(ReportDivisionSummarySchema),
+  trainingNights: v.array(KeyNightSchema),
+  rows: v.array(TrainingNightMonthlyRowSchema),
+  summary: v.object({
+    totalMembers: v.number(),
+    trainingNightCount: v.number(),
+    averageAttendancePercentage: v.number(),
+  }),
+})
+
+export type TrainingNightMonthlyReportData = v.InferOutput<
+  typeof TrainingNightMonthlyReportDataSchema
+>
+
+export const TrainingNightMonthlyReportResponseSchema = v.object({
+  ...ReportEnvelopeBaseEntries,
+  reportType: v.literal('training_night_monthly'),
+  data: TrainingNightMonthlyReportDataSchema,
+})
+
+export type TrainingNightMonthlyReportResponse = v.InferOutput<
+  typeof TrainingNightMonthlyReportResponseSchema
+>
+
+export const VisitorActivityRowSchema = v.object({
+  id: v.string(),
+  displayName: v.string(),
+  organization: v.nullable(v.string()),
+  visitType: v.string(),
+  visitPurpose: v.nullable(v.string()),
+  visitReason: v.nullable(v.string()),
+  checkInTime: v.string(),
+  checkOutTime: v.nullable(v.string()),
+  durationMinutes: v.nullable(v.number()),
+  event: v.nullable(
+    v.object({
+      id: v.string(),
+      name: v.string(),
+    })
+  ),
+  host: v.nullable(
+    v.object({
+      id: v.string(),
+      displayName: v.string(),
+    })
+  ),
+})
+
+export type VisitorActivityRow = v.InferOutput<typeof VisitorActivityRowSchema>
+
+export const VisitorActivityReportDataSchema = v.object({
+  summary: v.object({
+    totalVisitors: v.number(),
+    activeAtEnd: v.number(),
+    byVisitType: v.array(
+      v.object({
+        label: v.string(),
+        count: v.number(),
+      })
+    ),
+    byPurpose: v.array(
+      v.object({
+        label: v.string(),
+        count: v.number(),
+      })
+    ),
+    byEvent: v.array(
+      v.object({
+        label: v.string(),
+        count: v.number(),
+      })
+    ),
+  }),
+  rows: v.array(VisitorActivityRowSchema),
+})
+
+export type VisitorActivityReportData = v.InferOutput<typeof VisitorActivityReportDataSchema>
+
+export const VisitorActivityReportResponseSchema = v.object({
+  ...ReportEnvelopeBaseEntries,
+  reportType: v.literal('visitor_activity'),
+  data: VisitorActivityReportDataSchema,
+})
+
+export type VisitorActivityReportResponse = v.InferOutput<
+  typeof VisitorActivityReportResponseSchema
+>
 
 // ============================================================================
 // Response Schemas

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Adds an Admin Reports page at `/admin/reports` for operational attendance, presence, training night, and visitor reporting.
- Adds dedicated report API contracts and backend aggregation so reports use historical attendance data instead of current-presence lists.
- Adds printable browser report previews with warnings, empty states, compact summaries, and a `Print / Save PDF` action.
- Prepares the Sentinel `v3.2.0` minor release.

## Why this change was needed

Admins and department leads need a quick way to review attendance and visitor activity without exporting raw scan logs or manually combining check-in, member, tag, event, and visitor data. This adds report-focused views and API shapes that answer operational questions while keeping existing attendance, member, visitor, event, and dashboard behavior unchanged.

## What changed

### User-facing

- Added a new Admin sidebar entry for `Reports`.
- Added report type selection, dynamic filters, report previews, warning banners, and empty states.
- Added browser print styling so reports can be printed or saved as PDF through the browser print dialog.

### Admin/operator-facing

- Supports Daily Presence, Weekly Presence, Monthly Presence, Training Night Monthly, and Visitor Activity report flows.
- FTS and GEO are handled as tag-backed shortcuts and warn when matching tags are not configured.
- Training/Admin night classification uses existing unit event and schedule configuration and warns instead of inventing dates when configuration is missing.

### Backend/API

- Adds typed operational report endpoints under `/api/reports`.
- Adds report aggregation over existing check-in, member, division, tag, qualification, unit event, report setting, and visitor data.
- Adds explicit session pairing behavior for check-in/check-out records, including degraded/open-session warnings.

### Database

- No database schema changes are included.
- No migration is required for this release.
- Reports use current member metadata at generation time; historical membership snapshots remain out of scope.

### Deployment/update

- Bumps the monorepo and workspace packages to `3.2.0`.
- No new environment variables or port mappings are required.

### Tests

- Adds focused service tests for operational presence session pairing.

## User impact

Admin and Developer users can open `/admin/reports`, run operational reports, review results in the browser, and print or save them as PDFs through the browser print dialog.

## Operator impact

Operators do not need to run a database migration for this feature. Existing deployment migration checks should still be run as part of the normal release process.

## Upgrade or migration notes

No upgrade action required beyond the normal Sentinel release deployment process. No database migration or configuration change is required.

## Risk and rollback notes

The main risk is report aggregation accuracy around unusual historical check-in/check-out sequences or incomplete Training/Admin night configuration. The implementation reports warnings for degraded session pairing and missing schedule/event configuration rather than failing the whole report.

Rollback is safe because this release does not change the database schema or mutate existing attendance, member, visitor, event, badge scan, report audit, or dashboard sorting behavior.

## Testing performed

- `pnpm version:check`
- `pnpm --filter @sentinel/contracts typecheck`
- `pnpm --filter @sentinel/backend typecheck`
- `pnpm --filter frontend-admin typecheck`
- `pnpm --filter @sentinel/backend lint` completed with existing warning backlog and no errors.
- `pnpm --filter frontend-admin lint` completed with existing warning backlog and no errors.
- Playwright visual check of `/admin/reports` at `1920x1080` using a mocked Admin session and mocked report data.
- Print media check confirmed setup controls and Admin navigation are hidden while the report document remains visible.

Could not run `pnpm --filter @sentinel/backend exec vitest run src/services/operational-report-service.test.ts` because the backend workspace does not expose a `vitest` executable.

## Changelog candidates

- Added an Admin Reports page for printable attendance, presence, training night, and visitor reports. Admins and department leads can review operational patterns without digging through raw scan logs.
- Added dedicated report APIs for historical report aggregation. This keeps report behavior separate from current-presence and check-in list endpoints.
- Added print-friendly report previews with warnings and empty states. Operators can use browser print or Save to PDF without a separate PDF service.
- No database migration is required for this release.
