### PR TITLE
Release v3.2.3

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/services/operational-report-service.test.ts
+++ b/apps/backend/src/services/operational-report-service.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   pairOperationalPresenceSessions,
+  presenceSessionOverlapsRange,
   type PresenceSessionInternal,
 } from './operational-report-service.js'
 import type { OperationalReportCheckinRecord } from '../repositories/operational-report-repository.js'
@@ -77,5 +78,53 @@ describe('pairOperationalPresenceSessions', () => {
     expect(Array.from(warnings)).toContain(
       'Some checkout records could not be paired with a prior check-in and were ignored.'
     )
+  })
+})
+
+describe('presenceSessionOverlapsRange', () => {
+  const openSession: PresenceSessionInternal = {
+    memberId: 'member-1',
+    inAt: new Date('2026-05-05T23:00:00.000Z'),
+    outAt: null,
+    status: 'open',
+  }
+  const asOf = new Date('2026-05-06T14:23:00.000Z')
+
+  it('keeps open sessions present through the report generation time', () => {
+    expect(
+      presenceSessionOverlapsRange(
+        openSession,
+        new Date('2026-05-06T05:00:00.000Z'),
+        new Date('2026-05-07T05:00:00.000Z'),
+        asOf
+      )
+    ).toBe(true)
+  })
+
+  it('does not extend open sessions into future report days', () => {
+    expect(
+      presenceSessionOverlapsRange(
+        openSession,
+        new Date('2026-05-07T05:00:00.000Z'),
+        new Date('2026-05-08T05:00:00.000Z'),
+        asOf
+      )
+    ).toBe(false)
+  })
+
+  it('ignores sessions that start after the report generation time', () => {
+    expect(
+      presenceSessionOverlapsRange(
+        {
+          memberId: 'member-1',
+          inAt: new Date('2026-05-06T18:00:00.000Z'),
+          outAt: null,
+          status: 'open',
+        },
+        new Date('2026-05-06T05:00:00.000Z'),
+        new Date('2026-05-07T05:00:00.000Z'),
+        asOf
+      )
+    ).toBe(false)
   })
 })

--- a/apps/backend/src/services/operational-report-service.ts
+++ b/apps/backend/src/services/operational-report-service.ts
@@ -89,6 +89,22 @@ interface PresenceStats {
   note: string | null
 }
 
