### PR TITLE
fix(network): separate internet Wi-Fi from Sentinel hotspot

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/services/system-status-service.test.ts
+++ b/apps/backend/src/services/system-status-service.test.ts
@@ -105,7 +105,7 @@ describe('SystemStatusService', () => {
     vi.useRealTimers()
   })
 
-  it('marks network status as warning when connected to an unapproved SSID', async () => {
+  it('marks network status as warning when connected to an unapproved internet SSID', async () => {
     const { service } = createService({
       approvedSsids: ['ShipNet'],
       telemetryResult: {
@@ -142,7 +142,7 @@ describe('SystemStatusService', () => {
     expect(result.network.approvedSsid).toBe(false)
     expect(result.network.currentSsid).toBe('Coffee-Shop')
     expect(result.network.hostIpAddress).toBe('192.168.8.1')
-    expect(result.network.message).toContain('unapproved Wi-Fi SSID')
+    expect(result.network.message).toContain('unapproved internet Wi-Fi SSID')
     expect(result.remoteSystems.sessions[0]?.ipAddress).toBe('192.168.0.20')
     expect(result.overall.status).toBe('warning')
   })
@@ -201,7 +201,7 @@ describe('SystemStatusService', () => {
           remoteTarget: null,
           remoteReachable: null,
           portalRecoveryLikely: false,
-          message: 'Connected to approved Wi-Fi network',
+          message: 'Connected to approved internet Wi-Fi',
         },
         error: null,
       },
@@ -213,8 +213,51 @@ describe('SystemStatusService', () => {
     expect(result.network.issueCode).toBe('none')
     expect(result.network.approvedSsid).toBe(true)
     expect(result.network.hostIpAddress).toBe('192.168.8.1')
-    expect(result.network.message).toBe('Connected to approved Wi-Fi network')
+    expect(result.network.message).toBe('Connected to approved internet Wi-Fi')
     expect(result.overall.status).toBe('healthy')
+  })
+
+  it('keeps network status healthy when only the Sentinel hotspot is active', async () => {
+    const { service } = createService({
+      approvedSsids: ['GC Public'],
+      telemetryResult: {
+        telemetry: {
+          generatedAt: new Date('2026-04-01T11:59:40.000Z'),
+          issueCode: 'none',
+          wifiConnected: true,
+          currentSsid: null,
+          hostIpAddress: '10.42.0.1',
+          hotspotProfilePresent: true,
+          hotspotAdapterApproved: true,
+          scanAdapterPresent: true,
+          hotspotDevice: 'wlxb8fbb3c4e8ae',
+          hotspotSsid: 'Stone Frigate',
+          hotspotScanDevice: 'wlp0s20f3',
+          hotspotSsidVisibleFromLaptop: true,
+          hotspotAdapterBusy: false,
+          internetWifiConnection: null,
+          internetWifiSsid: null,
+          internetReachable: false,
+          remoteTarget: null,
+          remoteReachable: null,
+          portalRecoveryLikely: false,
+          message: 'Sentinel hotspot is visible; internet Wi-Fi is not connected',
+        },
+        error: null,
+      },
+    })
+
+    const result = await service.getSystemStatus()
+
+    expect(result.network.status).toBe('healthy')
+    expect(result.network.issueCode).toBe('none')
+    expect(result.network.approvedSsid).toBeNull()
+    expect(result.network.currentSsid).toBeNull()
+    expect(result.network.hotspotSsid).toBe('Stone Frigate')
+    expect(result.network.hotspotSsidVisibleFromLaptop).toBe(true)
+    expect(result.network.message).toBe(
+      'Sentinel hotspot is visible; internet Wi-Fi is not connected'
+    )
   })
 
   it('marks network status warning when hotspot SSID is not visible from laptop Wi-Fi', async () => {
@@ -391,7 +434,7 @@ describe('SystemStatusService', () => {
           remoteTarget: null,
           remoteReachable: null,
           portalRecoveryLikely: false,
-          message: 'Connected to approved Wi-Fi network',
+          message: 'Connected to approved internet Wi-Fi',
         },
         error: null,
       },

--- a/apps/backend/src/services/system-status-service.ts
+++ b/apps/backend/src/services/system-status-service.ts
@@ -140,7 +140,7 @@ function resolveNetworkStatusMessage(input: {
     case 'wifi_disconnected':
       return 'Wi-Fi disconnected'
     case 'unapproved_ssid':
-      return 'Connected to an unapproved Wi-Fi SSID'
+      return 'Connected to an unapproved internet Wi-Fi SSID'
     case 'hotspot_profile_missing':
       return 'The managed Sentinel hotspot profile is missing.'
     case 'approved_hotspot_adapter_missing':
@@ -165,7 +165,7 @@ function resolveNetworkStatusMessage(input: {
   }
 
   if (input.approvedSsidsConfigured && input.approvedSsid === true) {
-    return 'Connected to approved Wi-Fi network'
+    return 'Connected to approved internet Wi-Fi'
   }
 
   if (input.fallbackMessage) {

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/components/admin/admin-control-center.tsx
+++ b/apps/frontend-admin/src/components/admin/admin-control-center.tsx
@@ -231,7 +231,7 @@ function getApprovedWifiTelemetry(
   if (network.wifiConnected === false) {
     return {
       value: 'Wi-Fi disconnected',
-      detail: `Expected ${network.approvedSsids[0] ?? 'approved network'}.`,
+      detail: `Expected internet Wi-Fi ${network.approvedSsids[0] ?? 'approved network'} when internet access is needed.`,
       badge: 'Check',
       badgeStatus: 'warning',
     }
@@ -240,7 +240,7 @@ function getApprovedWifiTelemetry(
   if (network.approvedSsid === true) {
     return {
       value: network.currentSsid ?? network.approvedSsids[0] ?? 'Approved network',
-      detail: 'Current workstation is on an approved network.',
+      detail: 'Host internet Wi-Fi is on an approved network.',
       badge: 'Approved',
       badgeStatus: 'success',
     }
@@ -248,16 +248,25 @@ function getApprovedWifiTelemetry(
 
   if (network.approvedSsid === false) {
     return {
-      value: network.currentSsid ?? 'Wrong SSID',
-      detail: `Expected ${network.approvedSsids[0] ?? 'approved network'}.`,
+      value: network.currentSsid ?? 'Wrong internet SSID',
+      detail: `Expected internet Wi-Fi ${network.approvedSsids[0] ?? 'approved network'}.`,
       badge: 'Check',
       badgeStatus: 'warning',
     }
   }
 
+  if (network.hotspotSsidVisibleFromLaptop === true) {
+    return {
+      value: 'Internet optional',
+      detail: `${network.hotspotSsid ?? 'Sentinel hotspot'} is visible; internet Wi-Fi is not required for Sentinel access.`,
+      badge: 'Optional',
+      badgeStatus: 'neutral',
+    }
+  }
+
   return {
-    value: network.currentSsid ?? 'Unverified',
-    detail: 'Wi-Fi approval could not be confirmed.',
+    value: network.currentSsid ?? 'Internet unverified',
+    detail: 'Internet Wi-Fi approval could not be confirmed.',
     badge: 'Unknown',
     badgeStatus: 'neutral',
   }

--- a/apps/frontend-admin/src/components/kiosk/kiosk-domain.test.ts
+++ b/apps/frontend-admin/src/components/kiosk/kiosk-domain.test.ts
@@ -1,6 +1,8 @@
 import type { SystemStatusResponse } from '@sentinel/contracts'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { getKioskConnectivityBadge } from './kiosk-domain'
+
+vi.mock('@/lib/api-client', () => ({ apiClient: {} }))
 
 function createSystemStatus(overrides?: Partial<SystemStatusResponse>): SystemStatusResponse {
   return {
@@ -79,6 +81,50 @@ describe('getKioskConnectivityBadge', () => {
     expect(badge).toMatchObject({
       status: 'error',
       label: 'DISCONNECTED',
+    })
+  })
+
+  it('does not treat the host internet Wi-Fi SSID as the kiosk Wi-Fi status', () => {
+    const badge = getKioskConnectivityBadge({
+      systemStatus: createSystemStatus({
+        network: {
+          ...createSystemStatus().network,
+          status: 'warning',
+          issueCode: 'unapproved_ssid',
+          currentSsid: 'Coffee-Shop',
+          approvedSsids: ['GC Public'],
+          approvedSsid: false,
+          message: 'Connected to an unapproved internet Wi-Fi SSID',
+        },
+      }),
+      isLoading: false,
+      isError: false,
+    })
+
+    expect(badge).toMatchObject({
+      status: 'success',
+      label: 'CONNECTED',
+    })
+  })
+
+  it('surfaces host hotspot warnings without saying the kiosk is off Wi-Fi', () => {
+    const badge = getKioskConnectivityBadge({
+      systemStatus: createSystemStatus({
+        network: {
+          ...createSystemStatus().network,
+          status: 'warning',
+          issueCode: 'hotspot_not_visible',
+          hotspotSsidVisibleFromLaptop: false,
+          message: 'Hotspot SSID "Stone Frigate" is not visible from the laptop Wi-Fi adapter',
+        },
+      }),
+      isLoading: false,
+      isError: false,
+    })
+
+    expect(badge).toMatchObject({
+      status: 'warning',
+      label: 'CONNECTED (HOTSPOT WARNING)',
     })
   })
 })

--- a/apps/frontend-admin/src/components/kiosk/kiosk-domain.ts
+++ b/apps/frontend-admin/src/components/kiosk/kiosk-domain.ts
@@ -397,6 +397,13 @@ export function getKioskConnectivityBadge({
   }
 
   const network = systemStatus.network
+  const hotspotIssueCodes = new Set<SystemStatusResponse['network']['issueCode']>([
+    'hotspot_profile_missing',
+    'approved_hotspot_adapter_missing',
+    'hotspot_adapter_busy',
+    'scan_adapter_missing',
+    'hotspot_not_visible',
+  ])
 
   if (!network.telemetryAvailable) {
     return {
@@ -406,19 +413,11 @@ export function getKioskConnectivityBadge({
     }
   }
 
-  if (network.wifiConnected === false) {
-    return {
-      status: 'error',
-      label: 'WIFI DISCONNECTED',
-      detail: 'Backend link is unhealthy because the host Wi-Fi is disconnected.',
-    }
-  }
-
-  if (network.approvedSsids.length > 0 && network.approvedSsid === false) {
+  if (hotspotIssueCodes.has(network.issueCode)) {
     return {
       status: 'warning',
-      label: 'OFF SENTINEL WIFI',
-      detail: `Backend reachable, but current SSID (${network.currentSsid ?? 'unknown'}) is not approved.`,
+      label: 'CONNECTED (HOTSPOT WARNING)',
+      detail: network.message,
     }
   }
 
@@ -433,7 +432,7 @@ export function getKioskConnectivityBadge({
   return {
     status: 'success',
     label: 'CONNECTED',
-    detail: 'Backend is reachable on an approved Sentinel Wi-Fi context.',
+    detail: 'Backend is reachable from this kiosk.',
   }
 }
 

--- a/apps/frontend-admin/src/components/layout/app-navbar.tsx
+++ b/apps/frontend-admin/src/components/layout/app-navbar.tsx
@@ -104,8 +104,11 @@ export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
     isDevelopmentEnvironment
   )
   const networkSubtitle =
-    systemStatus?.network.currentSsid ??
-    (isDevelopmentEnvironment ? 'Local development host' : 'Host telemetry')
+    (systemStatus?.network.currentSsid
+      ? `Internet: ${systemStatus.network.currentSsid}`
+      : systemStatus?.network.hotspotSsid
+        ? `Hotspot: ${systemStatus.network.hotspotSsid}`
+        : null) ?? (isDevelopmentEnvironment ? 'Local development host' : 'Host telemetry')
   const wikiBaseUrl = resolveWikiBaseUrl(process.env.NEXT_PUBLIC_WIKI_BASE_URL?.trim() ?? '')
   const wikiLocation = stripUrlProtocol(wikiBaseUrl)
   const wikiStatus = getWikiStatus(wikiBaseUrl)
@@ -294,7 +297,7 @@ export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
                     </dd>
                   </div>
                   <div className="flex items-center justify-between gap-2">
-                    <dt>Approved SSID</dt>
+                    <dt>Approved internet</dt>
                     <dd className="font-mono text-right">
                       {systemStatus?.network.approvedSsids[0] ?? 'Not configured'}
                     </dd>
@@ -512,7 +515,7 @@ function formatNetworkIssueLabel(
     case 'wifi_disconnected':
       return 'Wi-Fi disconnected'
     case 'unapproved_ssid':
-      return 'Wrong SSID'
+      return 'Internet SSID'
     case 'hotspot_profile_missing':
       return 'Profile missing'
     case 'approved_hotspot_adapter_missing':
@@ -621,9 +624,9 @@ function getWirelessRecoveryCopy(
   const hotspotSsidLabel = systemStatus.network.hotspotSsid ?? 'the hosted Sentinel hotspot'
   switch (systemStatus.network.issueCode) {
     case 'wifi_disconnected':
-      return `Reconnect this laptop to ${approvedSsidLabel}, then requeue a host repair if the hotspot still needs attention.`
+      return `Internet Wi-Fi is disconnected. Reconnect this laptop to ${approvedSsidLabel} if internet access is needed, then requeue a host repair if the hotspot still needs attention.`
     case 'unapproved_ssid':
-      return `This laptop is on the wrong SSID. Reconnect it to ${approvedSsidLabel}, or requeue a host repair if the hotspot needs to be rebuilt.`
+      return `The host is connected to an unapproved internet Wi-Fi SSID. Use ${approvedSsidLabel} for internet access, or requeue a host repair if the Sentinel hotspot needs to be rebuilt.`
     case 'hotspot_profile_missing':
       return 'The host server is missing the managed hotspot profile. Requeue a host repair to recreate it.'
     case 'approved_hotspot_adapter_missing':
@@ -988,7 +991,7 @@ function getNetworkTooltip(
       reason = 'Red because Wi-Fi is disconnected.'
       break
     case 'unapproved_ssid':
-      reason = `Yellow because "${currentSsid}" is not in the approved Wi-Fi allowlist.`
+      reason = `Yellow because internet Wi-Fi "${currentSsid}" is not in the approved Wi-Fi allowlist.`
       break
     case 'hotspot_profile_missing':
       reason = 'Yellow because the managed host hotspot profile is missing.'
@@ -1023,9 +1026,10 @@ function getNetworkTooltip(
     network.wifiConnected === true
   ) {
     if (network.approvedSsids.length === 0) {
-      reason = 'Green because Wi-Fi is connected and no approved SSID allowlist is configured.'
+      reason =
+        'Green because Sentinel Wi-Fi is operational and no approved internet SSID allowlist is configured.'
     } else if (network.approvedSsid === true) {
-      reason = `Green because "${currentSsid}" is approved.`
+      reason = `Green because internet Wi-Fi "${currentSsid}" is approved.`
     } else {
       reason = `Green because ${network.message}.`
     }
@@ -1035,8 +1039,8 @@ function getNetworkTooltip(
     reason,
     `Detail: ${network.message}`,
     `Issue: ${formatNetworkIssueLabel(network.issueCode)}`,
-    `SSID: ${currentSsid}`,
-    `Approved SSIDs: ${approvedSsids}`,
+    `Internet SSID: ${currentSsid}`,
+    `Approved internet SSIDs: ${approvedSsids}`,
     `AP profile: ${formatHotspotProfilePresence(systemStatus)}`,
     `AP adapter: ${formatHotspotAdapter(systemStatus)}`,
     `Scan radio: ${formatScanRadio(systemStatus)}`,

--- a/deploy/write-network-status.sh
+++ b/deploy/write-network-status.sh
@@ -38,12 +38,42 @@ wifi_connected() {
   return 1
 }
 
-current_ssid() {
+internet_wifi_connection() {
+  local hotspot_device="${1:-}" connection_name
   if ! command -v nmcli >/dev/null 2>&1; then
     return 0
   fi
 
-  nmcli -t -f ACTIVE,SSID dev wifi 2>/dev/null | awk -F: '$1=="yes"{print substr($0, index($0,$2)); exit}'
+  connection_name="$(
+    nmcli -t -f NAME,TYPE,DEVICE connection show --active 2>/dev/null |
+      awk -F: -v hotspot_conn="${HOTSPOT_CONNECTION_NAME}" -v hotspot_dev="${hotspot_device}" \
+        '$2 == "wifi" || $2 == "802-11-wireless" {
+          if ($1 != hotspot_conn && (hotspot_dev == "" || $3 != hotspot_dev)) {
+            print $1
+            exit
+          }
+        }'
+  )"
+
+  if [[ -n "${connection_name}" ]]; then
+    printf '%s\n' "${connection_name}"
+  fi
+}
+
+internet_wifi_ssid() {
+  local connection_name="${1:-}" configured_ssid
+  [[ -n "${connection_name}" ]] || return 0
+
+  configured_ssid="$(
+    nmcli -g 802-11-wireless.ssid connection show "${connection_name}" 2>/dev/null |
+      head -n1
+  )"
+  if [[ -n "${configured_ssid}" ]]; then
+    printf '%s\n' "${configured_ssid}"
+    return 0
+  fi
+
+  printf '%s\n' "${connection_name}"
 }
 
 hotspot_connection_device() {
@@ -230,6 +260,12 @@ hotspot_ssid_visible_from_laptop_value="${HOTSPOT_STATE_HOTSPOT_VISIBILITY:-null
 hotspot_adapter_busy_value="${HOTSPOT_STATE_HOTSPOT_ADAPTER_BUSY:-false}"
 internet_wifi_connection_value="${HOTSPOT_STATE_INTERNET_WIFI_CONNECTION:-}"
 internet_wifi_ssid_value="${HOTSPOT_STATE_INTERNET_WIFI_SSID:-}"
+if [[ -z "${internet_wifi_connection_value}" ]]; then
+  internet_wifi_connection_value="$(internet_wifi_connection "${hotspot_device_value}" || true)"
+fi
+if [[ -z "${internet_wifi_ssid_value}" ]]; then
+  internet_wifi_ssid_value="$(internet_wifi_ssid "${internet_wifi_connection_value}" || true)"
+fi
 host_ip_address_value="$(resolve_host_ip_address "${hotspot_device_value}")"
 
 if [[ "${hotspot_issue_code_value}" != "none" && -n "${HOTSPOT_STATE_MESSAGE:-}" ]]; then
@@ -243,17 +279,17 @@ elif [[ $? -eq 1 ]]; then
   message_value="Wi-Fi disconnected"
 fi
 
-current_ssid_value="$(current_ssid || true)"
+current_ssid_value="${internet_wifi_ssid_value}"
 
 if check_url "${CHECK_URL}"; then
   internet_reachable_value="true"
 elif command -v curl >/dev/null 2>&1; then
   internet_reachable_value="false"
-  if [[ "${wifi_connected_value}" == "true" && "${hotspot_issue_code_value}" == "none" ]]; then
+  if [[ -n "${current_ssid_value}" && "${hotspot_issue_code_value}" == "none" ]]; then
     portal_recovery_likely_value="true"
-    message_value="Internet reachability failed while Wi-Fi is connected"
+    message_value="Internet reachability failed while internet Wi-Fi is connected"
   elif [[ "${hotspot_issue_code_value}" == "none" ]]; then
-    message_value="Internet reachability failed"
+    message_value="Sentinel hotspot is visible; internet Wi-Fi is not connected"
   fi
 fi
 
@@ -268,8 +304,10 @@ if [[ -n "${REMOTE_TARGET}" ]]; then
   fi
 fi
 
-if [[ "${wifi_connected_value}" == "true" && "${internet_reachable_value}" == "true" && "${hotspot_issue_code_value}" == "none" ]]; then
-  message_value="Connected to Wi-Fi and internet is reachable"
+if [[ -n "${current_ssid_value}" && "${internet_reachable_value}" == "true" && "${hotspot_issue_code_value}" == "none" ]]; then
+  message_value="Connected to internet Wi-Fi and internet is reachable"
+elif [[ -z "${current_ssid_value}" && "${hotspot_issue_code_value}" == "none" && "${hotspot_ssid_visible_from_laptop_value}" == "true" ]]; then
+  message_value="Sentinel hotspot is visible; internet Wi-Fi is not connected"
 fi
 
 tmp_file="$(mktemp "${OUTPUT_DIR}/network-status.XXXXXX")"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Separates the optional internet Wi-Fi connection from the Sentinel hotspot used by laptops and kiosks.
- Treats approved SSIDs such as GC Public as internet Wi-Fi only, while Stone Frigate remains the hosted Sentinel access hotspot.
- Updates System Status, Wireless Recovery, the Admin control card, and the kiosk connectivity label so they describe the correct network role.
- Prepares Sentinel v3.3.6 as a patch release.

## Why this change was needed

Sentinel was confusing two different Wi-Fi roles. GC Public is the internet Wi-Fi SSID and is useful for updates or outside connectivity, but Sentinel can still run locally without it. Stone Frigate is the hotspot that the USB AP adapter broadcasts so other laptops and kiosks can access Sentinel in a browser.

The System Status popup could report a wrong SSID when it saw Stone Frigate, and the kiosk header could show OFF SENTINEL WIFI even when the backend was reachable. That made the appliance look broken when the hotspot path was actually the important operational network.

## What changed

### User-facing

- The kiosk connection label now shows CONNECTED when the kiosk can reach the Sentinel backend.
- Hotspot-specific problems still surface as CONNECTED (HOTSPOT WARNING) instead of incorrectly saying the kiosk is off Sentinel Wi-Fi.

### Admin/operator-facing

- The navbar System Status popup now labels the host client connection as Internet SSID and the allowlist as Approved internet.
- Wireless Recovery copy now explains when reconnecting to internet Wi-Fi is optional and when hotspot repair is the relevant action.
- The Admin control center can show Internet optional when the Sentinel hotspot is visible but internet Wi-Fi is not connected.

### Backend/API

- System status messages now say approved or unapproved internet Wi-Fi, instead of generic approved Wi-Fi.
- No API schema change was introduced.

### Database

- No database changes or migrations.

### Deployment/update

- The host network telemetry script now derives the current internet Wi-Fi SSID from a non-hotspot Wi-Fi client connection.
- The hosted hotspot connection and adapter are excluded from the internet SSID check so Stone Frigate is not treated as the internet network.

### Tests

- Added kiosk-domain tests for unapproved host internet Wi-Fi and hotspot warning behavior.
- Added backend status coverage for the case where the Sentinel hotspot is visible and internet Wi-Fi is disconnected.

## User impact

Users should no longer see OFF SENTINEL WIFI on the kiosk just because the appliance host is not on GC Public. If the kiosk can reach Sentinel, it reports as connected.

## Operator impact

Operators get clearer language: GC Public is internet Wi-Fi, Stone Frigate is the Sentinel hotspot. Internet Wi-Fi may still matter for updates and outside access, but it is not required for local Sentinel access when the hotspot and backend are working.

## Upgrade or migration notes

No upgrade action required beyond the normal Sentinel update. No database migration and no manual configuration change are required.

## Risk and rollback notes

The main risk is that internet Wi-Fi warnings are now less prominent in the kiosk header by design. Operators should use System Status for host internet Wi-Fi details and hotspot repair state.

Verify by opening System Status and confirming that Internet SSID, Approved internet, AP adapter, scan radio, and hotspot visibility describe the expected radios. Rollback is safe and does not affect stored data.

## Testing performed

- `bash -n deploy/write-network-status.sh deploy/ensure-host-hotspot-profile.sh deploy/recover-host-hotspot.sh`
- `git diff --check`
- `pnpm --filter frontend-admin exec vitest run src/components/kiosk/kiosk-domain.test.ts src/components/layout/app-navbar.logic.test.ts src/components/settings/system-update-panel.logic.test.ts src/lib/admin-issues.test.ts`
- `pnpm --filter frontend-admin typecheck`
- `pnpm --filter backend typecheck`
- `pnpm --filter frontend-admin lint`
- `pnpm --filter backend lint`
- `pnpm version:check`

## Changelog candidates

- Fixed Sentinel network status so GC Public is treated as optional internet Wi-Fi and Stone Frigate remains the Sentinel hotspot.
- Fixed the kiosk header so backend reachability is not mistaken for being off Sentinel Wi-Fi.
- Improved System Status and Wireless Recovery wording for internet Wi-Fi, hotspot visibility, AP adapter, and scan radio checks.
