### PR TITLE
fix: unblock updates with root-only appliance env

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/deploy/deb/assets/usr/lib/sentinel/sentinel-update-bridge
+++ b/deploy/deb/assets/usr/lib/sentinel/sentinel-update-bridge
@@ -206,6 +206,18 @@ def start_updater_unit() -> None:
     trace("info", f"Updater unit {UPDATER_UNIT} was handed off successfully.")
 
 
+def load_bridge_appliance_state() -> dict[str, Any]:
+    try:
+        return load_appliance_state()
+    except (OSError, json.JSONDecodeError) as error:
+        trace(
+            "warning",
+            "Could not read appliance state before updater handoff; "
+            f"the root updater will refresh version metadata after it starts. Reason: {error}",
+        )
+        return {}
+
+
 def persist_initial_job(payload: dict[str, Any]) -> dict[str, Any]:
     lock_handle = LOCK_PATH.open("a+", encoding="utf-8")
     try:
@@ -219,8 +231,8 @@ def persist_initial_job(payload: dict[str, Any]) -> dict[str, Any]:
             trace_if_exists("warning", "Rejected a new update request because another update job is already active.")
             raise BridgeError("An update is already in progress.", status=409)
 
-        state = load_appliance_state()
         # The bridge runs as an unprivileged service account; appliance.env stays root-only.
+        state = load_bridge_appliance_state()
         current_version = state.get("currentVersion")
         job = {
             "schemaVersion": 2,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Fixes UI-started updates failing when the unprivileged update bridge cannot read root-only appliance state or env metadata.
- Keeps `/etc/sentinel/appliance.env` root-only while allowing the bridge to hand the update request to the privileged updater.
- Prepares the hotfix release as v3.2.6.

## Why This Is Needed

The update bridge can run as `sentinel-updater-bridge`, while `/etc/sentinel/appliance.env` is intentionally owned by root and mode `600`. On affected appliances, the bridge attempted to load appliance metadata before starting the root updater and crashed with `Permission denied: '/etc/sentinel/appliance.env'`. That blocked the update before the privileged updater could take over.

## What Changed

### Operator Facing

- Starting an update from Admin > Updates no longer fails just because the bridge cannot read root-only appliance metadata.
- Initial job metadata may briefly show an unknown current version, then the root updater refreshes accurate version details once it starts.

### Backend/Host Update

- Added a bridge-safe appliance state loader that catches unreadable state/env metadata and continues with an empty state.
- The root updater remains responsible for reading and updating `/etc/sentinel/appliance.env`.

### Database

- No database migration.

### Deployment/Update Notes

- No configuration change is required for appliances that can already install this package.
- Appliances already blocked by the old bridge may need a one-time host repair/manual package install before they can receive this fix through the UI.

## Testing Performed

- `pnpm version:check`
- `python3 -m py_compile deploy/deb/assets/usr/lib/sentinel/sentinel-update-bridge deploy/deb/assets/usr/lib/sentinel/sentinel-updater deploy/deb/assets/usr/lib/sentinel/sentinel_update_common.py`
- Simulated an unreadable appliance state path and confirmed the bridge-safe loader returns an empty state instead of raising `Permission denied`.

## Risk And Rollback

- Low risk. The change only affects pre-handoff metadata loading in the bridge.
- Rollback restores the previous behavior, including the possibility that unreadable appliance metadata blocks UI-started updates.

## Changelog Candidates

- Fixed UI-started appliance updates failing on root-only `/etc/sentinel/appliance.env` permission errors.
