### PR TITLE
Prepare Sentinel v3.3.3

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/frontend-admin/README.md
+++ b/apps/frontend-admin/README.md
@@ -69,7 +69,7 @@ Create `.env.local` in `apps/frontend-admin`:
 NEXT_PUBLIC_API_URL=http://localhost:3000
 NEXT_PUBLIC_WS_URL=http://localhost:3000
 NEXT_PUBLIC_APP_PORT=3001
-NEXT_PUBLIC_WIKI_BASE_URL=http://localhost:3002
+NEXT_PUBLIC_WIKI_BASE_URL=http://docs.sentinel.local
 NEXT_PUBLIC_HELP_FALLBACK_MODE=hybrid
 NEXT_PUBLIC_HELP_PREVIEW_ENABLED=false
 NEXT_PUBLIC_HELP_DOCS_VERSION=latest

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/components/layout/app-navbar.logic.test.ts
+++ b/apps/frontend-admin/src/components/layout/app-navbar.logic.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { SystemStatusResponse } from '@sentinel/contracts'
-import { getWirelessRecoveryState } from './app-navbar.logic'
+import {
+  WIKI_APPLIANCE_URL,
+  getWirelessRecoveryState,
+  resolveWikiBaseUrl,
+} from './app-navbar.logic'
 
 function createSystemStatus(overrides?: Partial<SystemStatusResponse>): SystemStatusResponse {
   return {
@@ -56,6 +60,21 @@ function createSystemStatus(overrides?: Partial<SystemStatusResponse>): SystemSt
 }
 
 describe('app-navbar logic', () => {
+  it('uses the docs host when no Wiki URL is configured', () => {
+    expect(resolveWikiBaseUrl('')).toBe(WIKI_APPLIANCE_URL)
+  })
+
+  it('does not use local or legacy Wiki ports for the navbar link', () => {
+    expect(resolveWikiBaseUrl('http://localhost:3002')).toBe(WIKI_APPLIANCE_URL)
+    expect(resolveWikiBaseUrl('http://127.0.0.1:3002')).toBe(WIKI_APPLIANCE_URL)
+    expect(resolveWikiBaseUrl('http://sentinel.local:3020')).toBe(WIKI_APPLIANCE_URL)
+  })
+
+  it('keeps a configured docs host pointed at the docs root', () => {
+    expect(resolveWikiBaseUrl('http://docs.sentinel.local/')).toBe(WIKI_APPLIANCE_URL)
+    expect(resolveWikiBaseUrl('http://docs.sentinel.local')).toBe(WIKI_APPLIANCE_URL)
+  })
+
   it('does not show the laptop reconnect action for non-network issues', () => {
     const result = getWirelessRecoveryState({
       systemStatus: createSystemStatus({

--- a/apps/frontend-admin/src/components/layout/app-navbar.logic.ts
+++ b/apps/frontend-admin/src/components/layout/app-navbar.logic.ts
@@ -1,5 +1,11 @@
 import type { SystemStatusResponse } from '@sentinel/contracts'
 
+export const WIKI_APPLIANCE_URL = 'http://docs.sentinel.local/'
+
+const WIKI_APPLIANCE_HOST = 'docs.sentinel.local'
+const LOCAL_WIKI_HOSTS = new Set(['localhost', '127.0.0.1', '::1'])
+const LOCAL_OR_LEGACY_WIKI_PORTS = new Set(['3002', '3020'])
+
 export interface WirelessRecoveryState {
   showSection: boolean
   showConnectLaptop: boolean
@@ -45,5 +51,45 @@ export function getWirelessRecoveryState(input: {
     showRepairHostHotspot,
     primaryApprovedSsid,
     issueCode,
+  }
+}
+
+export function resolveWikiBaseUrl(configuredWikiBase: string): string {
+  const normalizedWikiBase = configuredWikiBase.trim().replace(/\/+$/, '')
+  if (!normalizedWikiBase) {
+    return WIKI_APPLIANCE_URL
+  }
+
+  const parsedWikiBase = safeParseUrl(normalizedWikiBase)
+  if (!parsedWikiBase) {
+    return WIKI_APPLIANCE_URL
+  }
+
+  if (isLocalWikiUrl(parsedWikiBase)) {
+    return WIKI_APPLIANCE_URL
+  }
+
+  if (isApplianceDocsRoot(parsedWikiBase)) {
+    return WIKI_APPLIANCE_URL
+  }
+
+  return normalizedWikiBase
+}
+
+function isApplianceDocsRoot(url: globalThis.URL): boolean {
+  return url.hostname.toLowerCase() === WIKI_APPLIANCE_HOST && url.pathname === '/' && !url.search
+}
+
+function isLocalWikiUrl(url: globalThis.URL): boolean {
+  return (
+    LOCAL_WIKI_HOSTS.has(url.hostname.toLowerCase()) || LOCAL_OR_LEGACY_WIKI_PORTS.has(url.port)
+  )
+}
+
+function safeParseUrl(value: string): globalThis.URL | null {
+  try {
+    return new globalThis.URL(value)
+  } catch {
+    return null
   }
 }

--- a/apps/frontend-admin/src/components/layout/app-navbar.tsx
+++ b/apps/frontend-admin/src/components/layout/app-navbar.tsx
@@ -22,7 +22,7 @@ import { useSystemStatus } from '@/hooks/use-system-status'
 import { useSystemUpdateStatus } from '@/hooks/use-system-update'
 import { TID } from '@/lib/test-ids'
 import { AccountLevel, useAuthStore } from '@/store/auth-store'
-import { getWirelessRecoveryState } from './app-navbar.logic'
+import { getWirelessRecoveryState, resolveWikiBaseUrl } from './app-navbar.logic'
 
 const navLinks = [
   { href: '/dashboard', label: 'Dashboard' },
@@ -37,8 +37,6 @@ interface AppNavbarProps {
   isDrawerOpen: boolean
 }
 
-const WIKI_APPLIANCE_FALLBACK_URL = 'http://docs.sentinel.local'
-const WIKI_LOCAL_DEV_PORT = '3002'
 const DEPLOYMENT_REMOTE_SYSTEM_CODE = 'deployment_laptop'
 
 export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
@@ -108,10 +106,7 @@ export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
   const networkSubtitle =
     systemStatus?.network.currentSsid ??
     (isDevelopmentEnvironment ? 'Local development host' : 'Host telemetry')
-  const wikiBaseUrl = resolveWikiBaseUrl(
-    process.env.NEXT_PUBLIC_WIKI_BASE_URL?.trim() ?? '',
-    browserOrigin
-  )
+  const wikiBaseUrl = resolveWikiBaseUrl(process.env.NEXT_PUBLIC_WIKI_BASE_URL?.trim() ?? '')
   const wikiLocation = stripUrlProtocol(wikiBaseUrl)
   const wikiStatus = getWikiStatus(wikiBaseUrl)
   const wikiValue = getWikiValue(wikiBaseUrl)
@@ -1084,38 +1079,6 @@ function formatBooleanLabel(value: boolean | null): string {
 
 function stripUrlProtocol(value: string): string {
   return value.replace(/^https?:\/\//, '')
-}
-
-function resolveWikiBaseUrl(configuredWikiBase: string, browserOrigin: string): string {
-  if (configuredWikiBase.length > 0) {
-    return configuredWikiBase.replace(/\/+$/, '')
-  }
-
-  const parsedOrigin = safeParseUrl(browserOrigin)
-  if (!parsedOrigin) {
-    return ''
-  }
-
-  const protocol = parsedOrigin?.protocol === 'https:' ? 'https:' : 'http:'
-  const hostname = parsedOrigin?.hostname?.toLowerCase() ?? ''
-  const isLocalHost = hostname === 'localhost' || hostname === '127.0.0.1'
-  const wikiUrl = new globalThis.URL(parsedOrigin.origin)
-
-  if (isLocalHost) {
-    wikiUrl.protocol = protocol
-    wikiUrl.port = WIKI_LOCAL_DEV_PORT
-    return wikiUrl.origin
-  }
-
-  return WIKI_APPLIANCE_FALLBACK_URL
-}
-
-function safeParseUrl(value: string) {
-  try {
-    return new globalThis.URL(value)
-  } catch {
-    return null
-  }
 }
 
 function isSystemUpdateJobTerminal(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Fixes the navbar Wiki link so it opens `http://docs.sentinel.local/` instead of a local development Wiki URL.
- Prevents old local or legacy Wiki targets such as `localhost:3002`, `127.0.0.1:3002`, and `sentinel.local:3020` from being used by the navbar link.
- Moves Wiki URL resolution into tested navbar logic so this behavior is covered by automated tests.
- Updates the frontend README sample environment to point new dev setups at the docs host.
- Bumps Sentinel package versions to `3.3.3` for the patch release.

## Why this change was needed

Admins were clicking the navbar Wiki link and being sent to a development Wiki target instead of the published Wiki.js documentation host. That made the new Dashboard help pages hard to reach from the main navigation.

## What changed

### User-facing

- The navbar `Wiki` link now resolves to `http://docs.sentinel.local/`.
- The System Status Wiki target display uses the same safer resolution logic.

### Admin/operator-facing

- Existing environment values that still point at local or legacy Wiki ports no longer make the navbar link open those old targets.
- Operators do not need to change database state or migrate data.

### Documentation

- The frontend README `.env.local` example now uses `NEXT_PUBLIC_WIKI_BASE_URL=http://docs.sentinel.local`.

### Tests

- Added navbar logic tests for missing, docs-host, local development, and legacy Wiki URL inputs.

## User impact

Admins will reach the published Sentinel Wiki.js documentation from the navbar. This directly fixes access to the Dashboard help pages from the main app shell.

## Operator impact

No manual operator action is required for the app fix. If a local development environment still has `NEXT_PUBLIC_WIKI_BASE_URL` set to a dev Wiki URL, the navbar now protects users from that value for known local and legacy ports.

## Upgrade or migration notes

No database migration is required. No required configuration change is introduced.

## Risk and rollback notes

Risk is limited to the navbar Wiki link and the Wiki row shown inside System Status. Rollback is safe by reverting this patch release; no persisted data format changes are included.

## Testing performed

- `pnpm version:check`
- `pnpm --filter frontend-admin exec vitest run src/components/layout/app-navbar.logic.test.ts`
- `pnpm --filter frontend-admin typecheck`
- `pnpm --filter frontend-admin lint` (passes with existing warnings)
- Playwright visual/link sanity check at `1920x1080` confirmed the navbar Wiki href is `http://docs.sentinel.local/` before release commits.

## Changelog candidates

- Fixed the navbar Wiki link so Admin users open `http://docs.sentinel.local/` instead of a development Wiki target.
- Added tests that prevent local or legacy Wiki URLs from being used by the navbar link.
- Updated the frontend README sample environment to use the published docs host.
