### PR TITLE
fix(reports): hide Sentinel System from operations views

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/lib/system-bootstrap.test.ts
+++ b/apps/backend/src/lib/system-bootstrap.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { SENTINEL_BOOTSTRAP_SERVICE_NUMBER, isSentinelBootstrapMember } from './system-bootstrap.js'
+
+describe('isSentinelBootstrapMember', () => {
+  it('identifies the protected Sentinel bootstrap member by service number', () => {
+    expect(isSentinelBootstrapMember({ serviceNumber: SENTINEL_BOOTSTRAP_SERVICE_NUMBER })).toBe(
+      true
+    )
+  })
+
+  it('does not hide ordinary members with similar names', () => {
+    expect(isSentinelBootstrapMember({ serviceNumber: 'A12345678' })).toBe(false)
+    expect(isSentinelBootstrapMember({ serviceNumber: null })).toBe(false)
+  })
+})

--- a/apps/backend/src/lib/system-bootstrap.ts
+++ b/apps/backend/src/lib/system-bootstrap.ts
@@ -55,3 +55,7 @@ export function isSentinelBootstrapServiceNumber(
 ): boolean {
   return serviceNumber === SENTINEL_BOOTSTRAP_SERVICE_NUMBER
 }
+
+export function isSentinelBootstrapMember(member: { serviceNumber?: string | null }): boolean {
+  return isSentinelBootstrapServiceNumber(member.serviceNumber)
+}

