### PR TITLE
fix: correct operational reports and add exception visibility

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/repositories/operational-report-repository.ts
+++ b/apps/backend/src/repositories/operational-report-repository.ts
@@ -73,6 +73,73 @@ const visitorInclude = {
   },
 } satisfies Prisma.VisitorInclude
 
+const reportDutyMemberSelect = {
+  id: true,
+  rank: true,
+  firstName: true,
+  lastName: true,
+  displayName: true,
+} satisfies Prisma.MemberSelect
+
+const missedCheckoutInclude = {
+  member: {
+    select: reportDutyMemberSelect,
+  },
+  resolvedByAdmin: {
+    select: {
+      id: true,
+      displayName: true,
+      username: true,
+    },
+  },
+} satisfies Prisma.MissedCheckoutInclude
+
+const lockupExceptionStatusInclude = {
+  currentHolder: {
+    select: reportDutyMemberSelect,
+  },
+  securedByMember: {
+    select: reportDutyMemberSelect,
+  },
+  execution: {
+    select: {
+      id: true,
+      executedAt: true,
+      executedBy: true,
+      membersCheckedOut: true,
+      executedByMember: {
+        select: reportDutyMemberSelect,
+      },
+    },
+  },
+} satisfies Prisma.LockupStatusInclude
+
+const scheduledDutyInclude = {
+  dutyRole: {
+    select: {
+      code: true,
+    },
+  },
+  assignments: {
+    where: {
+      status: {
+        not: 'released',
+      },
+    },
+    select: {
+      memberId: true,
+      member: {
+        select: reportDutyMemberSelect,
+      },
+      dutyPosition: {
+        select: {
+          code: true,
+        },
+      },
+    },
+  },
+} satisfies Prisma.WeeklyScheduleInclude
+
 export type OperationalReportMemberRecord = Prisma.MemberGetPayload<{
   include: typeof reportMemberInclude
 }>
@@ -91,6 +158,25 @@ export type OperationalReportUnitEventRecord = Prisma.UnitEventGetPayload<{
 export type OperationalReportVisitorRecord = Prisma.VisitorGetPayload<{
   include: typeof visitorInclude
 }>
+
+export type OperationalReportMissedCheckoutRecord = Prisma.MissedCheckoutGetPayload<{
+  include: typeof missedCheckoutInclude
+}>
+
+export type OperationalReportLockupStatusRecord = Prisma.LockupStatusGetPayload<{
+  include: typeof lockupExceptionStatusInclude
+}>
+
+export type OperationalReportScheduledDutyRecord = Prisma.WeeklyScheduleGetPayload<{
+  include: typeof scheduledDutyInclude
+}>
+
+export type OperationalReportScheduledDutyRoleCode = 'DDS' | 'DUTY_WATCH'
+
+export interface OperationalReportScheduledDutyAssignmentRecord {
+  memberId: string
+  dutyRoleCode: OperationalReportScheduledDutyRoleCode
+}
 
 export interface OperationalReportMemberFilters {
   divisionId?: string
@@ -234,6 +320,108 @@ export class OperationalReportRepository {
         timestamp: true,
       },
       orderBy: [{ memberId: 'asc' }, { timestamp: 'asc' }],
+    })
+  }
+
+  async findScheduledDutyAssignmentsForMembers(
+    memberIds: string[],
+    weekStartDate: Date,
+    weekEndDate: Date
+  ): Promise<OperationalReportScheduledDutyAssignmentRecord[]> {
+    if (memberIds.length === 0) {
+      return []
+    }
+
+    const assignments = await this.prisma.scheduleAssignment.findMany({
+      where: {
+        memberId: {
+          in: memberIds,
+        },
+        status: {
+          not: 'released',
+        },
+        schedule: {
+          weekStartDate: {
+            gte: weekStartDate,
+            lte: weekEndDate,
+          },
+          dutyRole: {
+            code: {
+              in: ['DDS', 'DUTY_WATCH'],
+            },
+          },
+        },
+      },
+      select: {
+        memberId: true,
+        schedule: {
+          select: {
+            dutyRole: {
+              select: {
+                code: true,
+              },
+            },
+          },
+        },
+      },
+    })
+
+    return assignments.map((assignment) => ({
+      memberId: assignment.memberId,
+      dutyRoleCode: assignment.schedule.dutyRole.code as OperationalReportScheduledDutyRoleCode,
+    }))
+  }
+
+  async findMissedCheckouts(
+    startDate: Date,
+    endDate: Date
+  ): Promise<OperationalReportMissedCheckoutRecord[]> {
+    return this.prisma.missedCheckout.findMany({
+      where: {
+        date: {
+          gte: startDate,
+          lt: endDate,
+        },
+      },
+      include: missedCheckoutInclude,
+      orderBy: [{ date: 'desc' }, { forcedCheckoutAt: 'desc' }],
+    })
+  }
+
+  async findLockupStatuses(
+    startDate: Date,
+    endDate: Date
+  ): Promise<OperationalReportLockupStatusRecord[]> {
+    return this.prisma.lockupStatus.findMany({
+      where: {
+        date: {
+          gte: startDate,
+          lt: endDate,
+        },
+      },
+      include: lockupExceptionStatusInclude,
+      orderBy: [{ date: 'desc' }, { createdAt: 'desc' }],
+    })
+  }
+
+  async findScheduledDutySchedules(
+    weekStartDate: Date,
+    weekEndDate: Date
+  ): Promise<OperationalReportScheduledDutyRecord[]> {
+    return this.prisma.weeklySchedule.findMany({
+      where: {
+        weekStartDate: {
+          gte: weekStartDate,
+          lte: weekEndDate,
+        },
+        dutyRole: {
+          code: {
+            in: ['DDS', 'DUTY_WATCH'],
+          },
+        },
+      },
+      include: scheduledDutyInclude,
+      orderBy: [{ weekStartDate: 'asc' }],
     })
   }
 

