### PR TITLE
fix: match dashboard duty watch tags to schedule

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/components/dashboard/status-stats.tsx
+++ b/apps/frontend-admin/src/components/dashboard/status-stats.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
 import {
   Users,
@@ -18,6 +18,7 @@ import {
 import type { DutyWatchTeamResponse } from '@sentinel/contracts'
 import { useDdsStatus } from '@/hooks/use-dds'
 import { useCheckoutOptions, useLockupStatus } from '@/hooks/use-lockup'
+import { useQualificationTypes } from '@/hooks/use-qualifications'
 import { useTonightDutyWatch } from '@/hooks/use-schedules'
 import { useAuthStore, AccountLevel } from '@/store/auth-store'
 import { SetTodayDdsModal } from '@/components/dashboard/set-today-dds-modal'
@@ -26,9 +27,38 @@ import { ExecuteLockupModal } from '@/components/lockup/execute-lockup-modal'
 import { OpenBuildingModal } from '@/components/lockup/open-building-modal'
 import { AppBadge } from '@/components/ui/AppBadge'
 import { Chip } from '@/components/ui/chip'
+import type { ChipColor, ChipVariant } from '@/components/ui/chip'
 import { MotionButton } from '@/components/ui/motion-button'
 import { TID } from '@/lib/test-ids'
 import { getDutyWatchCoverageSummary } from '@/lib/dashboard-member-actions'
+
+const DUTY_WATCH_POSITION_ORDER = ['SWK', 'DSWK', 'QM', 'BM', 'APS'] as const
+const DUTY_WATCH_POSITION_ORDER_INDEX = new Map<string, number>(
+  DUTY_WATCH_POSITION_ORDER.map((code, index) => [code, index])
+)
+
+function getDutyWatchPositionSortIndex(assignment: DutyWatchTeamResponse['team'][number]): number {
+  const code = assignment.position?.code
+  if (!code) return Number.MAX_SAFE_INTEGER
+  return DUTY_WATCH_POSITION_ORDER_INDEX.get(code.toUpperCase()) ?? Number.MAX_SAFE_INTEGER
+}
+
+function compareDutyWatchAssignments(
+  left: DutyWatchTeamResponse['team'][number],
+  right: DutyWatchTeamResponse['team'][number]
+): number {
+  const orderDifference = getDutyWatchPositionSortIndex(left) - getDutyWatchPositionSortIndex(right)
+  if (orderDifference !== 0) return orderDifference
+
+  const leftCode = left.position?.code ?? ''
+  const rightCode = right.position?.code ?? ''
+  if (leftCode !== rightCode) return leftCode.localeCompare(rightCode)
+
+  const lastNameDifference = left.member.lastName.localeCompare(right.member.lastName)
+  if (lastNameDifference !== 0) return lastNameDifference
+
+  return left.member.firstName.localeCompare(right.member.firstName)
+}
 
 function formatTime(dateStr: string | null): string {
   if (!dateStr) return 'N/A'
@@ -357,6 +387,25 @@ function LockupHolderStat({
 
 function DutyWatchStat() {
   const { data: dutyWatch, isLoading, isError } = useTonightDutyWatch()
+  const { data: qualificationTypes } = useQualificationTypes()
+  const qualChipStyleByCode = useMemo(() => {
+    const map = new Map<string, { variant: ChipVariant; color: ChipColor }>()
+    if (qualificationTypes) {
+      for (const qt of qualificationTypes) {
+        if (qt.tag) {
+          map.set(qt.code, {
+            variant: (qt.tag.chipVariant as ChipVariant) || 'solid',
+            color: (qt.tag.chipColor as ChipColor) || 'default',
+          })
+        }
+      }
+    }
+    return map
+  }, [qualificationTypes])
+  const team = useMemo(
+    () => [...(dutyWatch?.team || [])].sort(compareDutyWatchAssignments),
+    [dutyWatch?.team]
+  )
 
   // Don't render if not a Duty Watch night
   if (!isLoading && !isError && !dutyWatch?.isDutyWatchNight) {
@@ -389,7 +438,6 @@ function DutyWatchStat() {
     return null
   }
 
-  const team = dutyWatch.team || []
   const coverageSummary = getDutyWatchCoverageSummary(dutyWatch)
   const checkedInCount = coverageSummary.coveredCount
   const plannedCount = coverageSummary.plannedCount
@@ -450,6 +498,9 @@ function DutyWatchStat() {
             <ul className="list rounded-box bg-base-100">
               {team.map((assignment) => {
                 const positionLabel = getDutyWatchPositionLabel(assignment.position)
+                const chipStyle = assignment.position?.code
+                  ? qualChipStyleByCode.get(assignment.position.code)
+                  : undefined
                 const isCovered = assignment.isCheckedIn || Boolean(assignment.liveCoverage)
 
                 return (
@@ -460,8 +511,8 @@ function DutyWatchStat() {
                     <div className="min-w-20 shrink-0">
                       <Chip
                         size="sm"
-                        variant="faded"
-                        color="secondary"
+                        variant={chipStyle?.variant ?? 'flat'}
+                        color={chipStyle?.color ?? 'default'}
                         className="font-mono uppercase tracking-wide"
                         title={positionLabel.fullLabel}
                       >

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Fixes the Dashboard Duty Watch Tonight popup so duty position tags appear in the same order as the Schedule page.
- Reuses qualification tag styling for the popup chips so the tag colors match the configured Sentinel tags.
- Prepares Sentinel v3.2.9 as a patch release.

## Why this change was needed

The dashboard popup was showing duty watch positions in the backend response order and forced every position tag to the same secondary color. Operators comparing the dashboard with the Schedule page could see positions out of sequence and with the wrong visual tag styling.

## What changed

### User-facing

- The Duty Watch Tonight popup now shows positions in this order: SWK, DSWK, QM, BM, APS, APS.
- Position chips now use the configured qualification tag colors and variants.

### Admin/operator-facing

- Package versions were updated from 3.2.8 to 3.2.9 for the patch release.

### Backend/API

- No backend or API behavior changed.

### Database

- No database changes.

### Deployment/update

- Version metadata was synchronized across the monorepo for v3.2.9.

### Documentation

- No documentation changes.

### Tests

- Ran lint, typecheck, version sync validation, and a rendered dashboard sanity check.

## User impact

Dashboard users will see Duty Watch popup tags in the expected Schedule page order and with the proper configured colors.

## Operator impact

No operator action is required beyond the normal update process. The release is a frontend display fix plus version metadata.

## Upgrade or migration notes

No upgrade action required. No database migration or configuration change is required.

## Risk and rollback notes

The main risk is a mismatch if a future duty watch position code is added without updating the dashboard sort order. Unknown position codes fall back after the known duty watch positions. Rollback is safe because this change only affects frontend presentation and package version metadata.

## Testing performed

- `pnpm version:check`
- `pnpm --filter frontend-admin lint` (passes with existing warning backlog: 79 warnings, 0 errors)
- `pnpm --filter frontend-admin typecheck`
- Playwright CLI visual sanity check at `1920x1080` on `/dashboard`, confirming popup order `SWK, DSWK, QM, BM, APS, APS` and configured chip attributes.

## Changelog candidates

- Fixed the Dashboard Duty Watch Tonight popup so duty position tags match the Schedule page order and configured tag colors.
- Prepared Sentinel v3.2.9 as a patch release. No database migration or configuration change is required.