--- a/apps/backend/src/repositories/checkin-repository.ts
+++ b/apps/backend/src/repositories/checkin-repository.ts
@@ -13,6 +13,7 @@ import type {
 import type { PrismaClientInstance } from '@sentinel/database'
 import { prisma as defaultPrisma, Prisma } from '@sentinel/database'
 import { DEFAULT_TIMEZONE, getOperationalDayStartTime } from '../utils/operational-date.js'
+import { SENTINEL_BOOTSTRAP_SERVICE_NUMBER } from '../lib/system-bootstrap.js'
 
 // TODO: Implement Redis caching when infrastructure is ready
 // import { redis } from '../redis';
@@ -694,13 +695,16 @@ export class CheckinRepository {
           COUNT(*) FILTER (WHERE m.status = 'active' AND (lc.direction = 'out' OR lc.direction IS NULL)) as absent
         FROM members m
         LEFT JOIN latest_checkins lc ON m.id = lc.member_id
+        WHERE m.service_number <> ${SENTINEL_BOOTSTRAP_SERVICE_NUMBER}
       ),
       late_arrivals AS (
-        SELECT COUNT(DISTINCT member_id) as count
-        FROM checkins
-        WHERE direction = 'in'
-          AND timestamp::date = CURRENT_DATE
-          AND EXTRACT(HOUR FROM timestamp) >= 8
+        SELECT COUNT(DISTINCT c.member_id) as count
+        FROM checkins c
+        INNER JOIN members m ON c.member_id = m.id
+        WHERE c.direction = 'in'
+          AND c.timestamp::date = CURRENT_DATE
+          AND EXTRACT(HOUR FROM c.timestamp) >= 8
+          AND m.service_number <> ${SENTINEL_BOOTSTRAP_SERVICE_NUMBER}
       ),
       active_visitors AS (
         SELECT COUNT(*) as count
@@ -842,7 +846,9 @@ export class CheckinRepository {
       LEFT JOIN ranks r ON m.rank_id = r.id
       LEFT JOIN member_tags_agg mta ON m.id = mta.member_id
       LEFT JOIN member_types mt ON mt.id = m.member_type_id OR (m.member_type_id IS NULL AND mt.code = m.member_type)
-      WHERE m.status = 'active' AND lc.direction = 'in'
+      WHERE m.status = 'active'
+        AND m.service_number <> ${SENTINEL_BOOTSTRAP_SERVICE_NUMBER}
+        AND lc.direction = 'in'
       ORDER BY lc.timestamp DESC
     `
 
@@ -941,6 +947,7 @@ export class CheckinRepository {
         LIMIT 1
       ) c ON true
       WHERE m.status = 'active'
+        AND m.service_number <> ${SENTINEL_BOOTSTRAP_SERVICE_NUMBER}
       ORDER BY m.last_name, m.first_name
     `
 
@@ -1085,6 +1092,7 @@ export class CheckinRepository {
         JOIN members m ON c.member_id = m.id
         LEFT JOIN divisions d ON m.division_id = d.id
         WHERE c.timestamp >= ${cutoffDate}
+          AND m.service_number <> ${SENTINEL_BOOTSTRAP_SERVICE_NUMBER}
         ORDER BY c.timestamp DESC
         LIMIT ${limit}
       )
@@ -1102,7 +1110,7 @@ export class CheckinRepository {
           v.organization,
           v.visit_type,
           v.visit_reason,
-          CASE WHEN hm.id IS NOT NULL THEN COALESCE(NULLIF(hm.display_name, ''), hm.first_name || ' ' || hm.last_name) ELSE NULL END as host_name,
+          CASE WHEN hm.id IS NOT NULL AND hm.service_number <> ${SENTINEL_BOOTSTRAP_SERVICE_NUMBER} THEN COALESCE(NULLIF(hm.display_name, ''), hm.first_name || ' ' || hm.last_name) ELSE NULL END as host_name,
           v.event_id,
           e.name as event_name
         FROM visitors v
@@ -1126,7 +1134,7 @@ export class CheckinRepository {
           v.organization,
           v.visit_type,
           v.visit_reason,
-          CASE WHEN hm.id IS NOT NULL THEN COALESCE(NULLIF(hm.display_name, ''), hm.first_name || ' ' || hm.last_name) ELSE NULL END as host_name,
+          CASE WHEN hm.id IS NOT NULL AND hm.service_number <> ${SENTINEL_BOOTSTRAP_SERVICE_NUMBER} THEN COALESCE(NULLIF(hm.display_name, ''), hm.first_name || ' ' || hm.last_name) ELSE NULL END as host_name,
           v.event_id,
           e.name as event_name
         FROM visitors v

--- a/apps/backend/src/repositories/operational-report-repository.ts
+++ b/apps/backend/src/repositories/operational-report-repository.ts
@@ -1,5 +1,6 @@
 import type { PrismaClientInstance } from '@sentinel/database'
 import { Prisma, prisma as defaultPrisma } from '@sentinel/database'
+import { SENTINEL_BOOTSTRAP_SERVICE_NUMBER } from '../lib/system-bootstrap.js'
 
 const reportMemberInclude = {
   division: {
@@ -63,6 +64,7 @@ const visitorInclude = {
   hostMember: {
     select: {
       id: true,
+      serviceNumber: true,
       rank: true,
       firstName: true,
       lastName: true,
@@ -163,6 +165,9 @@ export class OperationalReportRepository {
   ): Promise<OperationalReportMemberRecord[]> {
     const where: Prisma.MemberWhereInput = {
       status: 'active',
+      serviceNumber: {
+        not: SENTINEL_BOOTSTRAP_SERVICE_NUMBER,
+      },
     }
 
     if (filters.divisionId) {

--- a/apps/backend/src/repositories/visitor-repository.ts
+++ b/apps/backend/src/repositories/visitor-repository.ts
@@ -17,6 +17,7 @@ import {
   normalizeNamePart,
   splitLegacyVisitorName,
 } from '../utils/display-name.js'
+import { isSentinelBootstrapMember } from '../lib/system-bootstrap.js'
 
 interface VisitorFilters {
   dateRange?: {
@@ -759,7 +760,12 @@ export class VisitorRepository {
    */
   toVisitorWithRelations(
     visitor: PrismaVisitor & {
-      hostMember?: { firstName: string; lastName: string; displayName?: string | null } | null
+      hostMember?: {
+        serviceNumber: string
+        firstName: string
+        lastName: string
+        displayName?: string | null
+      } | null
       event?: { name: string } | null
       visitTypeRef?: {
         id: string
@@ -774,11 +780,14 @@ export class VisitorRepository {
     visitTypeInfo?: { id: string; name: string; chipVariant?: string; chipColor?: string }
   } {
     const base = this.toVisitorType(visitor)
+    const hostMember =
+      visitor.hostMember && !isSentinelBootstrapMember(visitor.hostMember)
+        ? visitor.hostMember
+        : null
     return {
       ...base,
-      hostName: visitor.hostMember
-        ? (visitor.hostMember.displayName ??
-          `${visitor.hostMember.firstName} ${visitor.hostMember.lastName}`)
+      hostName: hostMember
+        ? (hostMember.displayName ?? `${hostMember.firstName} ${hostMember.lastName}`)
         : undefined,
       eventName: visitor.event?.name ?? undefined,
       visitTypeInfo: visitor.visitTypeRef

--- a/apps/backend/src/routes/checkins.ts
+++ b/apps/backend/src/routes/checkins.ts
@@ -24,6 +24,7 @@ import { broadcastCheckin } from '../websocket/broadcast.js'
 import { serviceLogger } from '../lib/logger.js'
 import { formatAuditMemberName, logRequestAudit } from '../lib/audit-log.js'
 import { canMemberEditHistory } from '../lib/history-permissions.js'
+import { SENTINEL_BOOTSTRAP_SERVICE_NUMBER } from '../lib/system-bootstrap.js'
 import type { PrismaClientInstance } from '@sentinel/database'
 
 function getClientIp(req: unknown): string {
@@ -336,6 +337,7 @@ export const checkinsRouter = s.router(checkinContract, {
           COUNT(*) FILTER (WHERE m.status = 'active') as total
         FROM divisions d
         LEFT JOIN members m ON m.division_id = d.id
+          AND m.service_number <> ${SENTINEL_BOOTSTRAP_SERVICE_NUMBER}
         LEFT JOIN latest_checkins lc ON m.id = lc.member_id
         GROUP BY d.id, d.name
         ORDER BY d.name

--- a/apps/backend/src/routes/reports.ts
+++ b/apps/backend/src/routes/reports.ts
@@ -1,6 +1,7 @@
 import { initServer } from '@ts-rest/express'
 import type { Request } from 'express'
 import { reportContract } from '@sentinel/contracts'
+import type { Prisma } from '@sentinel/database'
 import type {
   DailyCheckinConfig,
   TrainingNightReportConfig,
@@ -14,6 +15,10 @@ import {
   OperationalReportService,
   type OperationalReportActor,
 } from '../services/operational-report-service.js'
+import {
+  SENTINEL_BOOTSTRAP_SERVICE_NUMBER,
+  isSentinelBootstrapMember,
+} from '../lib/system-bootstrap.js'
 
 const s = initServer()
 const prisma = getPrismaClient()
@@ -49,6 +54,15 @@ function getReportActor(req: Request): OperationalReportActor {
     rank: req.member?.rank,
     firstName: req.member?.firstName,
     lastName: req.member?.lastName,
+  }
+}
+
+function createVisibleActiveMemberWhere(): Prisma.MemberWhereInput {
+  return {
+    status: 'active',
+    serviceNumber: {
+      not: SENTINEL_BOOTSTRAP_SERVICE_NUMBER,
+    },
   }
 }
 
@@ -188,9 +202,7 @@ export const reportsRouter = s.router(reportContract, {
       today.setHours(0, 0, 0, 0)
 
       // Build where clause for member filtering
-      const memberWhere: Record<string, unknown> = {
-        status: 'active',
-      }
+      const memberWhere = createVisibleActiveMemberWhere()
 
       if (config.divisionId) {
         memberWhere.divisionId = config.divisionId
@@ -473,9 +485,7 @@ export const reportsRouter = s.router(reportContract, {
       }
 
       // Build member query
-      const memberWhere: Record<string, unknown> = {
-        status: 'active',
-      }
+      const memberWhere = createVisibleActiveMemberWhere()
 
       if (config.organizationOption === 'specific_division' && config.divisionId) {
         memberWhere.divisionId = config.divisionId
@@ -491,7 +501,7 @@ export const reportsRouter = s.router(reportContract, {
 
       // Get members with attendance data
       const members = await prisma.member.findMany({
-        where: memberWhere as Record<string, unknown>,
+        where: memberWhere,
         include: {
           division: {
             select: {
@@ -641,10 +651,14 @@ export const reportsRouter = s.router(reportContract, {
       })
 
       // Filter by division if specified
+      const visibleEnrollments = enrollments.filter(
+        (enrollment) => !isSentinelBootstrapMember(enrollment.member)
+      )
+
       const filteredEnrollments =
         config.organizationOption === 'specific_division' && config.divisionId
-          ? enrollments.filter((e) => e.member.divisionId === config.divisionId)
-          : enrollments
+          ? visibleEnrollments.filter((e) => e.member.divisionId === config.divisionId)
+          : visibleEnrollments
 
       // Calculate attendance for each enrollment
       const records = filteredEnrollments.map((enrollment) => {
@@ -706,9 +720,7 @@ export const reportsRouter = s.router(reportContract, {
       const config: PersonnelRosterConfig = body
 
       // Build member query
-      const memberWhere: Record<string, unknown> = {
-        status: 'active',
-      }
+      const memberWhere = createVisibleActiveMemberWhere()
 
       if (config.divisionId) {
         memberWhere.divisionId = config.divisionId
@@ -826,31 +838,38 @@ export const reportsRouter = s.router(reportContract, {
         },
       })
 
-      const records = visitors.map((visitor) => ({
-        id: visitor.id,
-        fullName: visitor.name || visitor.id,
-        organization: visitor.organization || null,
-        purpose: visitor.visitReason || null,
-        visitType: visitor.visitType,
-        checkInTime: visitor.checkInTime.toISOString(),
-        checkOutTime: visitor.checkOutTime?.toISOString() || null,
-        duration: visitor.checkOutTime
-          ? Math.round((visitor.checkOutTime.getTime() - visitor.checkInTime.getTime()) / 60000)
-          : null,
-        hostMember: visitor.hostMember
-          ? {
-              id: visitor.hostMember.id,
-              serviceNumber: visitor.hostMember.serviceNumber,
-              firstName: visitor.hostMember.firstName,
-              lastName: visitor.hostMember.lastName,
-              rank: visitor.hostMember.rank,
-              division: {
-                id: visitor.hostMember.division?.id ?? 'Unknown',
-                name: visitor.hostMember.division?.name ?? 'Unknown',
-              },
-            }
-          : null,
-      }))
+      const records = visitors.map((visitor) => {
+        const hostMember =
+          visitor.hostMember && !isSentinelBootstrapMember(visitor.hostMember)
+            ? visitor.hostMember
+            : null
+
+        return {
+          id: visitor.id,
+          fullName: visitor.name || visitor.id,
+          organization: visitor.organization || null,
+          purpose: visitor.visitReason || null,
+          visitType: visitor.visitType,
+          checkInTime: visitor.checkInTime.toISOString(),
+          checkOutTime: visitor.checkOutTime?.toISOString() || null,
+          duration: visitor.checkOutTime
+            ? Math.round((visitor.checkOutTime.getTime() - visitor.checkInTime.getTime()) / 60000)
+            : null,
+          hostMember: hostMember
+            ? {
+                id: hostMember.id,
+                serviceNumber: hostMember.serviceNumber,
+                firstName: hostMember.firstName,
+                lastName: hostMember.lastName,
+                rank: hostMember.rank,
+                division: {
+                  id: hostMember.division?.id ?? 'Unknown',
+                  name: hostMember.division?.name ?? 'Unknown',
+                },
+              }
+            : null,
+        }
+      })
 
       // Calculate summary statistics
       const byVisitType: Record<string, number> = {}

--- a/apps/backend/src/services/operational-report-service.ts
+++ b/apps/backend/src/services/operational-report-service.ts
@@ -34,6 +34,7 @@ import {
   type OperationalReportUnitEventRecord,
   type OperationalReportVisitorRecord,
 } from '../repositories/operational-report-repository.js'
+import { isSentinelBootstrapMember } from '../lib/system-bootstrap.js'
 
 const UNIT_NAME = 'HMCS Chippawa'
 const REPORT_LOOKBACK_DAYS = 1
@@ -1133,11 +1134,13 @@ export class OperationalReportService {
 
   private toVisitorActivityRow(visitor: OperationalReportVisitorRecord) {
     const displayName = visitor.displayName ?? visitor.name
-    const hostName = visitor.hostMember
-      ? (visitor.hostMember.displayName ??
-        [visitor.hostMember.rank, visitor.hostMember.firstName, visitor.hostMember.lastName]
-          .filter(Boolean)
-          .join(' '))
+    const hostMember =
+      visitor.hostMember && !isSentinelBootstrapMember(visitor.hostMember)
+        ? visitor.hostMember
+        : null
+    const hostName = hostMember
+      ? (hostMember.displayName ??
+        [hostMember.rank, hostMember.firstName, hostMember.lastName].filter(Boolean).join(' '))
       : null
 
     return {
@@ -1162,9 +1165,9 @@ export class OperationalReportService {
           }
         : null,
       host:
-        visitor.hostMember && hostName
+        hostMember && hostName
           ? {
-              id: visitor.hostMember.id,
+              id: hostMember.id,
               displayName: hostName,
             }
           : null,

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/components/admin/reports/AdminReportsPage.tsx
+++ b/apps/frontend-admin/src/components/admin/reports/AdminReportsPage.tsx
@@ -30,6 +30,8 @@ import {
 } from './report-definitions'
 import { ReportPreview } from './report-preview'
 
+const SENTINEL_BOOTSTRAP_SERVICE_NUMBER = 'SENTINEL-SYSTEM'
+
 function optionalString(value: string): string | undefined {
   const trimmed = value.trim()
   return trimmed.length > 0 ? trimmed : undefined
@@ -114,6 +116,9 @@ export function AdminReportsPage() {
   const tagsQuery = useTags()
   const visitTypesQuery = useVisitTypesForReports()
   const membersQuery = useMembers({ limit: 500, scope: 'all', status: 'active' })
+  const reportHostMembers = (membersQuery.data?.members ?? []).filter(
+    (member) => member.serviceNumber !== SENTINEL_BOOTSTRAP_SERVICE_NUMBER
+  )
   const reportRunner = useAdminReportRunner()
   const definition = getReportDefinition(filters.reportType)
   const tags = tagsQuery.data ?? []
@@ -216,7 +221,7 @@ export function AdminReportsPage() {
               divisions={divisionsQuery.data?.divisions ?? []}
               tags={tags}
               visitTypes={visitTypesQuery.data ?? []}
-              hostMembers={membersQuery.data?.members ?? []}
+              hostMembers={reportHostMembers}
               shortcutWarning={shortcutWarning}
             />
           </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Hides the protected `Sentinel System` bootstrap member from dashboard presence views and report output.
- Excludes the bootstrap account from operational report member lists, legacy report member queries, dashboard presence counts, present-member cards, and recent activity.
- Keeps visitor activity visible while suppressing `Sentinel System` as a visitor host label or host filter option.
- Prepares Sentinel `v3.2.2` as a patch release with no database migration.

## Why this change was needed

The `Sentinel System` account is a developer/bootstrap account used for appliance and testing workflows. It must remain trackable internally, but it should not affect operational attendance, presence, or report review. Showing it on the dashboard or reports could inflate attendance totals or distract duty staff and department leads.

## What changed

### User-facing

- The dashboard no longer shows `Sentinel System` as a present member.
- Dashboard presence totals and recent check-in activity exclude the bootstrap member.
- Admin Reports no longer include the bootstrap member in presence, training, roster, or attendance report member rows.
- Visitor reports still show visits, but do not display `Sentinel System` as the host.

### Admin/operator-facing

- The Reports page host filter no longer offers `Sentinel System` as a selectable host.
- The bootstrap member remains protected and usable for internal system workflows.

### Backend/API

- Adds a shared helper for identifying the Sentinel bootstrap member by protected service number.
- Filters dashboard presence queries and report member queries by the bootstrap service number instead of display name.
- Keeps check-in/check-out storage unchanged so existing system records are not deleted or rewritten.

### Database

- No database migration is required.
- No data cleanup is required.
- Existing `Sentinel System` records remain in the database for internal tracking.

### Deployment/update

- Workspace package versions are synced to `3.2.2`.
- No environment variable or deployment file changes are required.

### Tests

- Adds helper coverage for identifying the bootstrap member.
- Re-runs existing operational report session aggregation coverage.

## User impact

Duty staff, Admin users, and department leads should no longer see the developer/bootstrap account in dashboard presence or operational reports. Attendance and presence summaries should be clearer and less likely to include a non-operational account.

## Operator impact

No operator action is required. The account remains in place for system/bootstrap use, and deployments do not need database changes.

## Upgrade or migration notes

No upgrade action required.

No database migration is required. No configuration change is required. Existing check-in and report history records are left intact.

## Risk and rollback notes

The main risk is that an internal workflow unexpectedly depended on seeing the bootstrap account in operational views. The filter is limited to dashboard/report presentation and does not delete the account or change check-in tracking.

Rollback is safe from a database perspective because no schema or data migration is introduced.

## Testing performed

- `pnpm typecheck`
- `pnpm lint` passed with existing warnings only.
- `pnpm version:check`
- `git diff --check`
- `pnpm --dir apps/frontend-admin exec vitest --root ../.. run apps/backend/src/lib/system-bootstrap.test.ts apps/backend/src/services/operational-report-service.test.ts`

## Changelog candidates

- Fixed dashboard and report views so the protected `Sentinel System` bootstrap account no longer appears in operational attendance or presence output.
- Fixed visitor report host display so the bootstrap account is not shown as a visitor host.
- No database migration or configuration change is required for `v3.2.2`.
