### PR TITLE
fix(updates): release v3.2.8 update readiness

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/routes/system-update.test.ts
+++ b/apps/backend/src/routes/system-update.test.ts
@@ -54,11 +54,29 @@ function createStatusResponse(overrides?: Partial<Record<string, unknown>>) {
   return {
     currentVersion: 'v2.6.1',
     latestVersion: 'v2.6.2',
+    pendingReleaseVersion: null,
+    latestReleaseStatus: 'ready',
+    latestReleaseStatusMessage: 'Latest stable release is ready to install.',
     latestReleaseUrl: 'https://github.com/DeadshotOMEGA/sentinel/releases/tag/v2.6.2',
     latestReleaseNotes: null,
     updateAvailable: true,
     currentJob: null,
     ...overrides,
+  }
+}
+
+function createInstallableReleasePayload(version = 'v2.6.2') {
+  return {
+    tag_name: version,
+    name: `Sentinel ${version}`,
+    html_url: `https://github.com/DeadshotOMEGA/sentinel/releases/tag/${version}`,
+    published_at: '2026-04-22T12:00:00.000Z',
+    body: 'Release notes.',
+    assets: [
+      { name: 'build-info.env' },
+      { name: 'sentinel-appliance_2.6.2_all.deb' },
+      { name: 'SHA256SUMS.txt' },
+    ],
   }
 }
 
