### PR TITLE
fix(reports): release v3.2.7 forced checkout reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,6 +219,7 @@ $RECYCLE.BIN/
 
 # PostgreSQL
 *.sql.gz
+backups/*.dump
 
 # ===================================
 # Docker

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/jobs/daily-reset.ts
+++ b/apps/backend/src/jobs/daily-reset.ts
@@ -92,6 +92,7 @@ export async function runDailyReset(): Promise<void> {
               memberId: member.id,
               date: new Date(operationalDate),
               originalCheckinAt: lastCheckin?.timestamp || new Date(),
+              forcedCheckoutAt: resetTimestamp,
               resolvedBy: 'daily_reset',
               notes: 'Automatically force-checked out during daily reset',
             },
@@ -111,30 +112,28 @@ export async function runDailyReset(): Promise<void> {
             where: { assignedToId: member.id },
           })
 
-          if (badge) {
-            const checkout = await prisma.checkin.create({
-              data: {
-                memberId: member.id,
-                badgeId: badge.id,
-                direction: 'out',
-                kioskId: 'SYSTEM',
-                method: 'system',
-                timestamp: resetTimestamp,
-              },
-            })
-
-            // Broadcast checkout
-            broadcastCheckin({
-              id: checkout.id,
+          const checkout = await prisma.checkin.create({
+            data: {
               memberId: member.id,
-              memberName: `${member.rank} ${member.firstName} ${member.lastName}`,
+              badgeId: badge?.id ?? lastCheckin?.badgeId ?? null,
               direction: 'out',
-              timestamp: resetTimestamp.toISOString(),
               kioskId: 'SYSTEM',
-            })
+              method: 'system',
+              timestamp: resetTimestamp,
+            },
+          })
 
-            forceCheckedOutMemberIds.push(member.id)
-          }
+          // Broadcast checkout
+          broadcastCheckin({
+            id: checkout.id,
+            memberId: member.id,
+            memberName: `${member.rank} ${member.firstName} ${member.lastName}`,
+            direction: 'out',
+            timestamp: resetTimestamp.toISOString(),
+            kioskId: 'SYSTEM',
+          })
+
+          forceCheckedOutMemberIds.push(member.id)
 
           missedMembers.push({
             id: member.id,

--- a/apps/backend/src/repositories/operational-report-repository.ts
+++ b/apps/backend/src/repositories/operational-report-repository.ts
@@ -149,6 +149,7 @@ export interface OperationalReportCheckinRecord {
   memberId: string | null
   direction: string
   timestamp: Date
+  kioskId: string
 }
 
 export type OperationalReportUnitEventRecord = Prisma.UnitEventGetPayload<{
@@ -171,7 +172,14 @@ export type OperationalReportScheduledDutyRecord = Prisma.WeeklyScheduleGetPaylo
   include: typeof scheduledDutyInclude
 }>
 
-export type OperationalReportScheduledDutyRoleCode = 'DDS' | 'DUTY_WATCH'
+export type OperationalReportScheduledDutyRoleCode =
+  | 'DDS'
+  | 'DUTY_WATCH'
+  | 'SWK'
+  | 'DSWK'
+  | 'QM'
+  | 'BM'
+  | 'APS'
 
 export interface OperationalReportScheduledDutyAssignmentRecord {
   memberId: string
@@ -318,6 +326,7 @@ export class OperationalReportRepository {
         memberId: true,
         direction: true,
         timestamp: true,
+        kioskId: true,
       },
       orderBy: [{ memberId: 'asc' }, { timestamp: 'asc' }],
     })
@@ -354,6 +363,11 @@ export class OperationalReportRepository {
       },
       select: {
         memberId: true,
+        dutyPosition: {
+          select: {
+            code: true,
+          },
+        },
         schedule: {
           select: {
             dutyRole: {
@@ -368,8 +382,97 @@ export class OperationalReportRepository {
 
     return assignments.map((assignment) => ({
       memberId: assignment.memberId,
-      dutyRoleCode: assignment.schedule.dutyRole.code as OperationalReportScheduledDutyRoleCode,
+      dutyRoleCode: this.toScheduledDutyRoleCode(
+        assignment.schedule.dutyRole.code,
+        assignment.dutyPosition?.code ?? null
+      ),
     }))
+  }
+
+  async findDdsAssignmentsForMembers(
+    memberIds: string[],
+    startDate: Date,
+    endDate: Date
+  ): Promise<OperationalReportScheduledDutyAssignmentRecord[]> {
+    if (memberIds.length === 0) {
+      return []
+    }
+
+    const assignments = await this.prisma.ddsAssignment.findMany({
+      where: {
+        memberId: {
+          in: memberIds,
+        },
+        assignedDate: {
+          gte: startDate,
+          lt: endDate,
+        },
+      },
+      select: {
+        memberId: true,
+      },
+    })
+
+    return assignments.map((assignment) => ({
+      memberId: assignment.memberId,
+      dutyRoleCode: 'DDS',
+    }))
+  }
+
+  async findLiveDutyAssignmentsForMembers(
+    memberIds: string[],
+    start: Date,
+    end: Date
+  ): Promise<OperationalReportScheduledDutyAssignmentRecord[]> {
+    if (memberIds.length === 0) {
+      return []
+    }
+
+    const assignments = await this.prisma.liveDutyAssignment.findMany({
+      where: {
+        memberId: {
+          in: memberIds,
+        },
+        startedAt: {
+          lt: end,
+        },
+        OR: [{ endedAt: null }, { endedAt: { gte: start } }],
+      },
+      select: {
+        memberId: true,
+        dutyPosition: {
+          select: {
+            code: true,
+          },
+        },
+      },
+    })
+
+    return assignments.map((assignment) => ({
+      memberId: assignment.memberId,
+      dutyRoleCode: this.toScheduledDutyRoleCode('DUTY_WATCH', assignment.dutyPosition.code),
+    }))
+  }
+
+  private toScheduledDutyRoleCode(
+    dutyRoleCode: string,
+    dutyPositionCode: string | null
+  ): OperationalReportScheduledDutyRoleCode {
+    if (dutyRoleCode === 'DDS') {
+      return 'DDS'
+    }
+
+    if (
+      dutyPositionCode === 'SWK' ||
+      dutyPositionCode === 'DSWK' ||
+      dutyPositionCode === 'QM' ||
+      dutyPositionCode === 'BM' ||
+      dutyPositionCode === 'APS'
+    ) {
+      return dutyPositionCode
+    }
+
+    return 'DUTY_WATCH'
   }
 
   async findMissedCheckouts(

--- a/apps/backend/src/services/lockup-service.test.ts
+++ b/apps/backend/src/services/lockup-service.test.ts
@@ -21,6 +21,10 @@ function createService() {
     member: {
       findUnique: vi.fn(),
       findMany: vi.fn(),
+      update: vi.fn(),
+    },
+    missedCheckout: {
+      create: vi.fn(),
     },
     ddsAssignment: {
       findFirst: vi.fn(),
@@ -28,6 +32,7 @@ function createService() {
     responsibilityAuditLog: {
       create: vi.fn(),
     },
+    $transaction: vi.fn(async (operations: Array<Promise<unknown>>) => Promise.all(operations)),
   }
 
   const service = new LockupService(prisma as unknown as PrismaClient)
@@ -232,6 +237,8 @@ describe('LockupService.executeLockup', () => {
     lockupRepo.createExecution.mockResolvedValue({ id: 'execution-1' })
     lockupRepo.markSecured.mockResolvedValue({})
     prisma.responsibilityAuditLog.create.mockResolvedValue({})
+    prisma.member.update.mockResolvedValue({})
+    prisma.missedCheckout.create.mockResolvedValue({})
     presenceService.setMemberDirection.mockResolvedValue(undefined)
     liveDutyAssignmentService.clearAssignmentsForMembers.mockResolvedValue(2)
 
@@ -264,6 +271,110 @@ describe('LockupService.executeLockup', () => {
       ['member-1', 'member-2'],
       'lockup_execution',
       expect.any(Date)
+    )
+    expect(prisma.missedCheckout.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        memberId: 'member-2',
+        resolvedBy: 'lockup_sequence',
+        lockupExecutionId: 'execution-1',
+        originalCheckinAt: new Date('2026-03-26T17:10:00.000Z'),
+      }),
+    })
+    expect(prisma.member.update).toHaveBeenCalledWith({
+      where: { id: 'member-2' },
+      data: {
+        missedCheckoutCount: { increment: 1 },
+        lastMissedCheckout: expect.any(Date),
+      },
+    })
+  })
+
+  it('force-checks out present members even when no badge is currently assigned', async () => {
+    const {
+      service,
+      prisma,
+      checkinRepo,
+      visitorRepo,
+      lockupRepo,
+      presenceService,
+      liveDutyAssignmentService,
+    } = createService()
+
+    vi.spyOn(service, 'getCurrentStatus').mockResolvedValue({
+      id: 'status-1',
+      date: new Date('2026-03-26T00:00:00.000Z'),
+      currentHolderId: 'member-1',
+      acquiredAt: new Date('2026-03-26T08:00:00.000Z'),
+      buildingStatus: 'open',
+      securedAt: null,
+      securedBy: null,
+      isActive: true,
+      createdAt: new Date('2026-03-26T00:00:00.000Z'),
+      updatedAt: new Date('2026-03-26T00:00:00.000Z'),
+      currentHolder: null,
+      securedByMember: null,
+    })
+
+    checkinRepo.getPresentMembers.mockResolvedValue([
+      {
+        id: 'member-2',
+        firstName: 'Alex',
+        lastName: 'Other',
+        rank: 'Lt',
+        division: 'Ops',
+        divisionId: 'div-2',
+        memberType: 'reg_force',
+        mess: null,
+        checkedInAt: '2026-03-26T17:10:00.000Z',
+        kioskId: 'front',
+      },
+    ])
+    visitorRepo.findActive.mockResolvedValue([])
+    prisma.member.findUnique.mockImplementation(async ({ where }: { where: { id: string } }) => {
+      if (where.id === 'member-2') {
+        return {
+          badgeId: null,
+          firstName: 'Alex',
+          lastName: 'Other',
+          rank: 'Lt',
+        }
+      }
+
+      return {
+        badgeId: 'badge-1',
+        firstName: 'Pat',
+        lastName: 'Holder',
+        rank: 'Capt',
+      }
+    })
+    checkinRepo.create.mockResolvedValue({
+      id: 'checkout-1',
+      memberId: 'member-2',
+      badgeId: undefined,
+      direction: 'out',
+      timestamp: new Date('2026-03-26T23:00:00.000Z'),
+      kioskId: 'lockup-force-checkout',
+      synced: true,
+      createdAt: new Date('2026-03-26T23:00:00.000Z'),
+    })
+    lockupRepo.markLockingUp.mockResolvedValue({})
+    lockupRepo.createExecution.mockResolvedValue({ id: 'execution-1' })
+    lockupRepo.markSecured.mockResolvedValue({})
+    prisma.responsibilityAuditLog.create.mockResolvedValue({})
+    prisma.member.update.mockResolvedValue({})
+    prisma.missedCheckout.create.mockResolvedValue({})
+    presenceService.setMemberDirection.mockResolvedValue(undefined)
+    liveDutyAssignmentService.clearAssignmentsForMembers.mockResolvedValue(1)
+
+    await service.executeLockup('member-1', 'End of day')
+
+    expect(checkinRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        memberId: 'member-2',
+        badgeId: undefined,
+        direction: 'out',
+        kioskId: 'lockup-force-checkout',
+      })
     )
   })
 })

--- a/apps/backend/src/services/lockup-service.ts
+++ b/apps/backend/src/services/lockup-service.ts
@@ -38,6 +38,7 @@ interface LockupPresentData {
     mess: string | null
     checkedInAt: string
     kioskId?: string
+    activeCheckinId?: string
   }>
   visitors: Array<{
     id: string
@@ -730,6 +731,10 @@ export class LockupService {
     const { members, visitors } = await this.getPresentMembersForLockup()
 
     const checkedOutMembers: Array<{ id: string; name: string }> = []
+    const forcedMissedCheckouts: Array<{
+      memberId: string
+      originalCheckinAt: Date
+    }> = []
     const checkedOutVisitors: Array<{ id: string; name: string }> = []
     const now = new Date()
 
@@ -779,16 +784,17 @@ export class LockupService {
           select: { badgeId: true, firstName: true, lastName: true, rank: true },
         })
 
-        if (!memberData?.badgeId) {
+        if (!memberData) {
           continue
         }
 
         await this.checkinRepo.create({
           memberId: member.id,
-          badgeId: memberData.badgeId,
+          badgeId: memberData.badgeId ?? undefined,
           direction: 'out',
           timestamp: now,
           kioskId: 'lockup-force-checkout',
+          method: 'manual',
           synced: true,
         })
 
@@ -797,6 +803,10 @@ export class LockupService {
         checkedOutMembers.push({
           id: member.id,
           name: `${memberData.rank} ${memberData.firstName} ${memberData.lastName}`,
+        })
+        forcedMissedCheckouts.push({
+          memberId: member.id,
+          originalCheckinAt: new Date(member.checkedInAt),
         })
       } catch (error) {
         serviceLogger.error('Failed to checkout member during lockup', {
@@ -840,6 +850,36 @@ export class LockupService {
       totalCheckedOut: checkedOutMembers.length + checkedOutVisitors.length,
       notes: note,
     })
+
+    if (forcedMissedCheckouts.length > 0) {
+      const operationalDate = status.date
+      await this.prisma.$transaction([
+        ...forcedMissedCheckouts.map((missedCheckout) =>
+          this.prisma.missedCheckout.create({
+            data: {
+              memberId: missedCheckout.memberId,
+              date: operationalDate,
+              originalCheckinAt: missedCheckout.originalCheckinAt,
+              forcedCheckoutAt: now,
+              resolvedBy: 'lockup_sequence',
+              lockupExecutionId: execution.id,
+              notes:
+                note ??
+                'Member was force-checked out during Execute Lockup because no checkout was recorded.',
+            },
+          })
+        ),
+        ...forcedMissedCheckouts.map((missedCheckout) =>
+          this.prisma.member.update({
+            where: { id: missedCheckout.memberId },
+            data: {
+              missedCheckoutCount: { increment: 1 },
+              lastMissedCheckout: now,
+            },
+          })
+        ),
+      ])
+    }
 
     // Mark building as secured
     await this.lockupRepo.markSecured(status.id, performedById)

--- a/apps/backend/src/services/operational-report-service.test.ts
+++ b/apps/backend/src/services/operational-report-service.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { ReportTagSummary } from '@sentinel/contracts'
 import {
+  isStaleForcedCheckoutSession,
   filterReportMemberTagsForScheduledDuty,
   pairOperationalPresenceSessions,
   presenceSessionOverlapsRange,
@@ -12,13 +13,15 @@ function checkin(
   id: string,
   memberId: string,
   direction: 'in' | 'out',
-  timestamp: string
+  timestamp: string,
+  kioskId = 'front'
 ): OperationalReportCheckinRecord {
   return {
     id,
     memberId,
     direction,
     timestamp: new Date(timestamp),
+    kioskId,
   }
 }
 
@@ -48,6 +51,21 @@ describe('pairOperationalPresenceSessions', () => {
     expect(sessions[0]?.inAt.toISOString()).toBe('2026-05-05T08:00:00.000Z')
     expect(sessions[0]?.outAt?.toISOString()).toBe('2026-05-05T12:00:00.000Z')
     expect(warnings.size).toBe(0)
+  })
+
+  it('carries checkout kiosk IDs on completed sessions', () => {
+    const warnings = new Set<string>()
+    const sessionsByMember = pairOperationalPresenceSessions(
+      [
+        checkin('1', 'member-1', 'in', '2026-05-05T23:00:00.000Z'),
+        checkin('2', 'member-1', 'out', '2026-05-06T13:24:00.000Z', 'lockup-force-checkout'),
+      ],
+      warnings
+    )
+
+    expect(getSessions(sessionsByMember, 'member-1')[0]?.checkoutKioskId).toBe(
+      'lockup-force-checkout'
+    )
   })
 
   it('marks repeated check-ins without checkout as degraded and keeps the latest session open', () => {
@@ -80,6 +98,38 @@ describe('pairOperationalPresenceSessions', () => {
     expect(Array.from(warnings)).toContain(
       'Some checkout records could not be paired with a prior check-in and were ignored.'
     )
+  })
+})
+
+describe('isStaleForcedCheckoutSession', () => {
+  it('identifies prior-day sessions closed by lockup after the report day started', () => {
+    expect(
+      isStaleForcedCheckoutSession(
+        {
+          memberId: 'member-1',
+          inAt: new Date('2026-05-05T23:00:00.000Z'),
+          outAt: new Date('2026-05-06T13:24:00.000Z'),
+          status: 'complete',
+          checkoutKioskId: 'lockup-force-checkout',
+        },
+        new Date('2026-05-06T08:00:00.000Z')
+      )
+    ).toBe(true)
+  })
+
+  it('keeps normal sessions that began before the report day and checked out normally', () => {
+    expect(
+      isStaleForcedCheckoutSession(
+        {
+          memberId: 'member-1',
+          inAt: new Date('2026-05-05T23:00:00.000Z'),
+          outAt: new Date('2026-05-06T13:24:00.000Z'),
+          status: 'complete',
+          checkoutKioskId: 'front',
+        },
+        new Date('2026-05-06T08:00:00.000Z')
+      )
+    ).toBe(false)
   })
 })
 
@@ -156,10 +206,18 @@ describe('filterReportMemberTagsForScheduledDuty', () => {
     isPositional: true,
     source: 'direct',
   } satisfies ReportTagSummary
+  const qmTag = {
+    id: 'tag-qm',
+    name: 'QM',
+    chipVariant: 'solid',
+    chipColor: 'purple',
+    isPositional: false,
+    source: 'qualification',
+  } satisfies ReportTagSummary
 
   it('hides DDS and Duty Watch positional tags when the member is not scheduled', () => {
     const filtered = filterReportMemberTagsForScheduledDuty(
-      [baseTag, ddsTag, dutyWatchTag],
+      [baseTag, ddsTag, dutyWatchTag, qmTag],
       new Set()
     )
 
@@ -173,6 +231,21 @@ describe('filterReportMemberTagsForScheduledDuty', () => {
     )
 
     expect(filtered).toEqual([baseTag, ddsTag, dutyWatchTag])
+  })
+
+  it('keeps a Duty Watch position tag only when scheduled or acted in that position', () => {
+    expect(filterReportMemberTagsForScheduledDuty([qmTag], new Set(['QM']))).toEqual([qmTag])
+    expect(filterReportMemberTagsForScheduledDuty([qmTag], new Set(['SWK']))).toEqual([])
+  })
+
+  it('hides all DDS and Duty Watch family tags when monthly reports request it', () => {
+    const filtered = filterReportMemberTagsForScheduledDuty(
+      [baseTag, ddsTag, dutyWatchTag, qmTag],
+      new Set(['DDS', 'DUTY_WATCH', 'QM']),
+      { hideDutyTags: true }
+    )
+
+    expect(filtered).toEqual([baseTag])
   })
 
   it('does not hide non-positional tags with similar names', () => {

--- a/apps/backend/src/services/operational-report-service.ts
+++ b/apps/backend/src/services/operational-report-service.ts
@@ -79,6 +79,7 @@ export interface PresenceSessionInternal {
   inAt: Date
   outAt: Date | null
   status: 'complete' | 'open' | 'degraded'
+  checkoutKioskId?: string | null
 }
 
 interface KeyNightWindow extends KeyNight {
@@ -97,6 +98,9 @@ interface PresenceStats {
 }
 
 type ScheduledDutyRolesByMember = Map<string, Set<OperationalReportScheduledDutyRoleCode>>
+interface ReportMemberSummaryOptions {
+  hideDutyTags?: boolean
+}
 
 interface LockupCheckedOutMember {
   id: string
@@ -106,10 +110,6 @@ interface LockupCheckedOutMember {
 export function getScheduledDutyTagRole(
   tag: ReportTagSummary
 ): OperationalReportScheduledDutyRoleCode | null {
-  if (!tag.isPositional) {
-    return null
-  }
-
   const normalizedName = tag.name.trim().toLowerCase().replace(/[_-]+/g, ' ')
 
   if (normalizedName === 'dds') {
@@ -120,16 +120,48 @@ export function getScheduledDutyTagRole(
     return 'DUTY_WATCH'
   }
 
+  if (normalizedName === 'swk' || normalizedName === 'senior watchkeeper') {
+    return 'SWK'
+  }
+
+  if (normalizedName === 'dswk' || normalizedName === 'deputy senior watchkeeper') {
+    return 'DSWK'
+  }
+
+  if (normalizedName === 'qm' || normalizedName === 'quartermaster') {
+    return 'QM'
+  }
+
+  if (normalizedName === 'bm' || normalizedName === 'boatswain mate') {
+    return 'BM'
+  }
+
+  if (normalizedName === 'aps' || normalizedName === 'access point sentry') {
+    return 'APS'
+  }
+
   return null
 }
 
 export function filterReportMemberTagsForScheduledDuty(
   tags: ReportTagSummary[],
-  scheduledRoleCodes: ReadonlySet<OperationalReportScheduledDutyRoleCode>
+  scheduledRoleCodes: ReadonlySet<OperationalReportScheduledDutyRoleCode>,
+  options: { hideDutyTags?: boolean } = {}
 ): ReportTagSummary[] {
   return tags.filter((tag) => {
     const requiredRoleCode = getScheduledDutyTagRole(tag)
-    return requiredRoleCode === null || scheduledRoleCodes.has(requiredRoleCode)
+    if (requiredRoleCode === null) {
+      return true
+    }
+
+    if (options.hideDutyTags) {
+      return false
+    }
+
+    return (
+      scheduledRoleCodes.has(requiredRoleCode) ||
+      (requiredRoleCode !== 'DDS' && scheduledRoleCodes.has('DUTY_WATCH'))
+    )
   })
 }
 
@@ -147,6 +179,18 @@ export function presenceSessionOverlapsRange(
   const effectiveOut = rawOut > asOf ? asOf : rawOut
 
   return session.inAt < end && effectiveOut > start
+}
+
+export function isStaleForcedCheckoutSession(
+  session: PresenceSessionInternal,
+  start: Date
+): boolean {
+  if (!session.outAt || session.inAt >= start) {
+    return false
+  }
+
+  const checkoutKioskId = session.checkoutKioskId ?? ''
+  return checkoutKioskId === 'SYSTEM' || checkoutKioskId === 'lockup-force-checkout'
 }
 
 export function pairOperationalPresenceSessions(
@@ -212,6 +256,7 @@ export function pairOperationalPresenceSessions(
           inAt: openIn.timestamp,
           outAt: record.timestamp,
           status: 'complete',
+          checkoutKioskId: record.kioskId,
         })
         openIn = null
         continue
@@ -392,7 +437,6 @@ export class OperationalReportService {
           tagId: scope.tagId,
         })
     const sessionsByMember = await this.getSessionsByMember(members, range, warnings)
-    const scheduledDutyRolesByMember = await this.getScheduledDutyRolesByMember(members, range)
     const keyNights = await this.getKeyNights(range, ['training', 'administrative'], warnings)
     const days = this.getDatesInRange(range).map((date) => ({
       date,
@@ -415,7 +459,7 @@ export class OperationalReportService {
       )
 
       return {
-        member: this.toMemberSummary(member, scheduledDutyRolesByMember.get(member.id)),
+        member: this.toMemberSummary(member, new Set(), { hideDutyTags: true }),
         days: dayMarkers,
         keyNights: keyNightMarkers,
         totalDaysPresent: dayMarkers.filter((marker) => marker.present).length,
@@ -467,7 +511,6 @@ export class OperationalReportService {
       ? await this.repository.findActiveMembers({ divisionId: config.divisionId })
       : []
     const sessionsByMember = await this.getSessionsByMember(members, range, warnings)
-    const scheduledDutyRolesByMember = await this.getScheduledDutyRolesByMember(members, range)
     const keyNights = await this.getKeyNights(range, ['training'], warnings)
     const trainingNights = keyNights.filter((night) => night.category === 'training')
 
@@ -486,7 +529,7 @@ export class OperationalReportService {
       const possible = nightMarkers.filter((marker) => marker.requirement === 'required').length
 
       return {
-        member: this.toMemberSummary(member, scheduledDutyRolesByMember.get(member.id)),
+        member: this.toMemberSummary(member, new Set(), { hideDutyTags: true }),
         nights: nightMarkers,
         attended,
         possible,
@@ -1259,7 +1302,8 @@ export class OperationalReportService {
 
   private toMemberSummary(
     member: OperationalReportMemberRecord,
-    scheduledRoleCodes: ReadonlySet<OperationalReportScheduledDutyRoleCode> = new Set()
+    scheduledRoleCodes: ReadonlySet<OperationalReportScheduledDutyRoleCode> = new Set(),
+    options: ReportMemberSummaryOptions = {}
   ): ReportMemberSummary {
     const directTags = member.memberTags.map<ReportTagSummary>((memberTag) => ({
       id: memberTag.tag.id,
@@ -1282,7 +1326,8 @@ export class OperationalReportService {
       }))
     const tags = filterReportMemberTagsForScheduledDuty(
       this.dedupeTags([...directTags, ...qualificationTags]),
-      scheduledRoleCodes
+      scheduledRoleCodes,
+      options
     )
 
     return {
@@ -1496,6 +1541,10 @@ export class OperationalReportService {
   }
 
   private sessionOverlaps(session: PresenceSessionInternal, start: Date, end: Date): boolean {
+    if (isStaleForcedCheckoutSession(session, start)) {
+      return false
+    }
+
     return presenceSessionOverlapsRange(session, start, end)
   }
 
@@ -1549,15 +1598,28 @@ export class OperationalReportService {
       return new Map()
     }
 
+    const memberIds = members.map((member) => member.id)
     const { firstWeekStart, lastWeekStart } = this.getScheduleWeekRange(range)
-    const assignments = await this.repository.findScheduledDutyAssignmentsForMembers(
-      members.map((member) => member.id),
-      firstWeekStart,
-      lastWeekStart
-    )
+    const ddsStartDate = DateTime.fromISO(range.startDate, { zone: 'utc' }).startOf('day')
+    const ddsEndDate = DateTime.fromISO(range.endDate, { zone: 'utc' })
+      .plus({ days: 1 })
+      .startOf('day')
+    const [scheduledAssignments, ddsAssignments, liveAssignments] = await Promise.all([
+      this.repository.findScheduledDutyAssignmentsForMembers(
+        memberIds,
+        firstWeekStart,
+        lastWeekStart
+      ),
+      this.repository.findDdsAssignmentsForMembers(
+        memberIds,
+        ddsStartDate.toJSDate(),
+        ddsEndDate.toJSDate()
+      ),
+      this.repository.findLiveDutyAssignmentsForMembers(memberIds, range.start, range.end),
+    ])
     const scheduledRolesByMember: ScheduledDutyRolesByMember = new Map()
 
-    for (const assignment of assignments) {
+    for (const assignment of [...scheduledAssignments, ...ddsAssignments, ...liveAssignments]) {
       const roleCodes = scheduledRolesByMember.get(assignment.memberId) ?? new Set()
       roleCodes.add(assignment.dutyRoleCode)
       scheduledRolesByMember.set(assignment.memberId, roleCodes)

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Fixes Presence Report sessions created by stale forced checkouts so prior-day missed checkout cleanup does not make members look present from midnight or 3:00 AM.
- Records Execute Lockup forced member checkouts as missed checkout records, including members who no longer have a badge assigned.
- Hides DDS and Duty Watch family tags from reports unless the member was scheduled for or acted in that duty role; monthly reports hide those duty tags entirely.
- Prepares Sentinel v3.2.7 for the appliance update flow.

## Why this change was needed

Presence reports could include forced checkout records from the daily reset or lockup cleanup as if they were normal same-day attendance sessions. That made report times misleading when members forgot to check out the previous day. Duty tags also appeared as regular qualification tags, which made reports look like members were serving in DDS or Duty Watch positions when they were only qualified for them.

## What changed

### User-facing

- Daily and weekly presence reports keep normal qualification tags such as GEO, FTS, CMD, and VIP.
- DDS, Duty Watch, SWK, DSWK, QM, BM, and APS tags now only show when the member was scheduled for or acted in that role during the report period.
- Monthly presence reports and monthly training night reports hide all DDS and Duty Watch family tags.
- Stale forced checkout sessions from earlier operational days are ignored when calculating report presence.

### Admin/operator-facing

- Execute Lockup now records forced member checkouts as missed checkouts so operators can audit who had to be forced out.
- Daily reset records the forced checkout timestamp and creates the system checkout even when the member has no currently assigned badge.
- Local PostgreSQL dump backups under `backups/*.dump` are ignored so live-data repair backups are not accidentally committed.

### Backend/API

- Report session pairing now carries the checkout kiosk ID so system and lockup-forced sessions can be distinguished from normal member checkout sessions.
- Report tag filtering now recognizes DDS and Duty Watch family roles, including QM, BM, APS, SWK, and DSWK.
- Scheduled duty detection now combines weekly schedule assignments, DDS assignment dates, and live duty assignments.

### Database

- No schema migration is required.
- New missed checkout rows are written by Execute Lockup for future forced checkouts.
- Daily reset now stores `forcedCheckoutAt` on missed checkout rows for future cleanup events.

### Deployment/update

- Bumps Sentinel package versions to `3.2.7`.
- No environment or appliance configuration change is required.

### Tests

- Added backend service coverage for stale forced checkout session filtering.
- Added backend service coverage for DDS and Duty Watch family tag filtering, including QM and monthly report suppression.
- Added lockup service coverage for missed checkout creation and no-badge forced checkout handling.

## User impact

Report viewers should see cleaner presence times and fewer misleading duty badges. Members who are qualified for Duty Watch positions will no longer appear to have served those positions unless they were scheduled or acted in that role.

## Operator impact

Operators get better audit data after Execute Lockup and daily reset. Future forced checkouts are captured as missed checkout records, which makes it easier to identify members who forgot to check out and whether lockup cleanup happened.

## Upgrade or migration notes

No upgrade action required beyond installing the v3.2.7 appliance update. No database migration or configuration change is required.

## Risk and rollback notes

The main risk is report filtering being too strict for a duty tag whose name does not match one of the recognized role names. Normal qualification tags remain visible. Rollback is safe through the standard appliance rollback flow because this release does not change the database schema.

## Testing performed

- `pnpm --filter @sentinel/backend typecheck`
- `pnpm --filter @sentinel/backend lint` (passes with existing warnings only)
- `pnpm version:check`
- `git diff --check`

## Changelog candidates

- Fixed Presence Report sessions caused by stale system or lockup-forced checkouts. This prevents prior-day missed checkout cleanup from showing misleading same-day attendance times.
- Fixed report duty tags so DDS and Duty Watch family tags only show when the member was scheduled for or acted in that duty role, and never show on monthly reports.
- Improved Execute Lockup audit records by creating missed checkout entries for members forced out during lockup, including members without a currently assigned badge.
- Improved daily reset cleanup by recording forced checkout timestamps and ensuring system checkout rows are created for missed members.