--- a/apps/backend/src/routes/reports.ts
+++ b/apps/backend/src/routes/reports.ts
@@ -192,6 +192,34 @@ export const reportsRouter = s.router(reportContract, {
     }
   },
 
+  generateOperationalExceptions: async ({ body, req }) => {
+    const auth = requireAdminOrDeveloper(req)
+    if (auth) {
+      return auth
+    }
+
+    try {
+      return {
+        status: 200 as const,
+        body: await operationalReportService.generateOperationalExceptions(
+          body,
+          getReportActor(req)
+        ),
+      }
+    } catch (error) {
+      return {
+        status: 500 as const,
+        body: {
+          error: 'INTERNAL_ERROR',
+          message:
+            error instanceof Error
+              ? error.message
+              : 'Failed to generate operational exceptions report',
+        },
+      }
+    }
+  },
+
   /**
    * POST /api/reports/daily-checkin - Generate daily check-in summary
    */

--- a/apps/backend/src/services/operational-report-service.test.ts
+++ b/apps/backend/src/services/operational-report-service.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
+import type { ReportTagSummary } from '@sentinel/contracts'
 import {
+  filterReportMemberTagsForScheduledDuty,
   pairOperationalPresenceSessions,
   presenceSessionOverlapsRange,
   type PresenceSessionInternal,
@@ -126,5 +128,63 @@ describe('presenceSessionOverlapsRange', () => {
         asOf
       )
     ).toBe(false)
+  })
+})
+
+describe('filterReportMemberTagsForScheduledDuty', () => {
+  const baseTag = {
+    id: 'tag-other',
+    name: 'FTS',
+    chipVariant: 'solid',
+    chipColor: 'blue',
+    isPositional: false,
+    source: 'direct',
+  } satisfies ReportTagSummary
+  const ddsTag = {
+    id: 'tag-dds',
+    name: 'DDS',
+    chipVariant: 'solid',
+    chipColor: 'green',
+    isPositional: true,
+    source: 'direct',
+  } satisfies ReportTagSummary
+  const dutyWatchTag = {
+    id: 'tag-duty-watch',
+    name: 'Duty Watch',
+    chipVariant: 'solid',
+    chipColor: 'purple',
+    isPositional: true,
+    source: 'direct',
+  } satisfies ReportTagSummary
+
+  it('hides DDS and Duty Watch positional tags when the member is not scheduled', () => {
+    const filtered = filterReportMemberTagsForScheduledDuty(
+      [baseTag, ddsTag, dutyWatchTag],
+      new Set()
+    )
+
+    expect(filtered).toEqual([baseTag])
+  })
+
+  it('keeps each positional tag when the member is scheduled for that duty role', () => {
+    const filtered = filterReportMemberTagsForScheduledDuty(
+      [baseTag, ddsTag, dutyWatchTag],
+      new Set(['DDS', 'DUTY_WATCH'])
+    )
+
+    expect(filtered).toEqual([baseTag, ddsTag, dutyWatchTag])
+  })
+
+  it('does not hide non-positional tags with similar names', () => {
+    const qualificationTag = {
+      ...ddsTag,
+      id: 'tag-dds-qualified',
+      name: 'DDS Qualified',
+      isPositional: false,
+    } satisfies ReportTagSummary
+
+    expect(filterReportMemberTagsForScheduledDuty([qualificationTag], new Set())).toEqual([
+      qualificationTag,
+    ])
   })
 })