@@ -134,6 +152,8 @@ describe('systemUpdateRouter', () => {
   const originalReleaseRepository = process.env.SYSTEM_UPDATE_RELEASE_REPOSITORY
 
   afterEach(async () => {
+    vi.unstubAllGlobals()
+
     if (originalAppVersion === undefined) {
       delete process.env.APP_VERSION
     } else {
@@ -242,7 +262,14 @@ describe('systemUpdateRouter', () => {
     process.env.SYSTEM_UPDATE_STATE_ROOT = stateRoot
     process.env.SENTINEL_APPLIANCE_STATE = join(stateRoot, 'missing-appliance-state.json')
     process.env.SYSTEM_UPDATE_BRIDGE_SOCKET_PATH = socketPath
-    process.env.SYSTEM_UPDATE_RELEASE_REPOSITORY = ''
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          new globalThis.Response(JSON.stringify(createInstallableReleasePayload()))
+        )
+    )
 
     const server = await createBridgeServer(socketPath, (payload) => {
       expect(payload).toMatchObject({
@@ -309,6 +336,35 @@ describe('systemUpdateRouter', () => {
     } finally {
       await rm(stateRoot, { recursive: true, force: true })
     }
+  })
+
+  it('rejects starting an update while GitHub release assets are still being prepared', async () => {
+    const getStatus = vi.fn().mockResolvedValue(
+      createStatusResponse({
+        latestVersion: null,
+        pendingReleaseVersion: 'v2.6.2',
+        latestReleaseStatus: 'preparing',
+        latestReleaseStatusMessage: 'GitHub is still creating release assets.',
+        updateAvailable: false,
+      })
+    )
+    const statusService = {
+      getStatus,
+      getJob: vi.fn(),
+    } as unknown as SystemUpdateStatusService
+
+    const app = createTestApp(5, { statusService })
+    const response = await request(app)
+      .post('/api/admin/system/update')
+      .send({ targetVersion: 'v2.6.2' })
+
+    expect(response.status).toBe(409)
+    expect(response.body).toMatchObject({
+      error: 'CONFLICT',
+      message:
+        'Release v2.6.2 is still being prepared. Wait for the release workflow to finish, then refresh updates.',
+    })
+    expect(getStatus).toHaveBeenCalledWith({ forceRefresh: true })
   })
 
   it('treats an unfinished rollback as an active update job', async () => {
@@ -529,7 +585,14 @@ describe('systemUpdateRouter', () => {
     process.env.SYSTEM_UPDATE_STATE_ROOT = stateRoot
     process.env.SENTINEL_APPLIANCE_STATE = join(stateRoot, 'missing-appliance-state.json')
     process.env.SYSTEM_UPDATE_BRIDGE_SOCKET_PATH = join(stateRoot, 'missing.sock')
-    process.env.SYSTEM_UPDATE_RELEASE_REPOSITORY = ''
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          new globalThis.Response(JSON.stringify(createInstallableReleasePayload()))
+        )
+    )
 
     try {
       const app = createTestApp(5)

--- a/apps/backend/src/routes/system-update.ts
+++ b/apps/backend/src/routes/system-update.ts
@@ -103,7 +103,7 @@ export function createSystemUpdateRouter(options?: {
       }
 
       try {
-        const status = await statusService.getStatus()
+        const status = await statusService.getStatus({ forceRefresh: true })
 
         if (status.currentJob && !isSystemUpdateJobFinished(status.currentJob)) {
           return {
@@ -131,6 +131,19 @@ export function createSystemUpdateRouter(options?: {
             body: {
               error: 'CONFLICT',
               message: `Target version ${body.targetVersion} is not newer than the current version ${status.currentVersion}`,
+            },
+          }
+        }
+
+        if (status.latestReleaseStatus !== 'ready' || status.latestVersion !== body.targetVersion) {
+          return {
+            status: 409 as const,
+            body: {
+              error: 'CONFLICT',
+              message:
+                status.latestReleaseStatus === 'preparing' && status.pendingReleaseVersion
+                  ? `Release ${status.pendingReleaseVersion} is still being prepared. Wait for the release workflow to finish, then refresh updates.`
+                  : `Target version ${body.targetVersion} is not available as an installable Sentinel release yet.`,
             },
           }
         }

--- a/apps/backend/src/services/system-update-status-service.test.ts
+++ b/apps/backend/src/services/system-update-status-service.test.ts
@@ -32,6 +32,14 @@ describe('SystemUpdateStatusService', () => {
     })
   }
 
+  function createReleaseAssets(version = '2.6.7') {
+    return [
+      { name: 'build-info.env' },
+      { name: `sentinel-appliance_${version}_all.deb` },
+      { name: 'SHA256SUMS.txt' },
+    ]
+  }
+
   it('caches successful latest release lookups between status polls', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new globalThis.Response(
@@ -41,6 +49,7 @@ describe('SystemUpdateStatusService', () => {
           html_url: 'https://github.com/DeadshotOMEGA/sentinel/releases/tag/v2.6.7',
           published_at: '2026-04-23T14:00:00.000Z',
           body: '## Changelog\n\n- Added offline release notes.',
+          assets: createReleaseAssets(),
         }),
         {
           status: 200,
@@ -58,6 +67,7 @@ describe('SystemUpdateStatusService', () => {
     const secondStatus = await service.getStatus()
 
     expect(firstStatus.latestVersion).toBe('v2.6.7')
+    expect(firstStatus.latestReleaseStatus).toBe('ready')
     expect(firstStatus.latestReleaseNotes).toMatchObject({
       version: 'v2.6.7',
       title: 'Sentinel v2.6.7',
@@ -84,6 +94,7 @@ describe('SystemUpdateStatusService', () => {
             html_url: 'https://github.com/DeadshotOMEGA/sentinel/releases/tag/v2.6.7',
             published_at: '2026-04-23T14:00:00.000Z',
             body: '## Release notes\n\nCached for appliance operators.',
+            assets: createReleaseAssets(),
           }),
           {
             status: 200,
@@ -130,6 +141,7 @@ describe('SystemUpdateStatusService', () => {
           html_url: 'https://github.com/DeadshotOMEGA/sentinel/releases/tag/v2.6.9',
           published_at: '2026-04-23T14:00:00.000Z',
           body: 'Stored release notes.',
+          assets: createReleaseAssets('2.6.9'),
         }),
         { status: 200 }
       )
@@ -150,6 +162,7 @@ describe('SystemUpdateStatusService', () => {
           JSON.stringify({
             tag_name: 'v2.6.7',
             html_url: 'https://github.com/DeadshotOMEGA/sentinel/releases/tag/v2.6.7',
+            assets: createReleaseAssets(),
           }),
           {
             status: 200,
@@ -164,6 +177,7 @@ describe('SystemUpdateStatusService', () => {
           JSON.stringify({
             tag_name: 'v2.6.8',
             html_url: 'https://github.com/DeadshotOMEGA/sentinel/releases/tag/v2.6.8',
+            assets: createReleaseAssets('2.6.8'),
           }),
           {
             status: 200,
@@ -214,5 +228,31 @@ describe('SystemUpdateStatusService', () => {
     await vi.advanceTimersByTimeAsync(61 * 1000)
     await service.getStatus()
     expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not offer a GitHub release until appliance install assets are present', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new globalThis.Response(
+        JSON.stringify({
+          tag_name: 'v2.6.10',
+          name: 'Sentinel v2.6.10',
+          html_url: 'https://github.com/DeadshotOMEGA/sentinel/releases/tag/v2.6.10',
+          published_at: '2026-04-23T14:00:00.000Z',
+          body: 'Release workflow is still uploading assets.',
+          assets: [{ name: 'build-info.env' }],
+        }),
+        { status: 200 }
+      )
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const service = await createService()
+    const status = await service.getStatus()
+
+    expect(status.latestVersion).toBeNull()
+    expect(status.pendingReleaseVersion).toBe('v2.6.10')
+    expect(status.latestReleaseStatus).toBe('preparing')
+    expect(status.updateAvailable).toBe(false)
+    expect(status.latestReleaseStatusMessage).toContain('still being created')
   })
 })

--- a/apps/backend/src/services/system-update-status-service.ts
+++ b/apps/backend/src/services/system-update-status-service.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path'
 import type {
   SystemUpdateJob,
   SystemUpdateReleaseNotes,
+  SystemUpdateReleaseStatus,
   SystemUpdateStatusResponse,
 } from '@sentinel/contracts'
 import { serviceLogger } from '../lib/logger.js'
@@ -21,9 +22,13 @@ const DEFAULT_RELEASE_LOOKUP_ERROR_CACHE_TTL_MS = 60 * 1000
 const MAX_RELEASE_LOOKUP_ERROR_CACHE_TTL_MS = 60 * 60 * 1000
 const RELEASE_NOTES_CACHE_FILENAME = 'release-notes-cache.json'
 const MAX_RELEASE_NOTES_BODY_LENGTH = 100_000
+const REQUIRED_RELEASE_ASSET_NAMES = ['build-info.env', 'SHA256SUMS.txt'] as const
 
 interface LatestReleaseSummary {
   latestVersion: string | null
+  pendingReleaseVersion: string | null
+  latestReleaseStatus: SystemUpdateReleaseStatus
+  latestReleaseStatusMessage: string | null
   latestReleaseUrl: string | null
   latestReleaseNotes: SystemUpdateReleaseNotes | null
 }
@@ -92,11 +97,19 @@ export class SystemUpdateStatusService {
       resolveServiceVersionTag() ??
       currentJob?.currentVersion ??
       null
-    const latestVersion = releaseSummary.latestVersion ?? currentJob?.latestVersion ?? null
+    const latestVersion =
+      releaseSummary.latestReleaseStatus === 'ready'
+        ? releaseSummary.latestVersion
+        : releaseSummary.latestReleaseStatus === 'unavailable'
+          ? (currentJob?.latestVersion ?? null)
+          : null
 
     return {
       currentVersion,
       latestVersion,
+      pendingReleaseVersion: releaseSummary.pendingReleaseVersion,
+      latestReleaseStatus: releaseSummary.latestReleaseStatus,
+      latestReleaseStatusMessage: releaseSummary.latestReleaseStatusMessage,
       latestReleaseUrl: releaseSummary.latestReleaseUrl,
       latestReleaseNotes: releaseSummary.latestReleaseNotes,
       updateAvailable:
@@ -148,6 +161,17 @@ export class SystemUpdateStatusService {
     return this.readJobFromPath(join(this.stateRoot, 'jobs', `${jobId}.json`))
   }
 
+  private async buildUnavailableReleaseSummary(message: string): Promise<LatestReleaseSummary> {
+    return {
+      latestVersion: null,
+      pendingReleaseVersion: null,
+      latestReleaseStatus: 'unavailable',
+      latestReleaseStatusMessage: message,
+      latestReleaseUrl: null,
+      latestReleaseNotes: await this.readCachedReleaseNotes(),
+    }
+  }
+
   private async readCurrentJob(): Promise<SystemUpdateJob | null> {
     return this.readJobFromPath(join(this.stateRoot, 'current-job.json'))
   }
@@ -182,11 +206,7 @@ export class SystemUpdateStatusService {
   }): Promise<LatestReleaseSummary> {
     const repository = this.releaseRepository.trim()
     if (repository.length === 0) {
-      return {
-        latestVersion: null,
-        latestReleaseUrl: null,
-        latestReleaseNotes: await this.readCachedReleaseNotes(),
-      }
+      return this.buildUnavailableReleaseSummary('Release lookup is disabled on this appliance.')
     }
 
     const forceRefresh = options?.forceRefresh === true
@@ -237,11 +257,7 @@ export class SystemUpdateStatusService {
         })
 
         return {
-          summary: {
-            latestVersion: null,
-            latestReleaseUrl: null,
-            latestReleaseNotes: await this.readCachedReleaseNotes(),
-          },
+          summary: await this.buildUnavailableReleaseSummary('Latest release lookup failed.'),
           cacheTtlMs: this.getReleaseLookupErrorCacheTtl(response),
         }
       }
@@ -249,35 +265,72 @@ export class SystemUpdateStatusService {
       const payload: unknown = await response.json()
       if (!isRecord(payload)) {
         return {
-          summary: {
-            latestVersion: null,
-            latestReleaseUrl: null,
-            latestReleaseNotes: await this.readCachedReleaseNotes(),
-          },
+          summary: await this.buildUnavailableReleaseSummary(
+            'Latest release response was not valid.'
+          ),
           cacheTtlMs: this.latestReleaseCacheTtlMs,
         }
       }
 
       const tagName = typeof payload.tag_name === 'string' ? payload.tag_name.trim() : ''
-      const latestVersion = isStableVersionTag(tagName) ? tagName : null
       const latestReleaseUrl = typeof payload.html_url === 'string' ? payload.html_url : null
-      const latestReleaseNotes =
-        latestVersion === null
-          ? await this.readCachedReleaseNotes()
-          : await this.buildAndPersistReleaseNotes({
-              version: latestVersion,
-              title: typeof payload.name === 'string' ? payload.name.trim() || null : null,
-              url: latestReleaseUrl,
-              publishedAt:
-                typeof payload.published_at === 'string'
-                  ? payload.published_at.trim() || null
-                  : null,
-              body: typeof payload.body === 'string' ? payload.body : '',
-            })
+      const isStableRelease = isStableVersionTag(tagName)
+      const latestReleaseNotes = !isStableRelease
+        ? await this.readCachedReleaseNotes()
+        : await this.buildAndPersistReleaseNotes({
+            version: tagName,
+            title: typeof payload.name === 'string' ? payload.name.trim() || null : null,
+            url: latestReleaseUrl,
+            publishedAt:
+              typeof payload.published_at === 'string' ? payload.published_at.trim() || null : null,
+            body: typeof payload.body === 'string' ? payload.body : '',
+          })
+
+      if (!isStableRelease) {
+        return {
+          summary: {
+            latestVersion: null,
+            pendingReleaseVersion: null,
+            latestReleaseStatus: 'unavailable',
+            latestReleaseStatusMessage: 'Latest GitHub release is not a stable Sentinel version.',
+            latestReleaseUrl,
+            latestReleaseNotes,
+          },
+          cacheTtlMs: this.latestReleaseCacheTtlMs,
+        }
+      }
+
+      const releaseAssetNames = this.getReleaseAssetNames(payload)
+      if (!this.hasInstallableReleaseAssets(releaseAssetNames)) {
+        serviceLogger.info(
+          'Latest Sentinel release is published but install assets are not ready',
+          {
+            repository,
+            tagName,
+            releaseAssetNames,
+          }
+        )
+
+        return {
+          summary: {
+            latestVersion: null,
+            pendingReleaseVersion: tagName,
+            latestReleaseStatus: 'preparing',
+            latestReleaseStatusMessage:
+              'GitHub has published the release record, but the appliance package assets are still being created.',
+            latestReleaseUrl,
+            latestReleaseNotes,
+          },
+          cacheTtlMs: this.latestReleaseErrorCacheTtlMs,
+        }
+      }
 
       return {
         summary: {
-          latestVersion,
+          latestVersion: tagName,
+          pendingReleaseVersion: null,
+          latestReleaseStatus: 'ready',
+          latestReleaseStatusMessage: 'Latest stable release is ready to install.',
           latestReleaseUrl,
           latestReleaseNotes,
         },
@@ -290,11 +343,9 @@ export class SystemUpdateStatusService {
       })
 
       return {
-        summary: {
-          latestVersion: null,
-          latestReleaseUrl: null,
-          latestReleaseNotes: await this.readCachedReleaseNotes(),
-        },
+        summary: await this.buildUnavailableReleaseSummary(
+          'Latest release lookup raised an error.'
+        ),
         cacheTtlMs: this.latestReleaseErrorCacheTtlMs,
       }
     }
@@ -320,6 +371,31 @@ export class SystemUpdateStatusService {
       this.latestReleaseErrorCacheTtlMs,
       Math.min(resetDelayMs, MAX_RELEASE_LOOKUP_ERROR_CACHE_TTL_MS)
     )
+  }
+
+  private getReleaseAssetNames(payload: Record<string, unknown>): string[] {
+    if (!Array.isArray(payload.assets)) {
+      return []
+    }
+
+    return payload.assets
+      .map((asset) => {
+        if (!isRecord(asset)) {
+          return null
+        }
+
+        const name = typeof asset.name === 'string' ? asset.name.trim() : ''
+        return name.length > 0 ? name : null
+      })
+      .filter((name): name is string => name !== null)
+  }
+
+  private hasInstallableReleaseAssets(assetNames: readonly string[]): boolean {
+    const assetNameSet = new Set(assetNames)
+    const hasRequiredAssets = REQUIRED_RELEASE_ASSET_NAMES.every((name) => assetNameSet.has(name))
+    const hasDebPackage = assetNames.some((name) => name.endsWith('.deb'))
+
+    return hasRequiredAssets && hasDebPackage
   }
 
   private async readApplianceCurrentVersion(): Promise<string | null> {

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/components/admin/admin-control-center.tsx
+++ b/apps/frontend-admin/src/components/admin/admin-control-center.tsx
@@ -376,6 +376,17 @@ function getUpdateTelemetry(updateStatus: SystemUpdateStatusResponse | null): Ad
     }
   }
 
+  if (updateStatus.latestReleaseStatus === 'preparing') {
+    return {
+      value: updateStatus.pendingReleaseVersion
+        ? `Preparing ${updateStatus.pendingReleaseVersion}`
+        : 'Release preparing',
+      detail: 'GitHub is still building the appliance package.',
+      badge: 'Wait',
+      badgeStatus: 'warning',
+    }
+  }
+
   return {
     value: updateStatus.currentVersion ?? 'Current',
     detail: 'No pending update action.',
@@ -459,6 +470,19 @@ function getUpdateActionableSignal(
       href: '/admin/updates',
       routeId: 'updates',
       badge: 'Ready',
+      badgeStatus: 'warning',
+    }
+  }
+
+  if (updateStatus.latestReleaseStatus === 'preparing') {
+    return {
+      id: 'pending-update',
+      label: 'Pending update',
+      value: updateStatus.pendingReleaseVersion ?? 'Preparing',
+      detail: 'Release assets are still being created.',
+      href: '/admin/updates',
+      routeId: 'updates',
+      badge: 'Wait',
       badgeStatus: 'warning',
     }
   }

--- a/apps/frontend-admin/src/components/settings/system-update-panel.logic.test.ts
+++ b/apps/frontend-admin/src/components/settings/system-update-panel.logic.test.ts
@@ -352,6 +352,8 @@ describe('system-update-panel logic', () => {
         status: {
           currentVersion: 'v2.6.6',
           latestVersion: 'v2.6.8',
+          pendingReleaseVersion: null,
+          latestReleaseStatus: 'ready',
           updateAvailable: true,
           currentJob: null,
         },
@@ -360,6 +362,23 @@ describe('system-update-panel logic', () => {
       tone: 'info',
       headline: 'A newer Sentinel release is available',
       badge: 'Update available',
+    })
+
+    expect(
+      getUpdateHeroView({
+        status: {
+          currentVersion: 'v2.6.8',
+          latestVersion: null,
+          pendingReleaseVersion: 'v2.6.9',
+          latestReleaseStatus: 'preparing',
+          updateAvailable: false,
+          currentJob: null,
+        },
+      })
+    ).toMatchObject({
+      tone: 'warning',
+      headline: 'A release is being prepared',
+      badge: 'Preparing',
     })
 
     expect(

--- a/apps/frontend-admin/src/components/settings/system-update-panel.logic.ts
+++ b/apps/frontend-admin/src/components/settings/system-update-panel.logic.ts
@@ -324,7 +324,8 @@ export function getUpdateHeroView(input: {
   status: Pick<
     SystemUpdateStatusResponse,
     'currentVersion' | 'latestVersion' | 'updateAvailable' | 'currentJob'
-  >
+  > &
+    Partial<Pick<SystemUpdateStatusResponse, 'pendingReleaseVersion' | 'latestReleaseStatus'>>
 }): SystemUpdateHeroView {
   const { status } = input
   const job = status.currentJob
@@ -353,9 +354,9 @@ export function getUpdateHeroView(input: {
     return {
       tone: 'success',
       icon: 'check',
-      headline: `Sentinel updated to ${job.targetVersion}`,
+      headline: 'Sentinel is up to date',
       message:
-        'Version installed successfully. No action is needed until a newer release is published.',
+        'Last update installed successfully. No action is needed until a newer release is ready.',
       badge: 'Updated',
     }
   }
@@ -395,13 +396,23 @@ export function getUpdateHeroView(input: {
     }
   }
 
+  if (status.latestReleaseStatus === 'preparing') {
+    return {
+      tone: 'warning',
+      icon: 'clock',
+      headline: 'A release is being prepared',
+      message: status.pendingReleaseVersion
+        ? `Sentinel ${status.pendingReleaseVersion} is still building its appliance package. Refresh after the release workflow finishes.`
+        : 'GitHub is still building the appliance package for the newest Sentinel release.',
+      badge: 'Preparing',
+    }
+  }
+
   return {
     tone: 'success',
     icon: 'check',
     headline: 'Sentinel is up to date',
-    message: status.currentVersion
-      ? `Version ${status.currentVersion} is installed successfully.`
-      : 'The installed Sentinel version is current.',
+    message: 'Installed version matches the latest ready release.',
     badge: 'Current',
   }
 }

--- a/apps/frontend-admin/src/components/settings/system-update-panel.tsx
+++ b/apps/frontend-admin/src/components/settings/system-update-panel.tsx
@@ -218,19 +218,25 @@ export function SystemUpdatePanel() {
   const preferredTargetVersion = status ? getPreferredUpdateTargetVersion(status, currentJob) : null
   const phaseProgress = getSystemUpdatePhaseProgress(currentJob)
   const cachedReleaseNotes = status?.latestReleaseNotes ?? null
+  const releasePreparing = status?.latestReleaseStatus === 'preparing'
   const retryingLastTarget =
-    status !== null && status.latestVersion === null && preferredTargetVersion !== null
+    status !== null &&
+    status.latestVersion === null &&
+    preferredTargetVersion !== null &&
+    !releasePreparing
   const startActionLabel = hasActiveJob
     ? 'Update in progress'
     : !canStartUpdates
       ? 'Admin required'
-      : preferredTargetVersion === null
-        ? status?.latestVersion === null
-          ? 'No update target'
-          : 'Up to date'
-        : retryingLastTarget
-          ? `Retry ${preferredTargetVersion}`
-          : `Update to ${preferredTargetVersion}`
+      : releasePreparing
+        ? 'Release preparing'
+        : preferredTargetVersion === null
+          ? status?.latestVersion === null
+            ? 'No update target'
+            : 'Up to date'
+          : retryingLastTarget
+            ? `Retry ${preferredTargetVersion}`
+            : `Update to ${preferredTargetVersion}`
   const confirmActionLabel =
     preferredTargetVersion === null
       ? 'Start update'
@@ -240,6 +246,7 @@ export function SystemUpdatePanel() {
   const canStartNow =
     canStartUpdates &&
     preferredTargetVersion !== null &&
+    !releasePreparing &&
     !hasActiveJob &&
     !startSystemUpdate.isPending
   const traceQuery = useSystemUpdateTrace({
@@ -425,6 +432,18 @@ export function SystemUpdatePanel() {
   const lastUpdateTime = currentJob
     ? (currentJob.finishedAt ?? currentJob.startedAt ?? currentJob.requestedAt)
     : null
+  const releaseCardValue =
+    status.updateAvailable && status.latestVersion
+      ? status.latestVersion
+      : releasePreparing && status.pendingReleaseVersion
+        ? status.pendingReleaseVersion
+        : 'No newer release'
+  const releaseCardDetail = status.updateAvailable
+    ? 'Ready to install on this appliance.'
+    : releasePreparing
+      ? (status.latestReleaseStatusMessage ??
+        'Release workflow is still creating appliance assets.')
+      : 'Stable channel matches the installed version.'
 
   return (
     <div className="space-y-(--space-5)" data-testid={TID.settings.updates.panel}>
@@ -544,6 +563,13 @@ export function SystemUpdatePanel() {
             </AppAlert>
           )}
 
+          {releasePreparing && (
+            <AppAlert tone="warning" heading="Release package is still being built">
+              {status.latestReleaseStatusMessage ??
+                'Refresh this page after the GitHub release workflow finishes. The update button will stay disabled until the appliance package is attached.'}
+            </AppAlert>
+          )}
+
           <section className="grid min-w-0 gap-(--space-3) xl:grid-cols-4">
             <div className="rounded-box border-l-4 border-neutral/35 bg-base-200/85 p-(--space-5) shadow-[var(--shadow-2)] xl:col-span-2">
               <div className="min-w-0">
@@ -555,12 +581,21 @@ export function SystemUpdatePanel() {
                   {status.currentVersion ?? 'Unknown'}
                 </p>
                 <div className="mt-(--space-2) flex w-fit flex-wrap items-center gap-(--space-2)">
-                  <AppBadge status={status.updateAvailable ? 'info' : 'success'} size="sm">
-                    {status.updateAvailable ? 'Update ready' : 'Current'}
+                  <AppBadge
+                    status={
+                      releasePreparing ? 'warning' : status.updateAvailable ? 'info' : 'success'
+                    }
+                    size="sm"
+                  >
+                    {releasePreparing
+                      ? 'Release preparing'
+                      : status.updateAvailable
+                        ? 'Update ready'
+                        : 'Current'}
                   </AppBadge>
                   <span className="text-xs font-medium text-base-content/62">
                     {status.updateAvailable
-                      ? 'A newer stable release is ready.'
+                      ? `Installed version; ${status.latestVersion} is ready.`
                       : 'Installed Sentinel package/runtime version.'}
                   </span>
                 </div>
@@ -591,10 +626,13 @@ export function SystemUpdatePanel() {
             <div className="rounded-box bg-base-100 p-(--space-4) shadow-[var(--shadow-1)] xl:col-span-2">
               <p className="flex items-center gap-(--space-2) text-[0.68rem] font-semibold uppercase tracking-wide text-base-content/50">
                 <Download className="h-4 w-4" />
-                Latest stable
+                Release channel
               </p>
               <p className="mt-(--space-2) break-all font-mono text-2xl font-bold text-base-content">
-                {status.latestVersion ?? 'Unknown'}
+                {releaseCardValue}
+              </p>
+              <p className="mt-(--space-1) text-xs font-medium leading-relaxed text-base-content/55">
+                {releaseCardDetail}
               </p>
               <p className="mt-(--space-1) text-xs font-medium text-base-content/55">
                 {cachedReleaseNotes ? (

--- a/apps/frontend-admin/src/lib/admin-issues.test.ts
+++ b/apps/frontend-admin/src/lib/admin-issues.test.ts
@@ -58,6 +58,9 @@ function createUpdateStatus(
   return {
     currentVersion: 'v2.8.2',
     latestVersion: 'v2.8.2',
+    pendingReleaseVersion: null,
+    latestReleaseStatus: 'ready',
+    latestReleaseStatusMessage: 'Latest stable release is ready to install.',
     latestReleaseUrl: null,
     latestReleaseNotes: null,
     updateAvailable: false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/contracts/src/schemas/system-update.schema.ts
+++ b/packages/contracts/src/schemas/system-update.schema.ts
@@ -105,9 +105,17 @@ export const SystemUpdateReleaseNotesSchema = v.object({
   body: v.string(),
 })
 
+export const SystemUpdateReleaseStatusSchema = v.picklist(
+  ['ready', 'preparing', 'unavailable'],
+  'Choose a valid system update release status'
+)
+
 export const SystemUpdateStatusResponseSchema = v.object({
   currentVersion: NullableVersionSchema,
   latestVersion: NullableVersionSchema,
+  pendingReleaseVersion: NullableVersionSchema,
+  latestReleaseStatus: SystemUpdateReleaseStatusSchema,
+  latestReleaseStatusMessage: v.nullable(v.string()),
   latestReleaseUrl: v.nullable(v.string()),
   latestReleaseNotes: v.nullable(SystemUpdateReleaseNotesSchema),
   updateAvailable: v.boolean(),
@@ -156,6 +164,7 @@ export type SystemUpdateCheckpoint = v.InferOutput<typeof SystemUpdateCheckpoint
 export type SystemUpdateRequestedBy = v.InferOutput<typeof SystemUpdateRequestedBySchema>
 export type SystemUpdateJob = v.InferOutput<typeof SystemUpdateJobSchema>
 export type SystemUpdateReleaseNotes = v.InferOutput<typeof SystemUpdateReleaseNotesSchema>
+export type SystemUpdateReleaseStatus = v.InferOutput<typeof SystemUpdateReleaseStatusSchema>
 export type SystemUpdateStatusResponse = v.InferOutput<typeof SystemUpdateStatusResponseSchema>
 export type SystemUpdateStatusQuery = v.InferOutput<typeof SystemUpdateStatusQuerySchema>
 export type SystemUpdateTraceResponse = v.InferOutput<typeof SystemUpdateTraceResponseSchema>

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Prevents Sentinel from offering or starting a release update until GitHub has attached the installable appliance assets.
- Adds a clear "Release preparing" state when a GitHub Release exists but the release workflow is still building or uploading artifacts.
- Simplifies the Updates page so the installed version is not repeated in the hero, release channel, and action area at the same time.
- Prepares Sentinel v3.2.8 for the appliance update flow.

## Why this change was needed

The Updates page could see a newly published GitHub Release before the release workflow had finished uploading the appliance package. Operators could click update during that window and the updater would fail because the release was not actually installable yet. The page also repeated the same version number in several places and used similar success treatment for current and update-ready states, which made the update state harder to scan.

## What changed

### User-facing

- The up-to-date hero now says "Sentinel is up to date" instead of repeating the installed version.
- The release card is now "Release channel" and shows "No newer release", the installable target version, or the preparing version.
- When an update is ready, the primary action remains "Update to vX.Y.Z".
- When GitHub is still preparing release assets, the primary action is disabled as "Release preparing" with a warning explaining what is happening.

### Admin/operator-facing

- Admin overview update telemetry now shows a "Preparing" / "Wait" state while release assets are still being created.
- Operators should refresh after the GitHub release workflow finishes; Sentinel will enable the update only after the installable artifacts are attached.

### Backend/API

- The system update status response now includes `latestReleaseStatus`, `latestReleaseStatusMessage`, and `pendingReleaseVersion`.
- Latest release lookup only reports a release as installable when `build-info.env`, `SHA256SUMS.txt`, and a `.deb` package are attached to the GitHub Release.
- Starting an update force-refreshes release readiness and returns a conflict instead of queuing the update if the release is still preparing or unavailable.

### Database

- No database changes.

### Deployment/update

- Bumps Sentinel package versions to `3.2.8`.
- No environment or appliance configuration changes are required.

### Tests

- Added backend coverage for preparing releases without complete install assets.
- Added route coverage to reject update starts while assets are still preparing.
- Added frontend logic coverage for the preparing hero state and updated status fixtures.

## User impact

Admin users get clearer update status and fewer repeated version labels. They will no longer be offered a working update button while a GitHub release is only partially published.

## Operator impact

Appliance operators should see fewer update failures immediately after a new release tag is pushed. The update button becomes available only when the release package is ready.

## Upgrade or migration notes

No upgrade action required beyond installing the v3.2.8 appliance update. No database migration or configuration change is required.

## Risk and rollback notes

The main risk is being too strict about required release asset names. This matches the current release workflow outputs: `build-info.env`, `SHA256SUMS.txt`, and the appliance `.deb`. Rollback is safe through the standard appliance rollback flow because this release does not change the database schema.

## Testing performed

- `pnpm --filter @sentinel/backend typecheck`
- `pnpm --filter frontend-admin typecheck`
- `pnpm --filter @sentinel/backend lint` (passes with existing warnings only)
- `pnpm --filter frontend-admin lint` (passes with existing warnings only)
- `apps/frontend-admin/node_modules/.bin/vitest run apps/backend/src/services/system-update-status-service.test.ts apps/backend/src/routes/system-update.test.ts apps/frontend-admin/src/components/settings/system-update-panel.logic.test.ts apps/frontend-admin/src/lib/admin-issues.test.ts`
- `git diff --check`
- Playwright visual sanity at 1920x1080 for current, ready update, and release preparing states

## Changelog candidates

- Fixed update availability so Sentinel waits for installable GitHub Release assets before offering or starting an appliance update.
- Added a clear "Release preparing" state on the Updates page when GitHub is still building the release package.
- Reduced repeated version labels on the Updates page so current and update-ready states are easier to scan.