+export function presenceSessionOverlapsRange(
+  session: PresenceSessionInternal,
+  start: Date,
+  end: Date,
+  asOf: Date = new Date()
+): boolean {
+  if (session.inAt > asOf) {
+    return false
+  }
+
+  const rawOut = session.outAt ?? asOf
+  const effectiveOut = rawOut > asOf ? asOf : rawOut
+
+  return session.inAt < end && effectiveOut > start
+}
+
 export function pairOperationalPresenceSessions(
   checkins: OperationalReportCheckinRecord[],
   warnings: Set<string>
@@ -1175,8 +1191,7 @@ export class OperationalReportService {
   }
 
   private sessionOverlaps(session: PresenceSessionInternal, start: Date, end: Date): boolean {
-    const effectiveOut = session.outAt ?? end
-    return session.inAt < end && effectiveOut > start
+    return presenceSessionOverlapsRange(session, start, end)
   }
 
   private getCategoryPresence(

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/components/layout/app-navbar.tsx
+++ b/apps/frontend-admin/src/components/layout/app-navbar.tsx
@@ -3,8 +3,7 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { useSyncExternalStore } from 'react'
-import { useQueryClient } from '@tanstack/react-query'
+import { useState, useSyncExternalStore } from 'react'
 import type {
   SystemHealthStatus,
   SystemUpdateJob,
@@ -12,14 +11,13 @@ import type {
   SystemUpdateJobStatus,
 } from '@sentinel/contracts'
 import { Menu, PanelLeftOpen } from 'lucide-react'
-import { toast } from 'sonner'
 import { AppBadge, type AppBadgeStatus } from '@/components/ui/AppBadge'
 import { Chip } from '@/components/ui/chip'
 import { isAdminNavPath } from '@/lib/admin-routes'
 import { cn } from '@/lib/utils'
 import { UserMenu } from '@/components/layout/user-menu'
 import { HelpButton } from '@/components/help/HelpButton'
-import { useHostHotspotRecovery } from '@/hooks/use-network-settings'
+import { HostHotspotRepairDialog } from '@/components/network/host-hotspot-repair-dialog'
 import { useSystemStatus } from '@/hooks/use-system-status'
 import { useSystemUpdateStatus } from '@/hooks/use-system-update'
 import { TID } from '@/lib/test-ids'
@@ -48,8 +46,7 @@ export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
   const member = useAuthStore((state) => state.member)
   const authSession = useAuthStore((state) => state.session)
-  const queryClient = useQueryClient()
-  const hostHotspotRecovery = useHostHotspotRecovery()
+  const [hostHotspotRepairOpen, setHostHotspotRepairOpen] = useState(false)
   const systemStatusQuery = useSystemStatus({ enabled: isAuthenticated })
   const systemUpdateQuery = useSystemUpdateStatus({
     enabled: isAuthenticated,
@@ -139,20 +136,6 @@ export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
   const currentSystemUpdateJob = systemUpdateStatus?.currentJob ?? null
   const hasActiveSystemUpdate =
     currentSystemUpdateJob !== null && !isSystemUpdateJobTerminal(currentSystemUpdateJob)
-
-  const handleHostHotspotRecovery = async () => {
-    try {
-      const result = await hostHotspotRecovery.mutateAsync()
-      toast.success(result.message)
-      ;[2_000, 5_000, 10_000, 20_000].forEach((delayMs) => {
-        window.setTimeout(() => {
-          void queryClient.invalidateQueries({ queryKey: ['system-status'] })
-        }, delayMs)
-      })
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to queue host hotspot recovery')
-    }
-  }
 
   return (
     <div className="navbar w-full shadow-lg bg-primary text-primary-content">
@@ -409,11 +392,10 @@ export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
                       <button
                         type="button"
                         className="btn btn-xs btn-outline"
-                        onClick={() => void handleHostHotspotRecovery()}
-                        disabled={hostHotspotRecovery.isPending}
+                        onClick={() => setHostHotspotRepairOpen(true)}
                         data-testid={TID.nav.backendStatusHostRecovery}
                       >
-                        {hostHotspotRecovery.isPending ? 'Queueing...' : 'Repair host hotspot'}
+                        Repair host hotspot
                       </button>
                     )}
                   </div>
@@ -473,6 +455,10 @@ export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
         </div>
         <UserMenu />
       </div>
+      <HostHotspotRepairDialog
+        open={hostHotspotRepairOpen}
+        onOpenChange={setHostHotspotRepairOpen}
+      />
     </div>
   )
 }

--- a/apps/frontend-admin/src/components/network/host-hotspot-repair-dialog.logic.test.ts
+++ b/apps/frontend-admin/src/components/network/host-hotspot-repair-dialog.logic.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getHostHotspotAntennaWaitLabel,
+  getHostHotspotRepairStepState,
+  isHostHotspotAntennaWaitActionDisabled,
+} from './host-hotspot-repair-dialog.logic'
+
+describe('host hotspot repair dialog logic', () => {
+  it('marks earlier steps complete and later steps pending', () => {
+    expect(getHostHotspotRepairStepState('reset-antenna', 'run-repair')).toBe('complete')
+    expect(getHostHotspotRepairStepState('reset-antenna', 'reset-antenna')).toBe('active')
+    expect(getHostHotspotRepairStepState('reset-antenna', 'retry-repair')).toBe('pending')
+  })
+
+  it('marks all steps complete after the final repair is queued', () => {
+    expect(getHostHotspotRepairStepState('complete', 'run-repair')).toBe('complete')
+    expect(getHostHotspotRepairStepState('complete', 'reset-antenna')).toBe('complete')
+    expect(getHostHotspotRepairStepState('complete', 'retry-repair')).toBe('complete')
+  })
+
+  it('labels and disables the antenna wait action while the timer runs', () => {
+    expect(getHostHotspotAntennaWaitLabel({ started: false, secondsRemaining: 3 })).toBe(
+      'Start 3-second wait'
+    )
+    expect(isHostHotspotAntennaWaitActionDisabled({ started: false, secondsRemaining: 3 })).toBe(
+      false
+    )
+
+    expect(getHostHotspotAntennaWaitLabel({ started: true, secondsRemaining: 2 })).toBe('Wait 2s')
+    expect(isHostHotspotAntennaWaitActionDisabled({ started: true, secondsRemaining: 2 })).toBe(
+      true
+    )
+
+    expect(getHostHotspotAntennaWaitLabel({ started: true, secondsRemaining: 0 })).toBe(
+      'Antenna is plugged in'
+    )
+    expect(isHostHotspotAntennaWaitActionDisabled({ started: true, secondsRemaining: 0 })).toBe(
+      false
+    )
+  })
+})

--- a/apps/frontend-admin/src/components/network/host-hotspot-repair-dialog.logic.ts
+++ b/apps/frontend-admin/src/components/network/host-hotspot-repair-dialog.logic.ts
@@ -1,0 +1,67 @@
+export const HOST_HOTSPOT_ANTENNA_WAIT_SECONDS = 3
+
+export const HOST_HOTSPOT_REPAIR_STEPS = [
+  {
+    id: 'run-repair',
+    label: 'Run repair',
+  },
+  {
+    id: 'reset-antenna',
+    label: 'Reset antenna',
+  },
+  {
+    id: 'retry-repair',
+    label: 'Run repair again',
+  },
+] as const
+
+export type HostHotspotRepairStepId = (typeof HOST_HOTSPOT_REPAIR_STEPS)[number]['id']
+export type HostHotspotRepairStage = HostHotspotRepairStepId | 'complete'
+export type HostHotspotRepairStepState = 'complete' | 'active' | 'pending'
+
+export interface HostHotspotAntennaWaitState {
+  started: boolean
+  secondsRemaining: number
+}
+
+export function getHostHotspotRepairStepState(
+  stage: HostHotspotRepairStage,
+  stepId: HostHotspotRepairStepId
+): HostHotspotRepairStepState {
+  if (stage === 'complete') {
+    return 'complete'
+  }
+
+  const activeIndex = HOST_HOTSPOT_REPAIR_STEPS.findIndex((step) => step.id === stage)
+  const stepIndex = HOST_HOTSPOT_REPAIR_STEPS.findIndex((step) => step.id === stepId)
+
+  if (stepIndex < activeIndex) {
+    return 'complete'
+  }
+
+  if (stepIndex === activeIndex) {
+    return 'active'
+  }
+
+  return 'pending'
+}
+
+export function getHostHotspotAntennaWaitLabel(state: HostHotspotAntennaWaitState): string {
+  if (!state.started) {
+    return 'Start 3-second wait'
+  }
+
+  const secondsRemaining = Math.max(0, Math.ceil(state.secondsRemaining))
+
+  if (secondsRemaining === 0) {
+    return 'Antenna is plugged in'
+  }
+
+  return `Wait ${secondsRemaining}s`
+}
+
+export function isHostHotspotAntennaWaitActionDisabled(
+  state: HostHotspotAntennaWaitState
+): boolean {
+  return state.started && state.secondsRemaining > 0
+}

--- a/apps/frontend-admin/src/components/network/host-hotspot-repair-dialog.tsx
+++ b/apps/frontend-admin/src/components/network/host-hotspot-repair-dialog.tsx
@@ -1,0 +1,363 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { CheckCircle2, RotateCcw, Usb, Wrench, type LucideIcon } from 'lucide-react'
+import { toast } from 'sonner'
+import { AppBadge } from '@/components/ui/AppBadge'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { LoadingSpinner } from '@/components/ui/loading-spinner'
+import { useHostHotspotRecovery } from '@/hooks/use-network-settings'
+import { cn } from '@/lib/utils'
+import { TID } from '@/lib/test-ids'
+import {
+  HOST_HOTSPOT_ANTENNA_WAIT_SECONDS,
+  HOST_HOTSPOT_REPAIR_STEPS,
+  getHostHotspotAntennaWaitLabel,
+  getHostHotspotRepairStepState,
+  isHostHotspotAntennaWaitActionDisabled,
+  type HostHotspotRepairStage,
+  type HostHotspotRepairStepState,
+} from './host-hotspot-repair-dialog.logic'
+
+interface HostHotspotRepairDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onRepairQueued?: () => Promise<void> | void
+}
+
+const SYSTEM_STATUS_REFRESH_DELAYS_MS = [2_000, 5_000, 10_000, 20_000] as const
+
+const stepToneClasses: Record<HostHotspotRepairStepState, string> = {
+  complete: 'step-success',
+  active: 'step-warning',
+  pending: '',
+}
+
+const instructionSurfaceClasses: Record<HostHotspotRepairStage, string> = {
+  'run-repair': 'border-info/40 bg-info-fadded text-info-fadded-content',
+  'reset-antenna': 'border-warning/45 bg-warning-fadded text-warning-fadded-content',
+  'retry-repair': 'border-info/40 bg-info-fadded text-info-fadded-content',
+  complete: 'border-success/45 bg-success-fadded text-success-fadded-content',
+}
+
+export function HostHotspotRepairDialog({
+  open,
+  onOpenChange,
+  onRepairQueued,
+}: HostHotspotRepairDialogProps) {
+  const queryClient = useQueryClient()
+  const hostHotspotRecovery = useHostHotspotRecovery()
+  const [stage, setStage] = useState<HostHotspotRepairStage>('run-repair')
+  const [antennaWaitStarted, setAntennaWaitStarted] = useState(false)
+  const [antennaSecondsRemaining, setAntennaSecondsRemaining] = useState(
+    HOST_HOTSPOT_ANTENNA_WAIT_SECONDS
+  )
+  const [queuedMessage, setQueuedMessage] = useState<string | null>(null)
+
+  const resetFlow = () => {
+    setStage('run-repair')
+    setAntennaWaitStarted(false)
+    setAntennaSecondsRemaining(HOST_HOTSPOT_ANTENNA_WAIT_SECONDS)
+    setQueuedMessage(null)
+  }
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      resetFlow()
+    }
+
+    onOpenChange(nextOpen)
+  }
+
+  useEffect(() => {
+    if (!open || stage !== 'reset-antenna' || !antennaWaitStarted || antennaSecondsRemaining <= 0) {
+      return undefined
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setAntennaSecondsRemaining((current) => Math.max(0, current - 1))
+    }, 1_000)
+
+    return () => window.clearTimeout(timeoutId)
+  }, [antennaSecondsRemaining, antennaWaitStarted, open, stage])
+
+  const antennaWaitState = {
+    started: antennaWaitStarted,
+    secondsRemaining: antennaSecondsRemaining,
+  }
+  const primaryDisabled =
+    hostHotspotRecovery.isPending ||
+    (stage === 'reset-antenna' && isHostHotspotAntennaWaitActionDisabled(antennaWaitState))
+
+  const queueSystemStatusRefreshes = () => {
+    SYSTEM_STATUS_REFRESH_DELAYS_MS.forEach((delayMs) => {
+      window.setTimeout(() => {
+        void queryClient.invalidateQueries({ queryKey: ['system-status'] })
+      }, delayMs)
+    })
+  }
+
+  const handleRepair = async (nextStage: HostHotspotRepairStage) => {
+    try {
+      const result = await hostHotspotRecovery.mutateAsync()
+      setQueuedMessage(result.message)
+      setStage(nextStage)
+      queueSystemStatusRefreshes()
+      toast.success(result.message)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to queue host hotspot recovery')
+      return
+    }
+
+    try {
+      await onRepairQueued?.()
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : 'Repair queued, but status refresh failed'
+      )
+    }
+  }
+
+  const handlePrimaryAction = () => {
+    if (stage === 'run-repair') {
+      void handleRepair('reset-antenna')
+      return
+    }
+
+    if (stage === 'reset-antenna') {
+      if (!antennaWaitStarted) {
+        setAntennaWaitStarted(true)
+        setAntennaSecondsRemaining(HOST_HOTSPOT_ANTENNA_WAIT_SECONDS)
+        return
+      }
+
+      if (antennaSecondsRemaining === 0) {
+        setStage('retry-repair')
+      }
+      return
+    }
+
+    if (stage === 'retry-repair') {
+      void handleRepair('complete')
+      return
+    }
+
+    handleOpenChange(false)
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={handleOpenChange}
+      dismissible={!hostHotspotRecovery.isPending}
+    >
+      <DialogContent
+        size="lg"
+        showCloseButton={!hostHotspotRecovery.isPending}
+        testId={TID.hostHotspotRepair.dialog}
+      >
+        <DialogHeader className="mb-(--space-3) pr-(--space-10)">
+          <DialogTitle className="flex items-center gap-(--space-2)">
+            <Wrench aria-hidden="true" className="h-5 w-5 text-warning" />
+            Repair host hotspot
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-(--space-4)" aria-live="polite">
+          <ol className="steps steps-horizontal w-full" aria-label="Host hotspot repair steps">
+            {HOST_HOTSPOT_REPAIR_STEPS.map((step) => {
+              const state = getHostHotspotRepairStepState(stage, step.id)
+
+              return (
+                <li
+                  key={step.id}
+                  className={cn('step text-xs font-semibold', stepToneClasses[state])}
+                  aria-current={state === 'active' ? 'step' : undefined}
+                  data-state={state}
+                  data-testid={TID.hostHotspotRepair.step(step.id)}
+                >
+                  <span className="max-w-28 leading-tight">{step.label}</span>
+                </li>
+              )
+            })}
+          </ol>
+
+          <section
+            className={cn(
+              'rounded-box border-l-4 p-(--space-4) shadow-[var(--shadow-1)]',
+              instructionSurfaceClasses[stage]
+            )}
+          >
+            {renderInstruction(stage, {
+              antennaSecondsRemaining,
+              antennaWaitStarted,
+              queuedMessage,
+            })}
+          </section>
+        </div>
+
+        <DialogFooter className="items-center gap-(--space-2)">
+          {stage !== 'complete' && (
+            <button
+              type="button"
+              className="btn btn-ghost"
+              onClick={() => handleOpenChange(false)}
+              disabled={hostHotspotRecovery.isPending}
+              data-testid={TID.hostHotspotRepair.close}
+            >
+              Cancel
+            </button>
+          )}
+          <button
+            type="button"
+            className={cn(
+              'btn',
+              stage === 'reset-antenna'
+                ? 'btn-warning'
+                : stage === 'complete'
+                  ? 'btn-success'
+                  : 'btn-primary'
+            )}
+            onClick={handlePrimaryAction}
+            disabled={primaryDisabled}
+            data-testid={TID.hostHotspotRepair.primary}
+          >
+            {hostHotspotRecovery.isPending && <LoadingSpinner size="xs" className="mr-2" />}
+            {getPrimaryActionLabel(stage, {
+              antennaSecondsRemaining,
+              antennaWaitStarted,
+              isPending: hostHotspotRecovery.isPending,
+            })}
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function renderInstruction(
+  stage: HostHotspotRepairStage,
+  input: {
+    antennaSecondsRemaining: number
+    antennaWaitStarted: boolean
+    queuedMessage: string | null
+  }
+) {
+  if (stage === 'run-repair') {
+    return (
+      <div className="flex items-start gap-(--space-3)">
+        <InstructionIcon icon={Wrench} />
+        <div className="min-w-0">
+          <h4 className="font-bold">Run the repair first</h4>
+          <p className="mt-(--space-1) text-sm leading-relaxed">
+            Click Run repair. Sentinel will queue the host action that rebuilds and restarts the
+            managed hotspot.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  if (stage === 'reset-antenna') {
+    const body =
+      input.antennaWaitStarted && input.antennaSecondsRemaining === 0
+        ? 'Plug the Wi-Fi antenna back in, then continue.'
+        : input.antennaWaitStarted
+          ? 'Keep the Wi-Fi antenna disconnected until the timer finishes.'
+          : 'If the hotspot is still not available, disconnect the Wi-Fi antenna from the host laptop, then start the wait.'
+
+    return (
+      <div className="flex items-start gap-(--space-3)">
+        <InstructionIcon icon={Usb} />
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-(--space-2)">
+            <h4 className="font-bold">Reset the Wi-Fi antenna</h4>
+            {input.antennaWaitStarted && input.antennaSecondsRemaining > 0 && (
+              <AppBadge status="warning" size="sm">
+                {input.antennaSecondsRemaining}s
+              </AppBadge>
+            )}
+          </div>
+          <p className="mt-(--space-1) text-sm leading-relaxed">{body}</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (stage === 'retry-repair') {
+    return (
+      <div className="flex items-start gap-(--space-3)">
+        <InstructionIcon icon={RotateCcw} />
+        <div className="min-w-0">
+          <h4 className="font-bold">Run the repair again</h4>
+          <p className="mt-(--space-1) text-sm leading-relaxed">
+            With the antenna plugged back in, click Run repair again so the host can bind the
+            hotspot to the adapter.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex items-start gap-(--space-3)">
+      <InstructionIcon icon={CheckCircle2} />
+      <div className="min-w-0">
+        <h4 className="font-bold">Final repair queued</h4>
+        <p className="mt-(--space-1) text-sm leading-relaxed">
+          Give the host about 20 seconds. Sentinel will refresh network status automatically.
+        </p>
+        {input.queuedMessage && (
+          <p className="mt-(--space-2) font-mono text-xs leading-relaxed text-current opacity-75">
+            {input.queuedMessage}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function InstructionIcon({ icon: Icon }: { icon: LucideIcon }) {
+  return (
+    <span className="grid h-10 w-10 shrink-0 place-items-center rounded-box bg-base-100/80 shadow-[var(--shadow-1)]">
+      <Icon aria-hidden="true" className="h-5 w-5" />
+    </span>
+  )
+}
+
+function getPrimaryActionLabel(
+  stage: HostHotspotRepairStage,
+  input: {
+    antennaSecondsRemaining: number
+    antennaWaitStarted: boolean
+    isPending: boolean
+  }
+): string {
+  if (input.isPending) {
+    return stage === 'retry-repair' ? 'Queueing again...' : 'Queueing...'
+  }
+
+  if (stage === 'run-repair') {
+    return 'Run repair'
+  }
+
+  if (stage === 'reset-antenna') {
+    return getHostHotspotAntennaWaitLabel({
+      started: input.antennaWaitStarted,
+      secondsRemaining: input.antennaSecondsRemaining,
+    })
+  }
+
+  if (stage === 'retry-repair') {
+    return 'Run repair again'
+  }
+
+  return 'Close'
+}

--- a/apps/frontend-admin/src/components/settings/system-update-panel.tsx
+++ b/apps/frontend-admin/src/components/settings/system-update-panel.tsx
@@ -28,6 +28,7 @@ import {
 } from '@/components/ui/AppCard'
 import { AppAlert } from '@/components/ui/AppAlert'
 import { AppBadge } from '@/components/ui/AppBadge'
+import { HostHotspotRepairDialog } from '@/components/network/host-hotspot-repair-dialog'
 import {
   Dialog,
   DialogContent,
@@ -43,7 +44,6 @@ import {
   useSystemUpdateStatus,
   useSystemUpdateTrace,
 } from '@/hooks/use-system-update'
-import { useHostHotspotRecovery } from '@/hooks/use-network-settings'
 import { useSystemStatus } from '@/hooks/use-system-status'
 import { TID } from '@/lib/test-ids'
 import { AccountLevel, useAuthStore } from '@/store/auth-store'
@@ -183,6 +183,7 @@ export function SystemUpdatePanel() {
   const [isHydrated, setIsHydrated] = useState(false)
   const [confirmOpen, setConfirmOpen] = useState(false)
   const [releaseNotesOpen, setReleaseNotesOpen] = useState(false)
+  const [hotspotRepairOpen, setHotspotRepairOpen] = useState(false)
   const [tracePanelOpen, setTracePanelOpen] = useState(traceRequested)
   const [traceView, setTraceView] = useState<'summary' | 'raw'>('summary')
   const [traceSeverityFilter, setTraceSeverityFilter] = useState<SystemUpdateTraceSeverity | 'all'>(
@@ -208,7 +209,6 @@ export function SystemUpdatePanel() {
   })
   const startSystemUpdate = useStartSystemUpdate()
   const refreshSystemUpdate = useRefreshSystemUpdateStatus()
-  const hostHotspotRecovery = useHostHotspotRecovery()
 
   const status = systemUpdateQuery.data ?? null
   const currentJob = status?.currentJob ?? null
@@ -309,16 +309,6 @@ export function SystemUpdatePanel() {
       await systemUpdateQuery.refetch()
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Failed to start system update')
-    }
-  }
-
-  const handleHostHotspotRecovery = async () => {
-    try {
-      const result = await hostHotspotRecovery.mutateAsync()
-      toast.success(result.message)
-      await systemStatusQuery.refetch()
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to queue host hotspot recovery')
     }
   }
 
@@ -528,10 +518,9 @@ export function SystemUpdatePanel() {
                   <button
                     type="button"
                     className="btn btn-xs btn-warning"
-                    onClick={() => void handleHostHotspotRecovery()}
-                    disabled={hostHotspotRecovery.isPending}
+                    onClick={() => setHotspotRepairOpen(true)}
                   >
-                    {hostHotspotRecovery.isPending ? 'Queueing...' : 'Repair hotspot'}
+                    Repair hotspot
                   </button>
                 ) : null
               }
@@ -773,14 +762,10 @@ export function SystemUpdatePanel() {
                 <button
                   type="button"
                   className="btn btn-sm btn-primary shadow-sm"
-                  onClick={() => void handleHostHotspotRecovery()}
-                  disabled={!canStartUpdates || hostHotspotRecovery.isPending}
+                  onClick={() => setHotspotRepairOpen(true)}
+                  disabled={!canStartUpdates}
                 >
-                  {hostHotspotRecovery.isPending ? (
-                    <LoadingSpinner size="xs" className="mr-2" />
-                  ) : (
-                    <ShieldCheck className="mr-2 h-4 w-4" />
-                  )}
+                  <ShieldCheck className="mr-2 h-4 w-4" />
                   Repair hotspot
                 </button>
                 <button
@@ -1161,6 +1146,14 @@ export function SystemUpdatePanel() {
           )}
         </AppCardContent>
       </AppCard>
+
+      <HostHotspotRepairDialog
+        open={hotspotRepairOpen}
+        onOpenChange={setHotspotRepairOpen}
+        onRepairQueued={async () => {
+          await systemStatusQuery.refetch()
+        }}
+      />
 
       <Dialog
         open={confirmOpen}

--- a/apps/frontend-admin/src/lib/test-ids.ts
+++ b/apps/frontend-admin/src/lib/test-ids.ts
@@ -27,6 +27,12 @@ export const TID = {
     changePin: 'nav-change-pin',
     logout: 'nav-logout',
   },
+  hostHotspotRepair: {
+    dialog: 'host-hotspot-repair-dialog',
+    primary: 'host-hotspot-repair-primary',
+    close: 'host-hotspot-repair-close',
+    step: (step: string) => `host-hotspot-repair-step-${step}`,
+  },
   sidebar: {
     editBtn: (id: string) => `sidebar-edit-${id}`,
     saveBtn: 'sidebar-save-btn',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Fixes operational presence report logic so open sessions are counted only up to the time the report is generated.
- Changes Repair Host Hotspot from a one-click action into a guided popup that walks operators through the repair, antenna reset, and retry sequence.
- Bumps Sentinel workspace versions to `3.2.3` for this patch release.

## Why this change was needed

Open attendance sessions could be treated as overlapping future report windows, which could make operational reports look ahead beyond the current report time. Operators also needed clearer guidance for host hotspot recovery because the repair action may need a physical Wi-Fi antenna reset before a retry succeeds.

## What changed

### User-facing

- No normal attendance user workflow changes.

### Admin/operator-facing

- Repair Host Hotspot now opens a guided modal instead of immediately queueing the host repair.
- The modal first queues the existing repair action, then tells the operator to disconnect the Wi-Fi antenna, wait 3 seconds, plug it back in, and run repair again.
- Operational presence reports now avoid counting open sessions into future report days.

### Backend/API

- Added a bounded presence-session overlap helper for operational reports.
- Existing host hotspot recovery API behavior is reused without changing the endpoint contract.

### Database

- No database schema changes.
- No migration is required.

### Deployment/update

- Package versions are synchronized to `3.2.3`.
- No environment variable or port changes are required.

### Tests

- Added focused unit coverage for bounded open-session report overlap behavior.
- Added focused unit coverage for the host hotspot repair dialog step state and 3-second antenna wait behavior.

## User impact

Normal check-in and attendance users should not notice a workflow change.

## Operator impact

Admins get clearer recovery guidance when the host hotspot needs repair. Report reviewers should see more accurate presence calculations for members with currently open sessions.

## Upgrade or migration notes

No upgrade action required beyond the normal Sentinel update process. No database migration or configuration change is required.

## Risk and rollback notes

The main risk is UI workflow friction in the hotspot repair modal or an edge case in operational report date overlap handling. Verify by opening the Updates page hotspot warning, walking through the guided repair modal, and checking operational reports with open sessions.

Rollback is safe through the normal Sentinel rollback process. There are no data compatibility concerns.

## Testing performed

- `pnpm version:check`
- `pnpm --filter @sentinel/backend typecheck`
- `pnpm --filter frontend-admin typecheck`
- `pnpm --filter frontend-admin exec vitest run src/components/network/host-hotspot-repair-dialog.logic.test.ts`
- `pnpm --filter frontend-admin exec eslint . --quiet`
- Playwright visual smoke check at `1920x1080` on `/admin/updates` with the guided Repair Host Hotspot modal open

Attempted but blocked:

- `pnpm --filter @sentinel/backend exec vitest run src/services/operational-report-service.test.ts` could not run because the backend package does not expose a `vitest` executable.
- `pnpm exec vitest run apps/backend/src/services/operational-report-service.test.ts` was also blocked because the root workspace does not expose a `vitest` executable.

## Changelog candidates

- Fixed operational presence reports so open sessions are not counted into future report windows. This improves report accuracy for active attendance sessions.
- Added a guided Repair Host Hotspot popup. Operators now get the repair, antenna reset, and retry steps in the admin UI.
- Prepared Sentinel `v3.2.3` package metadata for release.