--- a/apps/backend/src/services/operational-report-service.ts
+++ b/apps/backend/src/services/operational-report-service.ts
@@ -9,8 +9,11 @@ import type {
   OperationalNightAudienceTarget,
   OperationalNightOccurrence,
   OperationalNightType,
+  OperationalExceptionsReportConfig,
+  OperationalExceptionsReportResponse,
   PresenceMarker,
   PresenceSession,
+  ReportDutyPerson,
   ReportMemberSummary,
   ReportTagSummary,
   TrainingNightMonthlyReportConfig,
@@ -26,11 +29,15 @@ import {
   ScheduleSettingsValueSchema,
 } from '@sentinel/contracts'
 import type { PrismaClientInstance } from '@sentinel/database'
-import { DEFAULT_TIMEZONE } from '../utils/operational-date.js'
+import { DEFAULT_TIMEZONE, getOperationalDayStartTime } from '../utils/operational-date.js'
 import {
   OperationalReportRepository,
   type OperationalReportCheckinRecord,
+  type OperationalReportLockupStatusRecord,
   type OperationalReportMemberRecord,
+  type OperationalReportMissedCheckoutRecord,
+  type OperationalReportScheduledDutyRoleCode,
+  type OperationalReportScheduledDutyRecord,
   type OperationalReportUnitEventRecord,
   type OperationalReportVisitorRecord,
 } from '../repositories/operational-report-repository.js'
@@ -87,6 +94,43 @@ interface PresenceStats {
   lastOut: string | null
   sessionCount: number
   note: string | null
+}
+
+type ScheduledDutyRolesByMember = Map<string, Set<OperationalReportScheduledDutyRoleCode>>
+
+interface LockupCheckedOutMember {
+  id: string
+  name: string
+}
+
+export function getScheduledDutyTagRole(
+  tag: ReportTagSummary
+): OperationalReportScheduledDutyRoleCode | null {
+  if (!tag.isPositional) {
+    return null
+  }
+
+  const normalizedName = tag.name.trim().toLowerCase().replace(/[_-]+/g, ' ')
+
+  if (normalizedName === 'dds') {
+    return 'DDS'
+  }
+
+  if (normalizedName === 'duty watch') {
+    return 'DUTY_WATCH'
+  }
+
+  return null
+}
+
+export function filterReportMemberTagsForScheduledDuty(
+  tags: ReportTagSummary[],
+  scheduledRoleCodes: ReadonlySet<OperationalReportScheduledDutyRoleCode>
+): ReportTagSummary[] {
+  return tags.filter((tag) => {
+    const requiredRoleCode = getScheduledDutyTagRole(tag)
+    return requiredRoleCode === null || scheduledRoleCodes.has(requiredRoleCode)
+  })
 }
 
 export function presenceSessionOverlapsRange(
@@ -212,6 +256,7 @@ export class OperationalReportService {
           tagId: scope.tagId,
         })
     const sessionsByMember = await this.getSessionsByMember(members, range, warnings)
+    const scheduledDutyRolesByMember = await this.getScheduledDutyRolesByMember(members, range)
 
     const rows = members
       .map((member) => {
@@ -227,7 +272,7 @@ export class OperationalReportService {
         const stats = this.getPresenceStats(overlappingSessions, range.start, range.end)
 
         return {
-          member: this.toMemberSummary(member),
+          member: this.toMemberSummary(member, scheduledDutyRolesByMember.get(member.id)),
           firstIn: stats.firstIn,
           lastOut: stats.lastOut,
           sessionCount: stats.sessionCount,
@@ -277,6 +322,7 @@ export class OperationalReportService {
           tagId: scope.tagId,
         })
     const sessionsByMember = await this.getSessionsByMember(members, range, warnings)
+    const scheduledDutyRolesByMember = await this.getScheduledDutyRolesByMember(members, range)
     const keyNights = await this.getKeyNights(range, ['training', 'administrative'], warnings)
     const days = this.getDatesInRange(range).map((date) => ({
       date,
@@ -299,7 +345,7 @@ export class OperationalReportService {
       )
 
       return {
-        member: this.toMemberSummary(member),
+        member: this.toMemberSummary(member, scheduledDutyRolesByMember.get(member.id)),
         days: dayMarkers,
         trainingNightPresent: this.getCategoryPresence('training', keyNights, keyNightMarkers),
         adminNightPresent: this.getCategoryPresence('administrative', keyNights, keyNightMarkers),
@@ -346,6 +392,7 @@ export class OperationalReportService {
           tagId: scope.tagId,
         })
     const sessionsByMember = await this.getSessionsByMember(members, range, warnings)
+    const scheduledDutyRolesByMember = await this.getScheduledDutyRolesByMember(members, range)
     const keyNights = await this.getKeyNights(range, ['training', 'administrative'], warnings)
     const days = this.getDatesInRange(range).map((date) => ({
       date,
@@ -368,7 +415,7 @@ export class OperationalReportService {
       )
 
       return {
-        member: this.toMemberSummary(member),
+        member: this.toMemberSummary(member, scheduledDutyRolesByMember.get(member.id)),
         days: dayMarkers,
         keyNights: keyNightMarkers,
         totalDaysPresent: dayMarkers.filter((marker) => marker.present).length,
@@ -420,6 +467,7 @@ export class OperationalReportService {
       ? await this.repository.findActiveMembers({ divisionId: config.divisionId })
       : []
     const sessionsByMember = await this.getSessionsByMember(members, range, warnings)
+    const scheduledDutyRolesByMember = await this.getScheduledDutyRolesByMember(members, range)
     const keyNights = await this.getKeyNights(range, ['training'], warnings)
     const trainingNights = keyNights.filter((night) => night.category === 'training')
 
@@ -438,7 +486,7 @@ export class OperationalReportService {
       const possible = nightMarkers.filter((marker) => marker.requirement === 'required').length
 
       return {
-        member: this.toMemberSummary(member),
+        member: this.toMemberSummary(member, scheduledDutyRolesByMember.get(member.id)),
         nights: nightMarkers,
         attended,
         possible,
@@ -525,13 +573,134 @@ export class OperationalReportService {
     }
   }
 
+  async generateOperationalExceptions(
+    config: OperationalExceptionsReportConfig,
+    actor: OperationalReportActor
+  ): Promise<OperationalExceptionsReportResponse> {
+    const range = this.getCustomRange(config.startDate, config.endDate)
+    const warnings = new Set<string>()
+    const scheduleWeekRange = this.getScheduleWeekRange(range)
+    const [missedCheckouts, lockupStatuses, scheduledDuties] = await Promise.all([
+      this.repository.findMissedCheckouts(range.start, range.end),
+      this.repository.findLockupStatuses(range.start, range.end),
+      this.repository.findScheduledDutySchedules(
+        scheduleWeekRange.firstWeekStart,
+        scheduleWeekRange.lastWeekStart
+      ),
+    ])
+    const scheduledDutiesByWeek = this.indexScheduledDutiesByWeek(scheduledDuties)
+    const systemForcedCheckoutCountByDate = new Map<string, number>()
+
+    for (const missedCheckout of missedCheckouts) {
+      if (missedCheckout.resolvedBy !== 'daily_reset') {
+        continue
+      }
+
+      const date = this.toLocalDate(missedCheckout.date)
+      systemForcedCheckoutCountByDate.set(
+        date,
+        (systemForcedCheckoutCountByDate.get(date) ?? 0) + 1
+      )
+    }
+
+    const forcedCheckouts = [
+      ...missedCheckouts.map((missedCheckout) => this.toForcedCheckoutRow(missedCheckout)),
+      ...lockupStatuses.flatMap((status) => this.toLockupExecutionForcedCheckoutRows(status)),
+    ].sort(
+      (left, right) =>
+        right.forcedCheckoutAt.localeCompare(left.forcedCheckoutAt) ||
+        right.operationalDate.localeCompare(left.operationalDate)
+    )
+
+    const lockupExceptions = lockupStatuses
+      .map((status) => {
+        const operationalDate = this.toLocalDate(status.date)
+        const systemForcedCheckoutCount = systemForcedCheckoutCountByDate.get(operationalDate) ?? 0
+        const notes: string[] = []
+
+        if (status.buildingStatus !== 'secured') {
+          notes.push(`Building status remained ${status.buildingStatus}`)
+        }
+
+        if (!status.execution) {
+          notes.push('No Execute Lockup record')
+        }
+
+        if (systemForcedCheckoutCount > 0) {
+          notes.push(
+            `System forced ${systemForcedCheckoutCount} member${
+              systemForcedCheckoutCount === 1 ? '' : 's'
+            } out during daily reset`
+          )
+        }
+
+        if (notes.length === 0) {
+          return null
+        }
+
+        const scheduledDuty = scheduledDutiesByWeek.get(this.getWeekKeyForDate(operationalDate))
+        const expectedDds = scheduledDuty?.dds ?? null
+        const expectedSwk = scheduledDuty?.swk ?? null
+        const expectedLockupHolder = status.currentHolder
+          ? this.toDutyPerson(status.currentHolder)
+          : status.securedByMember
+            ? this.toDutyPerson(status.securedByMember)
+            : (expectedSwk ?? expectedDds)
+
+        return {
+          id: status.id,
+          operationalDate,
+          buildingStatus: status.buildingStatus,
+          securedAt: status.securedAt?.toISOString() ?? null,
+          expectedDds,
+          expectedSwk,
+          expectedLockupHolder,
+          systemForcedCheckoutCount,
+          lockupExecutionId: status.execution?.id ?? null,
+          notes,
+        }
+      })
+      .filter((row): row is NonNullable<typeof row> => row !== null)
+
+    if (forcedCheckouts.length === 0 && lockupExceptions.length === 0) {
+      warnings.add('No forced checkouts or lockup exceptions were found for the selected range.')
+    }
+
+    return {
+      ...this.getEnvelopeBase(
+        'operational_exceptions',
+        'Operational Exceptions Report',
+        actor,
+        range,
+        {
+          scopeLabel: 'Forced checkouts and lockup exceptions',
+        }
+      ),
+      warnings: Array.from(warnings),
+      data: {
+        summary: {
+          forcedCheckoutCount: forcedCheckouts.length,
+          systemForcedCheckoutCount: forcedCheckouts.filter(
+            (row) => row.resolvedBy === 'daily_reset'
+          ).length,
+          adminForcedCheckoutCount: forcedCheckouts.filter((row) => row.resolvedBy === 'admin')
+            .length,
+          lockupExceptionCount: lockupExceptions.length,
+        },
+        forcedCheckouts,
+        lockupExceptions,
+      },
+    }
+  }
+
   private getEnvelopeBase<
     TReportType extends
       | 'daily_presence'
       | 'weekly_presence'
       | 'monthly_presence'
       | 'training_night_monthly'
-      | 'visitor_activity',
+      | 'visitor_activity'
+      | 'operational_exceptions',
   >(
     reportType: TReportType,
     title: string,
@@ -1088,7 +1257,10 @@ export class OperationalReportService {
     )
   }
 
-  private toMemberSummary(member: OperationalReportMemberRecord): ReportMemberSummary {
+  private toMemberSummary(
+    member: OperationalReportMemberRecord,
+    scheduledRoleCodes: ReadonlySet<OperationalReportScheduledDutyRoleCode> = new Set()
+  ): ReportMemberSummary {
     const directTags = member.memberTags.map<ReportTagSummary>((memberTag) => ({
       id: memberTag.tag.id,
       name: memberTag.tag.name,
@@ -1108,7 +1280,10 @@ export class OperationalReportService {
         isPositional: tag.isPositional,
         source: 'qualification',
       }))
-    const tags = this.dedupeTags([...directTags, ...qualificationTags])
+    const tags = filterReportMemberTagsForScheduledDuty(
+      this.dedupeTags([...directTags, ...qualificationTags]),
+      scheduledRoleCodes
+    )
 
     return {
       id: member.id,
@@ -1190,6 +1365,136 @@ export class OperationalReportService {
     }
   }
 
+  private toForcedCheckoutRow(missedCheckout: OperationalReportMissedCheckoutRecord) {
+    return {
+      id: missedCheckout.id,
+      operationalDate: this.toLocalDate(missedCheckout.date),
+      member: this.toDutyPerson(missedCheckout.member),
+      originalCheckinAt: missedCheckout.originalCheckinAt.toISOString(),
+      forcedCheckoutAt: missedCheckout.forcedCheckoutAt.toISOString(),
+      resolvedBy: missedCheckout.resolvedBy,
+      resolverLabel: this.getForcedCheckoutResolverLabel(missedCheckout),
+      notes: missedCheckout.notes,
+    }
+  }
+
+  private toLockupExecutionForcedCheckoutRows(status: OperationalReportLockupStatusRecord) {
+    if (!status.execution) {
+      return []
+    }
+
+    const members = this.getLockupCheckedOutMembers(status.execution.membersCheckedOut)
+    const executorName = this.formatDutyPerson(status.execution.executedByMember)
+
+    return members
+      .filter((member) => member.id !== status.execution?.executedBy)
+      .map((member) => ({
+        id: `${status.execution?.id ?? status.id}-${member.id}`,
+        operationalDate: this.toLocalDate(status.date),
+        member: {
+          id: member.id,
+          displayName: member.name,
+          rank: '',
+        },
+        originalCheckinAt:
+          status.execution?.executedAt.toISOString() ?? status.createdAt.toISOString(),
+        forcedCheckoutAt:
+          status.execution?.executedAt.toISOString() ?? status.createdAt.toISOString(),
+        resolvedBy: 'lockup_execution',
+        resolverLabel: `Execute Lockup by ${executorName}`,
+        notes: 'Checked out during Execute Lockup',
+      }))
+  }
+
+  private getForcedCheckoutResolverLabel(
+    missedCheckout: OperationalReportMissedCheckoutRecord
+  ): string {
+    if (missedCheckout.resolvedBy === 'daily_reset') {
+      return 'System daily reset'
+    }
+
+    if (missedCheckout.resolvedBy === 'admin') {
+      return missedCheckout.resolvedByAdmin?.displayName ?? 'Admin manual checkout'
+    }
+
+    if (missedCheckout.resolvedBy === 'lockup_sequence') {
+      return 'Execute Lockup'
+    }
+
+    return missedCheckout.resolvedBy
+  }
+
+  private getLockupCheckedOutMembers(value: unknown): LockupCheckedOutMember[] {
+    if (!Array.isArray(value)) {
+      return []
+    }
+
+    return value.filter((item): item is LockupCheckedOutMember => {
+      if (typeof item !== 'object' || item === null) {
+        return false
+      }
+
+      const candidate = item as { id?: unknown; name?: unknown }
+      return typeof candidate.id === 'string' && typeof candidate.name === 'string'
+    })
+  }
+
+  private indexScheduledDutiesByWeek(schedules: OperationalReportScheduledDutyRecord[]) {
+    const result = new Map<string, { dds: ReportDutyPerson | null; swk: ReportDutyPerson | null }>()
+
+    for (const schedule of schedules) {
+      const weekKey = this.toLocalDate(schedule.weekStartDate)
+      const current = result.get(weekKey) ?? { dds: null, swk: null }
+
+      if (schedule.dutyRole.code === 'DDS') {
+        const assignment = schedule.assignments[0]
+        current.dds = assignment ? this.toDutyPerson(assignment.member) : current.dds
+      }
+
+      if (schedule.dutyRole.code === 'DUTY_WATCH') {
+        const swkAssignment = schedule.assignments.find(
+          (assignment) => assignment.dutyPosition?.code === 'SWK'
+        )
+        current.swk = swkAssignment ? this.toDutyPerson(swkAssignment.member) : current.swk
+      }
+
+      result.set(weekKey, current)
+    }
+
+    return result
+  }
+
+  private getWeekKeyForDate(date: string): string {
+    return DateTime.fromISO(date, { zone: DEFAULT_TIMEZONE }).startOf('week').toISODate() ?? date
+  }
+
+  private toLocalDate(date: Date): string {
+    return DateTime.fromJSDate(date, { zone: DEFAULT_TIMEZONE }).toISODate() ?? date.toISOString()
+  }
+
+  private toDutyPerson(member: {
+    id: string
+    rank: string
+    firstName: string
+    lastName: string
+    displayName: string | null
+  }): ReportDutyPerson {
+    return {
+      id: member.id,
+      rank: member.rank,
+      displayName: this.formatDutyPerson(member),
+    }
+  }
+
+  private formatDutyPerson(member: {
+    rank: string
+    firstName: string
+    lastName: string
+    displayName: string | null
+  }): string {
+    return member.displayName ?? [member.rank, member.firstName, member.lastName].join(' ')
+  }
+
   private sessionOverlaps(session: PresenceSessionInternal, start: Date, end: Date): boolean {
     return presenceSessionOverlapsRange(session, start, end)
   }
@@ -1236,6 +1541,31 @@ export class OperationalReportService {
     return result.sort((left, right) => left.name.localeCompare(right.name))
   }
 
+  private async getScheduledDutyRolesByMember(
+    members: OperationalReportMemberRecord[],
+    range: DateRange
+  ): Promise<ScheduledDutyRolesByMember> {
+    if (members.length === 0) {
+      return new Map()
+    }
+
+    const { firstWeekStart, lastWeekStart } = this.getScheduleWeekRange(range)
+    const assignments = await this.repository.findScheduledDutyAssignmentsForMembers(
+      members.map((member) => member.id),
+      firstWeekStart,
+      lastWeekStart
+    )
+    const scheduledRolesByMember: ScheduledDutyRolesByMember = new Map()
+
+    for (const assignment of assignments) {
+      const roleCodes = scheduledRolesByMember.get(assignment.memberId) ?? new Set()
+      roleCodes.add(assignment.dutyRoleCode)
+      scheduledRolesByMember.set(assignment.memberId, roleCodes)
+    }
+
+    return scheduledRolesByMember
+  }
+
   private countByLabel(labels: string[]) {
     const counts = new Map<string, number>()
     for (const label of labels) {
@@ -1261,7 +1591,13 @@ export class OperationalReportService {
   }
 
   private getDayRange(date: string): DateRange {
-    const start = DateTime.fromISO(date, { zone: DEFAULT_TIMEZONE }).startOf('day')
+    const dayStart = getOperationalDayStartTime()
+    const start = DateTime.fromISO(date, { zone: DEFAULT_TIMEZONE }).set({
+      hour: dayStart.hour,
+      minute: dayStart.minute,
+      second: 0,
+      millisecond: 0,
+    })
     const end = start.plus({ days: 1 })
     return {
       start: start.toJSDate(),
@@ -1297,6 +1633,24 @@ export class OperationalReportService {
       startDate: start.toISODate() ?? `${month}-01`,
       endDate: endInclusive.toISODate() ?? `${month}-01`,
       label: start.toFormat('LLLL yyyy'),
+    }
+  }
+
+  private getScheduleWeekRange(range: DateRange): {
+    firstWeekStart: Date
+    lastWeekStart: Date
+  } {
+    const firstWeekStart = DateTime.fromJSDate(range.start, { zone: DEFAULT_TIMEZONE })
+      .startOf('week')
+      .startOf('day')
+    const lastReportDay = DateTime.fromJSDate(range.end, { zone: DEFAULT_TIMEZONE })
+      .minus({ days: 1 })
+      .startOf('day')
+    const lastWeekStart = lastReportDay.startOf('week').startOf('day')
+
+    return {
+      firstWeekStart: firstWeekStart.toJSDate(),
+      lastWeekStart: lastWeekStart.toJSDate(),
     }
   }
 

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/components/admin/reports/AdminReportsPage.tsx
+++ b/apps/frontend-admin/src/components/admin/reports/AdminReportsPage.tsx
@@ -104,6 +104,14 @@ function buildRunInput(filters: ReportFilters): RunAdminReportInput {
           organization: optionalString(filters.organization),
         },
       }
+    case 'operational_exceptions':
+      return {
+        reportType: 'operational_exceptions',
+        body: {
+          startDate: filters.startDate,
+          endDate: filters.endDate,
+        },
+      }
   }
 }
 

--- a/apps/frontend-admin/src/components/admin/reports/report-definitions.ts
+++ b/apps/frontend-admin/src/components/admin/reports/report-definitions.ts
@@ -6,6 +6,7 @@ export type AdminReportType =
   | 'monthly_presence'
   | 'training_night_monthly'
   | 'visitor_activity'
+  | 'operational_exceptions'
 
 export type ReportScopeType = 'everyone' | 'department' | 'tag' | 'fts' | 'geo'
 
@@ -54,12 +55,14 @@ export interface ReportDefinition {
     | 'generateMonthlyPresence'
     | 'generateTrainingNightMonthly'
     | 'generateVisitorActivity'
+    | 'generateOperationalExceptions'
   previewComponent:
     | 'DailyPresenceReport'
     | 'WeeklyPresenceReport'
     | 'MonthlyPresenceReport'
     | 'TrainingNightMonthlyReport'
     | 'VisitorActivityReport'
+    | 'OperationalExceptionsReport'
 }
 
 function today(): Date {
@@ -160,6 +163,16 @@ export const REPORT_DEFINITIONS = [
     ],
     runMutation: 'generateVisitorActivity',
     previewComponent: 'VisitorActivityReport',
+  },
+  {
+    reportType: 'operational_exceptions',
+    label: 'Operational Exceptions',
+    description: 'Forced checkouts and lockup exceptions that need DDS or Duty Watch review.',
+    defaultFilters: () => getBaseReportFilters('operational_exceptions'),
+    requiredFilters: ['startDate', 'endDate'],
+    visibleFilters: ['startDate', 'endDate'],
+    runMutation: 'generateOperationalExceptions',
+    previewComponent: 'OperationalExceptionsReport',
   },
 ] as const satisfies readonly ReportDefinition[]
 

--- a/apps/frontend-admin/src/components/admin/reports/report-preview.tsx
+++ b/apps/frontend-admin/src/components/admin/reports/report-preview.tsx
@@ -3,6 +3,7 @@
 import type {
   DailyPresenceReportResponse,
   MonthlyPresenceReportResponse,
+  OperationalExceptionsReportResponse,
   ReportMemberSummary,
   ReportTagSummary,
   TrainingNightMonthlyReportResponse,
@@ -111,6 +112,9 @@ export function ReportPreview({ report, isLoading, errorMessage }: ReportPreview
         <TrainingNightMonthlyReport report={report} />
       )}
       {report.reportType === 'visitor_activity' && <VisitorActivityReport report={report} />}
+      {report.reportType === 'operational_exceptions' && (
+        <OperationalExceptionsReport report={report} />
+      )}
     </ReportDocumentFrame>
   )
 }
@@ -127,7 +131,8 @@ function ReportDocumentFrame({
   const isMatrixReport =
     report.reportType === 'weekly_presence' ||
     report.reportType === 'monthly_presence' ||
-    report.reportType === 'training_night_monthly'
+    report.reportType === 'training_night_monthly' ||
+    report.reportType === 'operational_exceptions'
 
   return (
     <section
@@ -516,6 +521,106 @@ function VisitorActivityReport({ report }: { report: VisitorActivityReportRespon
               ))}
             </tbody>
           </table>
+        </div>
+      )}
+    </>
+  )
+}
+
+function OperationalExceptionsReport({ report }: { report: OperationalExceptionsReportResponse }) {
+  const { summary, forcedCheckouts, lockupExceptions } = report.data
+
+  return (
+    <>
+      <SummaryGrid
+        items={[
+          { label: 'Forced out', value: summary.forcedCheckoutCount },
+          { label: 'System', value: summary.systemForcedCheckoutCount },
+          { label: 'Admin', value: summary.adminForcedCheckoutCount },
+          { label: 'Lockup issues', value: summary.lockupExceptionCount },
+        ]}
+      />
+
+      {forcedCheckouts.length === 0 && lockupExceptions.length === 0 ? (
+        <ReportEmptyMessage
+          title="No operational exceptions"
+          detail="No forced checkouts or lockup exceptions matched the selected range."
+        />
+      ) : (
+        <div className="space-y-(--space-5)">
+          <section>
+            <h3 className="mb-(--space-2) text-sm font-semibold uppercase tracking-wide text-base-content/60">
+              Forced checkouts
+            </h3>
+            {forcedCheckouts.length === 0 ? (
+              <p className="text-sm text-base-content/55">No forced checkouts.</p>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="table table-sm reports-table">
+                  <thead>
+                    <tr>
+                      <th>Date</th>
+                      <th>Member</th>
+                      <th>Original in</th>
+                      <th>Forced out</th>
+                      <th>Resolved by</th>
+                      <th>Notes</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {forcedCheckouts.map((row) => (
+                      <tr key={row.id}>
+                        <td className="font-mono">{row.operationalDate}</td>
+                        <td className="font-semibold">{row.member.displayName}</td>
+                        <td className="font-mono">{formatReportDateTime(row.originalCheckinAt)}</td>
+                        <td className="font-mono">{formatReportDateTime(row.forcedCheckoutAt)}</td>
+                        <td>{row.resolverLabel}</td>
+                        <td>{row.notes ?? '—'}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+
+          <section>
+            <h3 className="mb-(--space-2) text-sm font-semibold uppercase tracking-wide text-base-content/60">
+              Lockup exceptions
+            </h3>
+            {lockupExceptions.length === 0 ? (
+              <p className="text-sm text-base-content/55">No lockup exceptions.</p>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="table table-sm reports-table">
+                  <thead>
+                    <tr>
+                      <th>Date</th>
+                      <th>Status</th>
+                      <th>Expected DDS</th>
+                      <th>Expected SWK</th>
+                      <th>Lockup holder</th>
+                      <th>System outs</th>
+                      <th>Notes</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {lockupExceptions.map((row) => (
+                      <tr key={row.id}>
+                        <td className="font-mono">{row.operationalDate}</td>
+                        <td>{row.buildingStatus}</td>
+                        <td>{row.expectedDds?.displayName ?? '—'}</td>
+                        <td>{row.expectedSwk?.displayName ?? '—'}</td>
+                        <td>{row.expectedLockupHolder?.displayName ?? '—'}</td>
+                        <td className="font-mono">{row.systemForcedCheckoutCount}</td>
+                        <td>{row.notes.join('; ')}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
         </div>
       )}
     </>

--- a/apps/frontend-admin/src/components/layout/app-navbar.tsx
+++ b/apps/frontend-admin/src/components/layout/app-navbar.tsx
@@ -208,8 +208,12 @@ export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
         <HelpButton />
         <div className="dropdown dropdown-end dropdown-hover">
           <div tabIndex={0} role="button" data-testid={TID.nav.backendStatus}>
-            <AppBadge status={badgeStatus} size="md" className="badge-outline backend-status-badge">
-              <span className={cn('status', dot)} />
+            <AppBadge
+              status={badgeStatus}
+              size="lg"
+              className="badge-outline backend-status-badge min-h-9 gap-(--space-2) px-(--space-3) text-sm font-semibold"
+            >
+              <span className={cn('status status-md', dot)} />
               <span className="hidden sm:inline">{label}</span>
             </AppBadge>
           </div>

--- a/apps/frontend-admin/src/hooks/use-admin-reports.ts
+++ b/apps/frontend-admin/src/hooks/use-admin-reports.ts
@@ -6,6 +6,8 @@ import type {
   DailyPresenceReportResponse,
   MonthlyPresenceReportConfig,
   MonthlyPresenceReportResponse,
+  OperationalExceptionsReportConfig,
+  OperationalExceptionsReportResponse,
   TrainingNightMonthlyReportConfig,
   TrainingNightMonthlyReportResponse,
   VisitorActivityReportConfig,
@@ -21,6 +23,7 @@ export type AdminReportResponse =
   | MonthlyPresenceReportResponse
   | TrainingNightMonthlyReportResponse
   | VisitorActivityReportResponse
+  | OperationalExceptionsReportResponse
 
 export type RunAdminReportInput =
   | {
@@ -42,6 +45,10 @@ export type RunAdminReportInput =
   | {
       reportType: 'visitor_activity'
       body: VisitorActivityReportConfig
+    }
+  | {
+      reportType: 'operational_exceptions'
+      body: OperationalExceptionsReportConfig
     }
 
 function getApiErrorMessage(body: unknown, fallback: string): string {
@@ -97,6 +104,17 @@ export function useAdminReportRunner() {
           const response = await apiClient.reports.generateVisitorActivity({ body: input.body })
           if (response.status !== 200) {
             throw new Error(getApiErrorMessage(response.body, 'Failed to run visitor report'))
+          }
+          return response.body
+        }
+        case 'operational_exceptions': {
+          const response = await apiClient.reports.generateOperationalExceptions({
+            body: input.body,
+          })
+          if (response.status !== 200) {
+            throw new Error(
+              getApiErrorMessage(response.body, 'Failed to run operational exceptions report')
+            )
           }
           return response.body
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/contracts/src/contracts/report.contract.ts
+++ b/packages/contracts/src/contracts/report.contract.ts
@@ -15,11 +15,13 @@ import {
   MonthlyPresenceReportConfigSchema,
   TrainingNightMonthlyReportConfigSchema,
   VisitorActivityReportConfigSchema,
+  OperationalExceptionsReportConfigSchema,
   ReportErrorResponseSchema,
 } from '../schemas/report.schema.js'
 import type {
   DailyPresenceReportResponse,
   MonthlyPresenceReportResponse,
+  OperationalExceptionsReportResponse,
   TrainingNightMonthlyReportResponse,
   VisitorActivityReportResponse,
   WeeklyPresenceReportResponse,
@@ -127,6 +129,24 @@ export const reportContract = c.router(
       summary: 'Generate visitor activity report',
       description:
         'Generate an operational visitor report using existing visitor visit type, purpose/reason, event association, host, organization, and date range data.',
+    },
+
+    generateOperationalExceptions: {
+      method: 'POST',
+      path: '/api/reports/operations/exceptions',
+      body: OperationalExceptionsReportConfigSchema,
+      responses: {
+        200: c.type<OperationalExceptionsReportResponse>(),
+        400: ReportErrorResponseSchema,
+        401: ReportErrorResponseSchema,
+        403: ReportErrorResponseSchema,
+        404: ReportErrorResponseSchema,
+        409: ReportErrorResponseSchema,
+        500: ReportErrorResponseSchema,
+      },
+      summary: 'Generate operational exceptions report',
+      description:
+        'Generate a report of forced member checkouts and lockup days where the building was not properly secured before daily reset.',
     },
 
     /**

--- a/packages/contracts/src/schemas/report.schema.ts
+++ b/packages/contracts/src/schemas/report.schema.ts
@@ -33,6 +33,7 @@ export const OperationalReportTypeEnum = v.picklist([
   'monthly_presence',
   'training_night_monthly',
   'visitor_activity',
+  'operational_exceptions',
 ])
 
 export const OperationalReportScopeEnum = v.picklist([
@@ -209,6 +210,21 @@ export const VisitorActivityReportConfigSchema = v.pipe(
 )
 
 export type VisitorActivityReportConfig = v.InferOutput<typeof VisitorActivityReportConfigSchema>
+
+export const OperationalExceptionsReportConfigSchema = v.pipe(
+  v.object({
+    startDate: LocalDateSchema,
+    endDate: LocalDateSchema,
+  }),
+  v.check(
+    (data) => new Date(data.startDate) <= new Date(data.endDate),
+    'Start date must be before or equal to end date'
+  )
+)
+
+export type OperationalExceptionsReportConfig = v.InferOutput<
+  typeof OperationalExceptionsReportConfigSchema
+>
 
 // ============================================================================
 // Response Component Schemas
@@ -585,6 +601,67 @@ export const VisitorActivityReportResponseSchema = v.object({
 
 export type VisitorActivityReportResponse = v.InferOutput<
   typeof VisitorActivityReportResponseSchema
+>
+
+const ReportDutyPersonSchema = v.object({
+  id: v.string(),
+  displayName: v.string(),
+  rank: v.string(),
+})
+
+export type ReportDutyPerson = v.InferOutput<typeof ReportDutyPersonSchema>
+
+export const ForcedCheckoutRowSchema = v.object({
+  id: v.string(),
+  operationalDate: v.string(),
+  member: ReportDutyPersonSchema,
+  originalCheckinAt: v.string(),
+  forcedCheckoutAt: v.string(),
+  resolvedBy: v.string(),
+  resolverLabel: v.string(),
+  notes: v.nullable(v.string()),
+})
+
+export type ForcedCheckoutRow = v.InferOutput<typeof ForcedCheckoutRowSchema>
+
+export const LockupExceptionRowSchema = v.object({
+  id: v.string(),
+  operationalDate: v.string(),
+  buildingStatus: v.string(),
+  securedAt: v.nullable(v.string()),
+  expectedDds: v.nullable(ReportDutyPersonSchema),
+  expectedSwk: v.nullable(ReportDutyPersonSchema),
+  expectedLockupHolder: v.nullable(ReportDutyPersonSchema),
+  systemForcedCheckoutCount: v.number(),
+  lockupExecutionId: v.nullable(v.string()),
+  notes: v.array(v.string()),
+})
+
+export type LockupExceptionRow = v.InferOutput<typeof LockupExceptionRowSchema>
+
+export const OperationalExceptionsReportDataSchema = v.object({
+  summary: v.object({
+    forcedCheckoutCount: v.number(),
+    systemForcedCheckoutCount: v.number(),
+    adminForcedCheckoutCount: v.number(),
+    lockupExceptionCount: v.number(),
+  }),
+  forcedCheckouts: v.array(ForcedCheckoutRowSchema),
+  lockupExceptions: v.array(LockupExceptionRowSchema),
+})
+
+export type OperationalExceptionsReportData = v.InferOutput<
+  typeof OperationalExceptionsReportDataSchema
+>
+
+export const OperationalExceptionsReportResponseSchema = v.object({
+  ...ReportEnvelopeBaseEntries,
+  reportType: v.literal('operational_exceptions'),
+  data: OperationalExceptionsReportDataSchema,
+})
+
+export type OperationalExceptionsReportResponse = v.InferOutput<
+  typeof OperationalExceptionsReportResponseSchema
 >
 
 // ============================================================================

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Fixes generated presence reports to use Sentinel's operational-day rollover instead of calendar midnight, preventing prior-night open sessions from appearing as 12:00 AM to 3:00 AM attendance on the next report day.
- Adds an Operational Exceptions report for forced checkouts and missed Execute Lockup days, including the expected DDS, SWK, and scheduled lockup holder when available.
- Hides DDS and Duty Watch tags in generated reports unless the member is actually scheduled for that position.
- Improves the navbar backend status badge so the current API state is easier to read.
- Prepares the patch release as v3.2.5.

## Why This Is Needed

Admins saw 6 May report entries for members such as S3 Briggs and S3 Basanti from 12:00 AM to 3:00 AM. That happened because the daily presence report was slicing by calendar day while Sentinel operations roll over at the configured operational start time. If the Duty Watch did not Execute Lockup, the system's daily reset could force people out after midnight and those clipped sessions looked like same-day presence.

## What Changed

### Admin/User Facing

- Daily presence style reports now align with the operational day boundary.
- Report member tags no longer show DDS or Duty Watch unless the person is scheduled in that role for the relevant day.
- A new Operational Exceptions report is available in Admin Reports with forced-checkout and missed-lockup tables.
- The backend status badge in the navbar is larger and easier to scan.

### Backend/API

- Added `/api/reports/operations/exceptions` through the reports contract and backend route.
- Added report repository queries for missed checkouts, lockup status, and scheduled duty context.
- Added service logic to identify forced checkouts by DDS/System and lockup days that were not properly completed.

### Database

- No database migration.
- The new report uses existing missed-checkout, lockup-status, scheduled-duty, and check-in data.

### Deployment/Update Notes

- No manual configuration or migration step is required.
- Deploy normally and restart services so the new backend route is available to the frontend.

## Testing Performed

- `pnpm version:check`
- `pnpm --filter @sentinel/contracts typecheck`
- `pnpm --filter @sentinel/backend typecheck`
- `pnpm --filter frontend-admin typecheck`
- `pnpm --filter @sentinel/backend lint` passed with 64 existing warnings.
- `pnpm --filter frontend-admin lint` passed with 79 existing warnings.
- Playwright visual check of Admin Reports confirmed the Operational Exceptions report selector and date filters render at desktop size. Running the report in the already-running local environment returned `Cannot POST /api/reports/operations/exceptions` because that backend process had not been restarted with this branch's new route.

## Risk And Rollback

- Main behavior change is report interpretation around the operational-day boundary. It should better match unit operations, but report comparisons against older exports may differ around midnight to rollover.
- Rollback is code-only. Reverting this release restores previous report behavior and removes the Operational Exceptions report endpoint/UI.

## Changelog Candidates

- Fixed daily presence reports to respect the operational-day rollover.
- Added Operational Exceptions reporting for forced checkouts and missed Execute Lockup days.
- Hid DDS and Duty Watch tags in reports unless scheduled for those roles.
- Improved backend status visibility in the admin navbar.
