### PR TITLE
Release v3.2.4

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/deploy/deb/assets/usr/lib/sentinel/sentinel-update-bridge
+++ b/deploy/deb/assets/usr/lib/sentinel/sentinel-update-bridge
@@ -18,7 +18,6 @@ if str(CURRENT_DIR) not in sys.path:
     sys.path.insert(0, str(CURRENT_DIR))
 
 from sentinel_update_common import (
-    APPLIANCE_ENV_PATH,
     CURRENT_JOB_PATH,
     JOB_ID_PATTERN,
     JOBS_DIR,
@@ -33,7 +32,6 @@ from sentinel_update_common import (
     is_terminal_job,
     is_terminal_status,
     load_appliance_state,
-    read_env_file,
     read_json_file,
     utc_now,
     write_json_file,
@@ -222,8 +220,8 @@ def persist_initial_job(payload: dict[str, Any]) -> dict[str, Any]:
             raise BridgeError("An update is already in progress.", status=409)
 
         state = load_appliance_state()
-        appliance_env = read_env_file(APPLIANCE_ENV_PATH)
-        current_version = appliance_env.get("SENTINEL_VERSION") or state.get("currentVersion")
+        # The bridge runs as an unprivileged service account; appliance.env stays root-only.
+        current_version = state.get("currentVersion")
         job = {
             "schemaVersion": 2,
             "operation": "update",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Fixes the host update bridge so it no longer reads root-only `/etc/sentinel/appliance.env` while running as the unprivileged bridge account.
- Keeps `appliance.env` protected for the root updater while allowing UI update requests to be accepted and handed off through systemd.
- Prepares the monorepo package versions for the `v3.2.4` patch release.

## Why this change was needed

Appliances on `v3.2.2`/`v3.2.3` can show `Unhandled bridge error: [Errno 13] Permission denied: '/etc/sentinel/appliance.env'` when an admin starts an update from the UI. The bridge service runs as `sentinel-updater-bridge`, but `appliance.env` is intentionally root-only. The bridge only needed the visible current version for initial job metadata, so it should read the appliance state JSON instead.

## What changed

### Admin/operator-facing

- UI-started update requests can get past bridge job creation after this version is installed.
- Existing affected appliances still need one manual root-updater invocation to install this fixed bridge because the currently installed bridge cannot self-update through the UI.

### Deployment/update

- `sentinel-update-bridge` now derives `currentVersion` from appliance state instead of reading `/etc/sentinel/appliance.env`.
- Workspace package versions are synchronized to `3.2.4`.

### Database

- No database migration is required.

### Tests

- `pnpm version:check`
- `python3 -m py_compile deploy/deb/assets/usr/lib/sentinel/sentinel_update_common.py deploy/deb/assets/usr/lib/sentinel/sentinel-update-bridge deploy/deb/assets/usr/lib/sentinel/sentinel-updater`
- `bash -n deploy/deb/build-deb.sh deploy/_common.sh deploy/update.sh deploy/install.sh`
- `deploy/deb/build-deb.sh --version 3.2.4 --output-dir <tmpdir>`
- `pnpm typecheck`
- `pnpm lint` passes with existing repo warnings and no errors

## User impact

Normal Sentinel users should not notice a change.

## Operator impact

Admins who hit the bridge permission toast will need to install `v3.2.4` manually through the root updater CLI once. After that, the UI update path should be able to use the bridge again.

## Upgrade or migration notes

Manual operator action required for appliances already affected by this bridge bug:

```bash
sudo /usr/lib/sentinel/sentinel-updater enqueue-manual-update --version v3.2.4 --requested-by "Local operator" --source cli
sudo /usr/lib/sentinel/sentinel-updater show-current-job
sudo tail -f /var/lib/sentinel/updater/update-trace.log
```

No database migration or configuration change is required.

## Risk and rollback notes

Risk is limited to update bridge job metadata creation. The root updater still owns privileged environment access and package installation. Roll back by installing the previous Sentinel package with the appliance updater or restoring from the pre-update backup if the update does not complete cleanly.

## Changelog candidates

- Fixed UI-started updates failing when the unprivileged host bridge tried to read root-only appliance environment settings.
