### PR TITLE
feat(network): show host hotspot reset progress

### DIFF
--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -1454,6 +1454,65 @@
         }
       }
     },
+    "/api/visitors/groups": {
+      "post": {
+        "description": "Atomically create a visitor group with one or more members and optional group-level vehicles",
+        "summary": "Create visitor group",
+        "tags": ["visitors"],
+        "parameters": [],
+        "responses": {
+          "201": {
+            "description": "201"
+          },
+          "400": {
+            "description": "400"
+          },
+          "401": {
+            "description": "401"
+          },
+          "409": {
+            "description": "409"
+          },
+          "500": {
+            "description": "500"
+          }
+        }
+      }
+    },
+    "/api/visitors/groups/{groupId}/checkout": {
+      "post": {
+        "description": "Sign out an entire visitor group or selected active members from that visitor group",
+        "summary": "Checkout visitor group members",
+        "tags": ["visitors"],
+        "parameters": [
+          {
+            "name": "groupId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200"
+          },
+          "400": {
+            "description": "400"
+          },
+          "401": {
+            "description": "401"
+          },
+          "404": {
+            "description": "404"
+          },
+          "500": {
+            "description": "500"
+          }
+        }
+      }
+    },
     "/api/visitors/{id}/checkout": {
       "post": {
         "description": "Sign out a visitor",
@@ -4006,6 +4065,192 @@
           },
           "404": {
             "description": "404"
+          },
+          "500": {
+            "description": "500"
+          }
+        }
+      }
+    },
+    "/api/reports/presence/daily": {
+      "post": {
+        "description": "Generate an operational daily presence report with first arrival, final departure, session count, leave-and-return state, and warning metadata.",
+        "summary": "Generate daily presence report",
+        "tags": ["reports"],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "200"
+          },
+          "400": {
+            "description": "400"
+          },
+          "401": {
+            "description": "401"
+          },
+          "403": {
+            "description": "403"
+          },
+          "404": {
+            "description": "404"
+          },
+          "409": {
+            "description": "409"
+          },
+          "500": {
+            "description": "500"
+          }
+        }
+      }
+    },
+    "/api/reports/presence/weekly": {
+      "post": {
+        "description": "Generate an operational weekly presence report grouped around daily presence markers and Training/Admin night attendance.",
+        "summary": "Generate weekly presence report",
+        "tags": ["reports"],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "200"
+          },
+          "400": {
+            "description": "400"
+          },
+          "401": {
+            "description": "401"
+          },
+          "403": {
+            "description": "403"
+          },
+          "404": {
+            "description": "404"
+          },
+          "409": {
+            "description": "409"
+          },
+          "500": {
+            "description": "500"
+          }
+        }
+      }
+    },
+    "/api/reports/presence/monthly": {
+      "post": {
+        "description": "Generate an operational monthly presence overview with compact day markers, key-night attendance, and scoped member summaries.",
+        "summary": "Generate monthly presence report",
+        "tags": ["reports"],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "200"
+          },
+          "400": {
+            "description": "400"
+          },
+          "401": {
+            "description": "401"
+          },
+          "403": {
+            "description": "403"
+          },
+          "404": {
+            "description": "404"
+          },
+          "409": {
+            "description": "409"
+          },
+          "500": {
+            "description": "500"
+          }
+        }
+      }
+    },
+    "/api/reports/training-night/monthly": {
+      "post": {
+        "description": "Generate a department training night matrix for a selected month, including all active department members and each Training Night.",
+        "summary": "Generate monthly training night report",
+        "tags": ["reports"],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "200"
+          },
+          "400": {
+            "description": "400"
+          },
+          "401": {
+            "description": "401"
+          },
+          "403": {
+            "description": "403"
+          },
+          "404": {
+            "description": "404"
+          },
+          "409": {
+            "description": "409"
+          },
+          "500": {
+            "description": "500"
+          }
+        }
+      }
+    },
+    "/api/reports/visitors/activity": {
+      "post": {
+        "description": "Generate an operational visitor report using existing visitor visit type, purpose/reason, event association, host, organization, and date range data.",
+        "summary": "Generate visitor activity report",
+        "tags": ["reports"],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "200"
+          },
+          "400": {
+            "description": "400"
+          },
+          "401": {
+            "description": "401"
+          },
+          "403": {
+            "description": "403"
+          },
+          "404": {
+            "description": "404"
+          },
+          "409": {
+            "description": "409"
+          },
+          "500": {
+            "description": "500"
+          }
+        }
+      }
+    },
+    "/api/reports/operations/exceptions": {
+      "post": {
+        "description": "Generate a report of forced member checkouts and lockup days where the building was not properly secured before daily reset.",
+        "summary": "Generate operational exceptions report",
+        "tags": ["reports"],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "200"
+          },
+          "400": {
+            "description": "400"
+          },
+          "401": {
+            "description": "401"
+          },
+          "403": {
+            "description": "403"
+          },
+          "404": {
+            "description": "404"
+          },
+          "409": {
+            "description": "409"
           },
           "500": {
             "description": "500"

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.3.7",
+  "version": "3.3.8",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/routes/network-settings.test.ts
+++ b/apps/backend/src/routes/network-settings.test.ts
@@ -60,7 +60,8 @@ describe('networkSettingsRouter', () => {
   })
 
   it('queues a host hotspot recovery request for admins', async () => {
-    const requestDir = await mkdtemp(join(tmpdir(), 'sentinel-hotspot-recovery-'))
+    const rootDir = await mkdtemp(join(tmpdir(), 'sentinel-hotspot-recovery-'))
+    const requestDir = join(rootDir, 'requests')
     process.env.HOST_HOTSPOT_RECOVERY_REQUEST_DIR = requestDir
 
     const app = createTestApp(5)
@@ -93,6 +94,6 @@ describe('networkSettingsRouter', () => {
       requestedFromUserAgent: 'vitest',
     })
 
-    await rm(requestDir, { recursive: true, force: true })
+    await rm(rootDir, { recursive: true, force: true })
   })
 })

--- a/apps/backend/src/services/host-hotspot-recovery-service.test.ts
+++ b/apps/backend/src/services/host-hotspot-recovery-service.test.ts
@@ -1,7 +1,12 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   DEFAULT_HOST_HOTSPOT_RECOVERY_REQUEST_DIR,
+  DEFAULT_HOST_HOTSPOT_RECOVERY_STATUS_FILE,
   HostHotspotRecoveryQueueError,
+  HostHotspotRecoveryService,
 } from './host-hotspot-recovery-service.js'
 
 describe('HostHotspotRecoveryService', () => {
@@ -9,6 +14,35 @@ describe('HostHotspotRecoveryService', () => {
     expect(DEFAULT_HOST_HOTSPOT_RECOVERY_REQUEST_DIR).toBe(
       '/opt/sentinel/deploy/runtime/hotspot-recovery/requests'
     )
+    expect(DEFAULT_HOST_HOTSPOT_RECOVERY_STATUS_FILE).toBe(
+      '/opt/sentinel/deploy/runtime/hotspot-recovery/status.json'
+    )
+  })
+
+  it('writes and reads a queued recovery status when a repair is requested', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'sentinel-hotspot-recovery-'))
+    const requestDir = join(rootDir, 'requests')
+    const statusFile = join(rootDir, 'status.json')
+    const service = new HostHotspotRecoveryService(requestDir, statusFile)
+
+    const queued = await service.queueRecoveryRequest({
+      requestedByMemberId: 'member-1',
+      requestedByMemberName: 'PO2 Alex Example',
+      requestedByRemoteSystemName: 'Server',
+      requestedFromIp: '10.42.0.1',
+      requestedFromUserAgent: 'vitest',
+    })
+    const status = await service.readLatestStatus()
+
+    expect(status).toMatchObject({
+      state: 'queued',
+      stage: 'request_queued',
+      requestId: queued.requestId,
+      message: 'Host hotspot repair request queued. Waiting for the host processor to start.',
+    })
+    expect(status?.updatedAt).toBeTruthy()
+
+    await rm(rootDir, { recursive: true, force: true })
   })
 
   it('explains permission failures without leaking raw EACCES text to operators', () => {

--- a/apps/backend/src/services/host-hotspot-recovery-service.ts
+++ b/apps/backend/src/services/host-hotspot-recovery-service.ts
@@ -1,9 +1,13 @@
 import { randomUUID } from 'node:crypto'
-import { mkdir, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { basename, dirname, join } from 'node:path'
+import type { HostHotspotRecoveryStatus, HostHotspotRecoveryStage } from '@sentinel/contracts'
 
 export const DEFAULT_HOST_HOTSPOT_RECOVERY_REQUEST_DIR =
   '/opt/sentinel/deploy/runtime/hotspot-recovery/requests'
+export const DEFAULT_HOST_HOTSPOT_RECOVERY_STATUS_FILE =
+  '/opt/sentinel/deploy/runtime/hotspot-recovery/status.json'
+const HOST_HOTSPOT_RECOVERY_STATUS_STALE_SECONDS = 600
 
 export interface QueueHostHotspotRecoveryInput {
   requestedByMemberId: string
@@ -15,13 +19,18 @@ export interface QueueHostHotspotRecoveryInput {
 
 export class HostHotspotRecoveryService {
   private readonly requestDir: string
+  private readonly statusFilePath: string
 
-  constructor(requestDir?: string) {
+  constructor(requestDir?: string, statusFilePath?: string) {
     requestDir =
       requestDir ??
       process.env.HOST_HOTSPOT_RECOVERY_REQUEST_DIR ??
       DEFAULT_HOST_HOTSPOT_RECOVERY_REQUEST_DIR
     this.requestDir = requestDir
+    this.statusFilePath =
+      statusFilePath ??
+      process.env.HOST_HOTSPOT_RECOVERY_STATUS_FILE ??
+      resolveDefaultStatusFilePath(requestDir)
   }
 
   async queueRecoveryRequest(input: QueueHostHotspotRecoveryInput): Promise<{
@@ -47,9 +56,64 @@ export class HostHotspotRecoveryService {
       throw new HostHotspotRecoveryQueueError(this.requestDir, error)
     }
 
+    await this.writeRecoveryStatus({
+      state: 'queued',
+      stage: 'request_queued',
+      message: 'Host hotspot repair request queued. Waiting for the host processor to start.',
+      requestId,
+      requestedAt: payload.requestedAt,
+    })
+
     return {
       requestId,
       requestPath,
+    }
+  }
+
+  async readLatestStatus(): Promise<HostHotspotRecoveryStatus | null> {
+    try {
+      const raw = await readFile(this.statusFilePath, 'utf-8')
+      const status = parseHostHotspotRecoveryStatus(JSON.parse(raw) as unknown)
+      if (!status || isStaleRecoveryStatus(status)) {
+        return null
+      }
+
+      return status
+    } catch {
+      return null
+    }
+  }
+
+  private async writeRecoveryStatus(input: {
+    state: HostHotspotRecoveryStatus['state']
+    stage: HostHotspotRecoveryStage
+    message: string
+    requestId: string
+    requestedAt: string
+  }): Promise<void> {
+    const status: HostHotspotRecoveryStatus = {
+      state: input.state,
+      stage: input.stage,
+      message: input.message,
+      requestId: input.requestId,
+      connectionName: null,
+      hotspotSsid: null,
+      hotspotDevice: null,
+      scanDevice: null,
+      usbDevice: null,
+      hardwareResetApplied: null,
+      startedAt: input.requestedAt,
+      updatedAt: new Date().toISOString(),
+      completedAt: null,
+    }
+
+    try {
+      await mkdir(dirname(this.statusFilePath), { recursive: true })
+      await writeFile(this.statusFilePath, JSON.stringify(status, null, 2), {
+        encoding: 'utf-8',
+      })
+    } catch {
+      // The request file is the source of truth for recovery execution. Status is best-effort UI telemetry.
     }
   }
 }
@@ -76,4 +140,101 @@ function isPermissionError(error: unknown): boolean {
   return (
     error instanceof Error && 'code' in error && (error as { code?: unknown }).code === 'EACCES'
   )
+}
+
+function resolveDefaultStatusFilePath(requestDir: string): string {
+  return basename(requestDir) === 'requests'
+    ? join(dirname(requestDir), 'status.json')
+    : join(requestDir, 'status.json')
+}
+
+function parseHostHotspotRecoveryStatus(payload: unknown): HostHotspotRecoveryStatus | null {
+  if (!isRecord(payload)) {
+    return null
+  }
+
+  const state = parseRecoveryState(payload.state)
+  const stage = parseRecoveryStage(payload.stage)
+  const message = normalizeNullableString(payload.message)
+  const updatedAt = normalizeTimestampString(payload.updatedAt)
+
+  if (!state || !stage || !message || !updatedAt) {
+    return null
+  }
+
+  return {
+    state,
+    stage,
+    message,
+    requestId: normalizeNullableString(payload.requestId),
+    connectionName: normalizeNullableString(payload.connectionName),
+    hotspotSsid: normalizeNullableString(payload.hotspotSsid),
+    hotspotDevice: normalizeNullableString(payload.hotspotDevice),
+    scanDevice: normalizeNullableString(payload.scanDevice),
+    usbDevice: normalizeNullableString(payload.usbDevice),
+    hardwareResetApplied: normalizeNullableBoolean(payload.hardwareResetApplied),
+    startedAt: normalizeTimestampString(payload.startedAt),
+    updatedAt,
+    completedAt: normalizeTimestampString(payload.completedAt),
+  }
+}
+
+function parseRecoveryState(value: unknown): HostHotspotRecoveryStatus['state'] | null {
+  switch (value) {
+    case 'queued':
+    case 'running':
+    case 'completed':
+    case 'failed':
+      return value
+    default:
+      return null
+  }
+}
+
+function parseRecoveryStage(value: unknown): HostHotspotRecoveryStage | null {
+  switch (value) {
+    case 'request_queued':
+    case 'processing_request':
+    case 'moving_internet_wifi':
+    case 'ensuring_profile':
+    case 'stopping_hotspot':
+    case 'resetting_driver':
+    case 'resetting_usb':
+    case 'waiting_for_adapter':
+    case 'starting_hotspot':
+    case 'verifying_visibility':
+    case 'completed':
+    case 'failed':
+      return value
+    default:
+      return null
+  }
+}
+
+function normalizeNullableBoolean(value: unknown): boolean | null {
+  return typeof value === 'boolean' ? value : null
+}
+
+function normalizeNullableString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
+function normalizeTimestampString(value: unknown): string | null {
+  const normalized = normalizeNullableString(value)
+  if (!normalized) {
+    return null
+  }
+
+  const parsed = new Date(normalized)
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString()
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function isStaleRecoveryStatus(status: HostHotspotRecoveryStatus): boolean {
+  const updatedAt = new Date(status.updatedAt)
+  const ageSeconds = Math.max(0, (Date.now() - updatedAt.getTime()) / 1_000)
+  return ageSeconds > HOST_HOTSPOT_RECOVERY_STATUS_STALE_SECONDS
 }

--- a/apps/backend/src/services/system-status-service.ts
+++ b/apps/backend/src/services/system-status-service.ts
@@ -22,6 +22,7 @@ import { resolveServiceVersionDisplay } from '../lib/service-version.js'
 import { DEPLOYMENT_REMOTE_SYSTEM_CODE } from '../repositories/remote-system-repository.js'
 import { SessionRepository } from '../repositories/session-repository.js'
 import { HostNetworkStatusService } from './host-network-status-service.js'
+import { HostHotspotRecoveryService } from './host-hotspot-recovery-service.js'
 import { NetworkSettingsService } from './network-settings-service.js'
 
 const REMOTE_SESSION_LIMIT = 5
@@ -237,12 +238,14 @@ export class SystemStatusService {
   private sessionRepository: SessionRepository
   private networkSettingsService: NetworkSettingsService
   private hostNetworkStatusService: HostNetworkStatusService
+  private hostHotspotRecoveryService: HostHotspotRecoveryService
   private kioskPresenceStore: KioskDevicePresenceStore
 
   constructor(
     prismaClient: PrismaClientInstance = defaultPrisma,
     options?: {
       hostNetworkStatusService?: HostNetworkStatusService
+      hostHotspotRecoveryService?: HostHotspotRecoveryService
       networkSettingsService?: NetworkSettingsService
       kioskPresenceStore?: KioskDevicePresenceStore
     }
@@ -253,6 +256,8 @@ export class SystemStatusService {
       options?.networkSettingsService ?? new NetworkSettingsService(prismaClient)
     this.hostNetworkStatusService =
       options?.hostNetworkStatusService ?? new HostNetworkStatusService()
+    this.hostHotspotRecoveryService =
+      options?.hostHotspotRecoveryService ?? new HostHotspotRecoveryService()
     this.kioskPresenceStore = options?.kioskPresenceStore ?? kioskDevicePresenceStore
   }
 
@@ -261,16 +266,22 @@ export class SystemStatusService {
     const developmentBuild = isDevelopmentBuild()
     const runningInsideContainer = isRunningInsideContainer()
 
-    const [networkSettingsState, telemetryResult, memberRemoteSessions, activeSessionCount] =
-      await Promise.all([
-        this.networkSettingsService.getNetworkSettings(),
-        this.hostNetworkStatusService.readTelemetry(),
-        this.sessionRepository.findActiveRemoteSessions({
-          limit: REMOTE_SESSION_LIMIT,
-          activeWithinSeconds: ACTIVE_REMOTE_SESSION_THRESHOLD_SECONDS,
-        }),
-        this.sessionRepository.countActiveSessions(),
-      ])
+    const [
+      networkSettingsState,
+      telemetryResult,
+      hostHotspotRecoveryStatus,
+      memberRemoteSessions,
+      activeSessionCount,
+    ] = await Promise.all([
+      this.networkSettingsService.getNetworkSettings(),
+      this.hostNetworkStatusService.readTelemetry(),
+      this.hostHotspotRecoveryService.readLatestStatus(),
+      this.sessionRepository.findActiveRemoteSessions({
+        limit: REMOTE_SESSION_LIMIT,
+        activeWithinSeconds: ACTIVE_REMOTE_SESSION_THRESHOLD_SECONDS,
+      }),
+      this.sessionRepository.countActiveSessions(),
+    ])
 
     let databaseHealthy = false
     try {
@@ -385,6 +396,7 @@ export class SystemStatusService {
         remoteTarget: telemetry?.remoteTarget ?? null,
         remoteReachable: telemetry?.remoteReachable ?? null,
         portalRecoveryLikely: telemetry?.portalRecoveryLikely ?? null,
+        hostHotspotRecovery: hostHotspotRecoveryStatus,
         generatedAt: telemetry?.generatedAt.toISOString() ?? null,
       },
       remoteSystems: {

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.3.7",
+  "version": "3.3.8",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/components/network/host-hotspot-repair-dialog.logic.test.ts
+++ b/apps/frontend-admin/src/components/network/host-hotspot-repair-dialog.logic.test.ts
@@ -2,13 +2,18 @@ import { describe, expect, it } from 'vitest'
 import {
   getHostHotspotAntennaWaitLabel,
   getHostHotspotRepairStepState,
+  getHostHotspotResetWatchLabel,
   isHostHotspotAntennaWaitActionDisabled,
+  isHostHotspotResetWatchActionDisabled,
 } from './host-hotspot-repair-dialog.logic'
 
 describe('host hotspot repair dialog logic', () => {
   it('marks earlier steps complete and later steps pending', () => {
     expect(getHostHotspotRepairStepState('run-repair', 'check-wifi')).toBe('complete')
+    expect(getHostHotspotRepairStepState('watch-reset', 'run-repair')).toBe('complete')
+    expect(getHostHotspotRepairStepState('watch-reset', 'watch-reset')).toBe('active')
     expect(getHostHotspotRepairStepState('reset-antenna', 'run-repair')).toBe('complete')
+    expect(getHostHotspotRepairStepState('reset-antenna', 'watch-reset')).toBe('complete')
     expect(getHostHotspotRepairStepState('reset-antenna', 'reset-antenna')).toBe('active')
     expect(getHostHotspotRepairStepState('reset-antenna', 'retry-repair')).toBe('pending')
   })
@@ -16,8 +21,17 @@ describe('host hotspot repair dialog logic', () => {
   it('marks all steps complete after the final repair is queued', () => {
     expect(getHostHotspotRepairStepState('complete', 'check-wifi')).toBe('complete')
     expect(getHostHotspotRepairStepState('complete', 'run-repair')).toBe('complete')
+    expect(getHostHotspotRepairStepState('complete', 'watch-reset')).toBe('complete')
     expect(getHostHotspotRepairStepState('complete', 'reset-antenna')).toBe('complete')
     expect(getHostHotspotRepairStepState('complete', 'retry-repair')).toBe('complete')
+  })
+
+  it('labels and disables the reset watch action while the adapter settles', () => {
+    expect(getHostHotspotResetWatchLabel({ secondsRemaining: 10 })).toBe('Watching reset 10s')
+    expect(isHostHotspotResetWatchActionDisabled({ secondsRemaining: 10 })).toBe(true)
+
+    expect(getHostHotspotResetWatchLabel({ secondsRemaining: 0 })).toBe('Continue if needed')
+    expect(isHostHotspotResetWatchActionDisabled({ secondsRemaining: 0 })).toBe(false)
   })
 
   it('labels and disables the antenna wait action while the timer runs', () => {

--- a/apps/frontend-admin/src/components/network/host-hotspot-repair-dialog.logic.ts
+++ b/apps/frontend-admin/src/components/network/host-hotspot-repair-dialog.logic.ts
@@ -1,4 +1,5 @@
 export const HOST_HOTSPOT_ANTENNA_WAIT_SECONDS = 3
+export const HOST_HOTSPOT_RESET_WATCH_SECONDS = 10
 
 export const HOST_HOTSPOT_REPAIR_STEPS = [
   {
@@ -10,8 +11,12 @@ export const HOST_HOTSPOT_REPAIR_STEPS = [
     label: 'Run repair',
   },
   {
+    id: 'watch-reset',
+    label: 'Watch reset',
+  },
+  {
     id: 'reset-antenna',
-    label: 'Reset antenna',
+    label: 'Reseat antenna',
   },
   {
     id: 'retry-repair',
@@ -25,6 +30,10 @@ export type HostHotspotRepairStepState = 'complete' | 'active' | 'pending'
 
 export interface HostHotspotAntennaWaitState {
   started: boolean
+  secondsRemaining: number
+}
+
+export interface HostHotspotResetWatchState {
   secondsRemaining: number
 }
 
@@ -62,6 +71,20 @@ export function getHostHotspotAntennaWaitLabel(state: HostHotspotAntennaWaitStat
   }
 
   return `Wait ${secondsRemaining}s`
+}
+
+export function getHostHotspotResetWatchLabel(state: HostHotspotResetWatchState): string {
+  const secondsRemaining = Math.max(0, Math.ceil(state.secondsRemaining))
+
+  if (secondsRemaining === 0) {
+    return 'Continue if needed'
+  }
+
+  return `Watching reset ${secondsRemaining}s`
+}
+
+export function isHostHotspotResetWatchActionDisabled(state: HostHotspotResetWatchState): boolean {
+  return state.secondsRemaining > 0
 }
 
 export function isHostHotspotAntennaWaitActionDisabled(

--- a/apps/frontend-admin/src/components/network/host-hotspot-repair-dialog.tsx
+++ b/apps/frontend-admin/src/components/network/host-hotspot-repair-dialog.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
-import { CheckCircle2, RotateCcw, Usb, Wifi, Wrench, type LucideIcon } from 'lucide-react'
+import type { HostHotspotRecoveryStatus } from '@sentinel/contracts'
+import { Activity, CheckCircle2, RotateCcw, Usb, Wifi, Wrench, type LucideIcon } from 'lucide-react'
 import { toast } from 'sonner'
 import { AppBadge } from '@/components/ui/AppBadge'
 import {
@@ -14,14 +15,18 @@ import {
 } from '@/components/ui/dialog'
 import { LoadingSpinner } from '@/components/ui/loading-spinner'
 import { useHostHotspotRecovery } from '@/hooks/use-network-settings'
+import { useSystemStatus } from '@/hooks/use-system-status'
 import { cn } from '@/lib/utils'
 import { TID } from '@/lib/test-ids'
 import {
   HOST_HOTSPOT_ANTENNA_WAIT_SECONDS,
   HOST_HOTSPOT_REPAIR_STEPS,
+  HOST_HOTSPOT_RESET_WATCH_SECONDS,
   getHostHotspotAntennaWaitLabel,
   getHostHotspotRepairStepState,
+  getHostHotspotResetWatchLabel,
   isHostHotspotAntennaWaitActionDisabled,
+  isHostHotspotResetWatchActionDisabled,
   type HostHotspotRepairStage,
   type HostHotspotRepairStepState,
 } from './host-hotspot-repair-dialog.logic'
@@ -43,6 +48,7 @@ const stepToneClasses: Record<HostHotspotRepairStepState, string> = {
 const instructionSurfaceClasses: Record<HostHotspotRepairStage, string> = {
   'check-wifi': 'border-info/40 bg-info-fadded text-info-fadded-content',
   'run-repair': 'border-info/40 bg-info-fadded text-info-fadded-content',
+  'watch-reset': 'border-warning/45 bg-warning-fadded text-warning-fadded-content',
   'reset-antenna': 'border-warning/45 bg-warning-fadded text-warning-fadded-content',
   'retry-repair': 'border-info/40 bg-info-fadded text-info-fadded-content',
   complete: 'border-success/45 bg-success-fadded text-success-fadded-content',
@@ -55,7 +61,15 @@ export function HostHotspotRepairDialog({
 }: HostHotspotRepairDialogProps) {
   const queryClient = useQueryClient()
   const hostHotspotRecovery = useHostHotspotRecovery()
+  const systemStatusQuery = useSystemStatus({
+    enabled: open,
+    refetchIntervalMs: open ? 2_000 : 30_000,
+  })
+  const recoveryStatus = systemStatusQuery.data?.network.hostHotspotRecovery ?? null
   const [stage, setStage] = useState<HostHotspotRepairStage>('check-wifi')
+  const [resetWatchSecondsRemaining, setResetWatchSecondsRemaining] = useState(
+    HOST_HOTSPOT_RESET_WATCH_SECONDS
+  )
   const [antennaWaitStarted, setAntennaWaitStarted] = useState(false)
   const [antennaSecondsRemaining, setAntennaSecondsRemaining] = useState(
     HOST_HOTSPOT_ANTENNA_WAIT_SECONDS
@@ -64,6 +78,7 @@ export function HostHotspotRepairDialog({
 
   const resetFlow = () => {
     setStage('check-wifi')
+    setResetWatchSecondsRemaining(HOST_HOTSPOT_RESET_WATCH_SECONDS)
     setAntennaWaitStarted(false)
     setAntennaSecondsRemaining(HOST_HOTSPOT_ANTENNA_WAIT_SECONDS)
     setQueuedMessage(null)
@@ -76,6 +91,18 @@ export function HostHotspotRepairDialog({
 
     onOpenChange(nextOpen)
   }
+
+  useEffect(() => {
+    if (!open || stage !== 'watch-reset' || resetWatchSecondsRemaining <= 0) {
+      return undefined
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setResetWatchSecondsRemaining((current) => Math.max(0, current - 1))
+    }, 1_000)
+
+    return () => window.clearTimeout(timeoutId)
+  }, [open, resetWatchSecondsRemaining, stage])
 
   useEffect(() => {
     if (!open || stage !== 'reset-antenna' || !antennaWaitStarted || antennaSecondsRemaining <= 0) {
@@ -93,8 +120,12 @@ export function HostHotspotRepairDialog({
     started: antennaWaitStarted,
     secondsRemaining: antennaSecondsRemaining,
   }
+  const resetWatchState = {
+    secondsRemaining: resetWatchSecondsRemaining,
+  }
   const primaryDisabled =
     hostHotspotRecovery.isPending ||
+    (stage === 'watch-reset' && isHostHotspotResetWatchActionDisabled(resetWatchState)) ||
     (stage === 'reset-antenna' && isHostHotspotAntennaWaitActionDisabled(antennaWaitState))
 
   const queueSystemStatusRefreshes = () => {
@@ -133,7 +164,18 @@ export function HostHotspotRepairDialog({
     }
 
     if (stage === 'run-repair') {
-      void handleRepair('reset-antenna')
+      setResetWatchSecondsRemaining(HOST_HOTSPOT_RESET_WATCH_SECONDS)
+      void handleRepair('watch-reset')
+      return
+    }
+
+    if (stage === 'watch-reset') {
+      if (recoveryStatus?.state === 'completed') {
+        setStage('complete')
+        return
+      }
+
+      setStage('reset-antenna')
       return
     }
 
@@ -205,8 +247,17 @@ export function HostHotspotRepairDialog({
               antennaSecondsRemaining,
               antennaWaitStarted,
               queuedMessage,
+              recoveryStatus,
+              resetWatchSecondsRemaining,
             })}
           </section>
+
+          {renderRecoveryActivity(recoveryStatus, {
+            isLoading: systemStatusQuery.isLoading,
+            isError: systemStatusQuery.isError,
+            queuedMessage,
+            stage,
+          })}
         </div>
 
         <DialogFooter className="items-center gap-(--space-2)">
@@ -240,6 +291,8 @@ export function HostHotspotRepairDialog({
               antennaSecondsRemaining,
               antennaWaitStarted,
               isPending: hostHotspotRecovery.isPending,
+              recoveryStatus,
+              resetWatchSecondsRemaining,
             })}
           </button>
         </DialogFooter>
@@ -254,6 +307,8 @@ function renderInstruction(
     antennaSecondsRemaining: number
     antennaWaitStarted: boolean
     queuedMessage: string | null
+    recoveryStatus: HostHotspotRecoveryStatus | null
+    resetWatchSecondsRemaining: number
   }
 ) {
   if (stage === 'check-wifi') {
@@ -312,6 +367,38 @@ function renderInstruction(
     )
   }
 
+  if (stage === 'watch-reset') {
+    const isComplete = input.recoveryStatus?.state === 'completed'
+    const isFailed = input.recoveryStatus?.state === 'failed'
+    const body = isComplete
+      ? 'The host reports that recovery finished. Check System Status and close this repair flow if the hotspot is healthy.'
+      : isFailed
+        ? 'The host finished the reset attempt but still needs attention. Let the timer finish, then re-seat the antenna only if needed.'
+        : 'Sentinel is resetting the USB AP dongle now. Do not unplug it yet; the adapter may disappear and come back after about 10 seconds.'
+
+    return (
+      <div className="flex items-start gap-(--space-3)">
+        <InstructionIcon icon={Activity} />
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-(--space-2)">
+            <h4 className="font-bold">Watch the USB reset</h4>
+            {!isComplete && input.resetWatchSecondsRemaining > 0 && (
+              <AppBadge status="warning" size="sm">
+                {input.resetWatchSecondsRemaining}s
+              </AppBadge>
+            )}
+            {isComplete && (
+              <AppBadge status="success" size="sm">
+                Complete
+              </AppBadge>
+            )}
+          </div>
+          <p className="mt-(--space-1) text-sm leading-relaxed">{body}</p>
+        </div>
+      </div>
+    )
+  }
+
   if (stage === 'retry-repair') {
     return (
       <div className="flex items-start gap-(--space-3)">
@@ -345,6 +432,89 @@ function renderInstruction(
   )
 }
 
+function renderRecoveryActivity(
+  recoveryStatus: HostHotspotRecoveryStatus | null,
+  input: {
+    isLoading: boolean
+    isError: boolean
+    queuedMessage: string | null
+    stage: HostHotspotRepairStage
+  }
+) {
+  if (!recoveryStatus && !input.queuedMessage && input.stage !== 'watch-reset') {
+    return null
+  }
+
+  const statusTone = getRecoveryStatusTone(recoveryStatus)
+  const message =
+    recoveryStatus?.message ??
+    input.queuedMessage ??
+    (input.isLoading
+      ? 'Checking host hotspot recovery status.'
+      : 'Waiting for host recovery status.')
+  const progressValue = getRecoveryProgressValue(recoveryStatus)
+
+  return (
+    <section
+      className="rounded-box border border-base-300 bg-base-200 p-(--space-3) text-sm text-base-content shadow-inner"
+      aria-label="Host hotspot recovery activity"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-(--space-2)">
+        <div className="flex min-w-0 items-center gap-(--space-2)">
+          <Activity
+            aria-hidden="true"
+            className={cn(
+              'h-4 w-4 shrink-0',
+              recoveryStatus?.state === 'running' ? 'text-warning' : 'text-base-content/60'
+            )}
+          />
+          <p className="truncate font-semibold">{formatRecoveryStage(recoveryStatus?.stage)}</p>
+        </div>
+        <AppBadge status={statusTone} size="sm" pulse={recoveryStatus?.state === 'running'}>
+          {formatRecoveryState(recoveryStatus?.state, input.isError)}
+        </AppBadge>
+      </div>
+
+      <progress
+        className={cn(
+          'progress mt-(--space-3) h-2 w-full',
+          recoveryStatus?.state === 'completed'
+            ? 'progress-success'
+            : recoveryStatus?.state === 'failed'
+              ? 'progress-error'
+              : 'progress-warning'
+        )}
+        value={progressValue}
+        max={100}
+        aria-label="Host hotspot recovery progress"
+      />
+
+      <p className="mt-(--space-2) leading-relaxed">{message}</p>
+
+      {recoveryStatus && (
+        <dl className="mt-(--space-2) grid grid-cols-2 gap-x-(--space-3) gap-y-(--space-1) text-xs text-base-content/70">
+          <RecoveryDetail label="AP dongle" value={recoveryStatus.hotspotDevice} />
+          <RecoveryDetail label="USB device" value={recoveryStatus.usbDevice} />
+          <RecoveryDetail label="Scan radio" value={recoveryStatus.scanDevice} />
+          <RecoveryDetail
+            label="Updated"
+            value={formatRelativeTimestamp(recoveryStatus.updatedAt)}
+          />
+        </dl>
+      )}
+    </section>
+  )
+}
+
+function RecoveryDetail({ label, value }: { label: string; value: string | null }) {
+  return (
+    <div className="min-w-0">
+      <dt className="font-semibold uppercase tracking-wide">{label}</dt>
+      <dd className="truncate font-mono text-base-content">{value ?? 'Pending'}</dd>
+    </div>
+  )
+}
+
 function InstructionIcon({ icon: Icon }: { icon: LucideIcon }) {
   return (
     <span className="grid h-10 w-10 shrink-0 place-items-center rounded-box bg-base-100/80 shadow-[var(--shadow-1)]">
@@ -359,6 +529,8 @@ function getPrimaryActionLabel(
     antennaSecondsRemaining: number
     antennaWaitStarted: boolean
     isPending: boolean
+    recoveryStatus: HostHotspotRecoveryStatus | null
+    resetWatchSecondsRemaining: number
   }
 ): string {
   if (input.isPending) {
@@ -373,6 +545,16 @@ function getPrimaryActionLabel(
     return 'Run repair'
   }
 
+  if (stage === 'watch-reset') {
+    if (input.recoveryStatus?.state === 'completed') {
+      return 'Review complete'
+    }
+
+    return getHostHotspotResetWatchLabel({
+      secondsRemaining: input.resetWatchSecondsRemaining,
+    })
+  }
+
   if (stage === 'reset-antenna') {
     return getHostHotspotAntennaWaitLabel({
       started: input.antennaWaitStarted,
@@ -385,4 +567,126 @@ function getPrimaryActionLabel(
   }
 
   return 'Close'
+}
+
+function getRecoveryStatusTone(
+  recoveryStatus: HostHotspotRecoveryStatus | null
+): 'success' | 'warning' | 'error' | 'neutral' {
+  switch (recoveryStatus?.state) {
+    case 'completed':
+      return 'success'
+    case 'failed':
+      return 'error'
+    case 'queued':
+    case 'running':
+      return 'warning'
+    default:
+      return 'neutral'
+  }
+}
+
+function formatRecoveryState(
+  state: HostHotspotRecoveryStatus['state'] | undefined,
+  isError: boolean
+): string {
+  if (isError) {
+    return 'Status unavailable'
+  }
+
+  switch (state) {
+    case 'queued':
+      return 'Queued'
+    case 'running':
+      return 'Running'
+    case 'completed':
+      return 'Complete'
+    case 'failed':
+      return 'Needs attention'
+    default:
+      return 'Checking'
+  }
+}
+
+function formatRecoveryStage(stage: HostHotspotRecoveryStatus['stage'] | undefined): string {
+  switch (stage) {
+    case 'request_queued':
+      return 'Waiting for host'
+    case 'processing_request':
+      return 'Starting repair'
+    case 'moving_internet_wifi':
+      return 'Moving internet Wi-Fi'
+    case 'ensuring_profile':
+      return 'Checking hotspot profile'
+    case 'stopping_hotspot':
+      return 'Stopping hotspot'
+    case 'resetting_driver':
+      return 'Resetting driver'
+    case 'resetting_usb':
+      return 'Resetting USB dongle'
+    case 'waiting_for_adapter':
+      return 'Waiting for adapter'
+    case 'starting_hotspot':
+      return 'Starting hotspot'
+    case 'verifying_visibility':
+      return 'Checking visibility'
+    case 'completed':
+      return 'Repair complete'
+    case 'failed':
+      return 'Repair needs attention'
+    default:
+      return 'Host activity'
+  }
+}
+
+function getRecoveryProgressValue(recoveryStatus: HostHotspotRecoveryStatus | null): number {
+  if (!recoveryStatus) {
+    return 10
+  }
+
+  switch (recoveryStatus.stage) {
+    case 'request_queued':
+      return 10
+    case 'processing_request':
+      return 18
+    case 'moving_internet_wifi':
+      return 28
+    case 'ensuring_profile':
+      return 38
+    case 'stopping_hotspot':
+      return 48
+    case 'resetting_driver':
+    case 'resetting_usb':
+      return 58
+    case 'waiting_for_adapter':
+      return 68
+    case 'starting_hotspot':
+      return 80
+    case 'verifying_visibility':
+      return 90
+    case 'completed':
+      return 100
+    case 'failed':
+      return 100
+    default:
+      return 10
+  }
+}
+
+function formatRelativeTimestamp(value: string): string {
+  const timestamp = new Date(value)
+  if (Number.isNaN(timestamp.getTime())) {
+    return 'unknown'
+  }
+
+  const elapsedSeconds = Math.max(0, Math.round((Date.now() - timestamp.getTime()) / 1_000))
+  if (elapsedSeconds < 2) {
+    return 'just now'
+  }
+
+  if (elapsedSeconds < 60) {
+    return `${elapsedSeconds}s ago`
+  }
+
+  const elapsedMinutes = Math.floor(elapsedSeconds / 60)
+  return `${elapsedMinutes}m ago`
 }

--- a/apps/frontend-admin/src/hooks/use-system-status.ts
+++ b/apps/frontend-admin/src/hooks/use-system-status.ts
@@ -17,7 +17,7 @@ function getErrorMessage(body: unknown, fallback: string): string {
   return fallback
 }
 
-export function useSystemStatus(options?: { enabled?: boolean }) {
+export function useSystemStatus(options?: { enabled?: boolean; refetchIntervalMs?: number }) {
   return useQuery({
     queryKey: systemStatusQueryKey,
     queryFn: async (): Promise<SystemStatusResponse> => {
@@ -30,7 +30,7 @@ export function useSystemStatus(options?: { enabled?: boolean }) {
       return response.body
     },
     enabled: options?.enabled,
-    refetchInterval: 30_000,
+    refetchInterval: options?.refetchIntervalMs ?? 30_000,
     refetchOnWindowFocus: true,
     retry: 1,
   })

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -73,6 +73,7 @@ services:
       HOTSPOT_SSID: ${HOTSPOT_SSID:-Stone Frigate}
       NETWORK_STATUS_FILE_PATH: /run/sentinel/network-status/network-status.json
       HOST_HOTSPOT_RECOVERY_REQUEST_DIR: /run/sentinel/hotspot-recovery/requests
+      HOST_HOTSPOT_RECOVERY_STATUS_FILE: /run/sentinel/hotspot-recovery/status.json
       SYSTEM_UPDATE_BRIDGE_SOCKET_PATH: /run/sentinel/update-bridge.sock
       SYSTEM_UPDATE_STATE_ROOT: /var/lib/sentinel/updater
       SYSTEM_UPDATE_RELEASE_REPOSITORY: ${GHCR_OWNER:-deadshotomega}/sentinel

--- a/deploy/process-host-hotspot-recovery-requests.sh
+++ b/deploy/process-host-hotspot-recovery-requests.sh
@@ -31,9 +31,10 @@ fi
 
 for request_file in "${requests[@]}"; do
   base_name="$(basename "${request_file}")"
+  request_id="${base_name%.json}"
   log "Processing host hotspot recovery request ${base_name}"
 
-  if "${SCRIPT_DIR}/recover-host-hotspot.sh" "${CONNECTION_NAME}"; then
+  if "${SCRIPT_DIR}/recover-host-hotspot.sh" "${CONNECTION_NAME}" "${request_id}"; then
     mv "${request_file}" "${PROCESSED_DIR}/${base_name}"
     log "Host hotspot recovery request ${base_name} completed."
   else

--- a/deploy/recover-host-hotspot.sh
+++ b/deploy/recover-host-hotspot.sh
@@ -7,20 +7,97 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/ensure-host-hotspot-profile.sh"
 
 CONNECTION_NAME="${1:-$(env_value HOTSPOT_CONNECTION_NAME 'Sentinel Hotspot')}"
+REQUEST_ID="${2:-}"
 SSID_WAIT_TIMEOUT="${SSID_WAIT_TIMEOUT:-20}"
 SSID_POLL_INTERVAL="${SSID_POLL_INTERVAL:-2}"
 HOTSPOT_BAND="$(env_value HOTSPOT_BAND 'bg')"
 HOTSPOT_CHANNEL="$(env_value HOTSPOT_CHANNEL '1')"
 LOCK_FILE="${LOCK_FILE:-/run/lock/sentinel-host-hotspot-recover.lock}"
+STATUS_FILE="${HOST_HOTSPOT_RECOVERY_STATUS_FILE:-${SCRIPT_DIR}/runtime/hotspot-recovery/status.json}"
 export HOTSPOT_CONNECTION_NAME_OVERRIDE="${CONNECTION_NAME}"
+
+STARTED_AT="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+DEVICE=""
+SSID=""
+SCAN_DEVICE=""
+USB_DEVICE_NAME=""
+hardware_reset_applied="false"
 
 log() {
   printf '[host-hotspot-recover] %s\n' "$*"
 }
 
 die() {
+  recovery_write_status "failed" "failed" "$*" "true" || true
   printf '[host-hotspot-recover] %s\n' "$*" >&2
   exit 1
+}
+
+json_string_or_null() {
+  local value="${1:-}"
+  if [[ -z "${value}" ]]; then
+    printf 'null'
+    return 0
+  fi
+
+  printf '"%s"' "$(json_escape "${value}")"
+}
+
+recovery_write_status() {
+  local state="$1"
+  local stage="$2"
+  local message="$3"
+  local completed="${4:-false}"
+  local updated_at completed_at tmp_file had_errexit
+
+  updated_at="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+  if [[ "${completed}" == "true" ]]; then
+    completed_at="${updated_at}"
+  else
+    completed_at=""
+  fi
+
+  had_errexit="false"
+  case "$-" in
+    *e*)
+      had_errexit="true"
+      set +e
+      ;;
+  esac
+
+  mkdir -p "$(dirname "${STATUS_FILE}")" >/dev/null 2>&1
+  tmp_file="$(mktemp "$(dirname "${STATUS_FILE}")/status.XXXXXX" 2>/dev/null)"
+  if [[ -z "${tmp_file}" ]]; then
+    if [[ "${had_errexit}" == "true" ]]; then
+      set -e
+    fi
+    return 0
+  fi
+
+  cat >"${tmp_file}" <<JSON
+{
+  "state": "$(json_escape "${state}")",
+  "stage": "$(json_escape "${stage}")",
+  "message": "$(json_escape "${message}")",
+  "requestId": $(json_string_or_null "${REQUEST_ID}"),
+  "connectionName": $(json_string_or_null "${CONNECTION_NAME}"),
+  "hotspotSsid": $(json_string_or_null "${SSID:-}"),
+  "hotspotDevice": $(json_string_or_null "${DEVICE:-}"),
+  "scanDevice": $(json_string_or_null "${SCAN_DEVICE:-}"),
+  "usbDevice": $(json_string_or_null "${USB_DEVICE_NAME:-}"),
+  "hardwareResetApplied": $(json_bool "${hardware_reset_applied:-false}"),
+  "startedAt": "$(json_escape "${STARTED_AT}")",
+  "updatedAt": "$(json_escape "${updated_at}")",
+  "completedAt": $(json_string_or_null "${completed_at}")
+}
+JSON
+  chmod 664 "${tmp_file}" >/dev/null 2>&1 || true
+  mv "${tmp_file}" "${STATUS_FILE}" >/dev/null 2>&1 || rm -f "${tmp_file}" >/dev/null 2>&1 || true
+
+  if [[ "${had_errexit}" == "true" ]]; then
+    set -e
+  fi
+  return 0
 }
 
 have_command() {
@@ -85,6 +162,7 @@ wait_for_ssid() {
 
 stop_hotspot() {
   log "Bringing hotspot connection down"
+  recovery_write_status "running" "stopping_hotspot" "Stopping the hotspot before resetting the USB AP dongle."
   nmcli -w 15 connection down "${CONNECTION_NAME}" >/dev/null 2>&1 || true
 }
 
@@ -147,6 +225,7 @@ move_client_wifi_off_hotspot_adapter() {
   original_interface="$(connection_interface_name "${client_connection}" || true)"
 
   log "Moving internet Wi-Fi profile ${client_connection} (${client_ssid}) from AP dongle ${hotspot_device} to scan radio ${scan_device}"
+  recovery_write_status "running" "moving_internet_wifi" "Moving internet Wi-Fi off the USB AP dongle so the dongle can host the Sentinel hotspot."
   nmcli connection modify "${client_connection}" \
     connection.interface-name "${scan_device}" \
     connection.autoconnect yes \
@@ -174,6 +253,7 @@ reset_driver_binding() {
   fi
 
   log "Rebinding driver function ${usb_function_name}"
+  recovery_write_status "running" "resetting_driver" "Resetting the USB AP dongle driver. The adapter may disappear briefly."
   printf '%s' "${usb_function_name}" >"${driver_unbind}"
   sleep 2
   printf '%s' "${usb_function_name}" >"${driver_bind}"
@@ -188,6 +268,7 @@ reset_usb_device() {
 
   if [[ -w "${usb_authorized}" ]]; then
     log "Toggling USB authorization for ${usb_device_name}"
+    recovery_write_status "running" "resetting_usb" "Power-cycling the USB AP dongle. The adapter may take about 10 seconds to return."
     printf '0' >"${usb_authorized}"
     sleep 2
     printf '1' >"${usb_authorized}"
@@ -196,6 +277,7 @@ reset_usb_device() {
 
   if [[ -w "${usb_unbind}" && -w "${usb_bind}" ]]; then
     log "Rebinding USB device ${usb_device_name}"
+    recovery_write_status "running" "resetting_usb" "Rebinding the USB AP dongle. The adapter may take about 10 seconds to return."
     printf '%s' "${usb_device_name}" >"${usb_unbind}"
     sleep 2
     printf '%s' "${usb_device_name}" >"${usb_bind}"
@@ -215,13 +297,16 @@ have_command flock || die "flock is required"
 mkdir -p "$(dirname "${LOCK_FILE}")"
 exec 9>"${LOCK_FILE}"
 if ! flock -n 9; then
+  recovery_write_status "running" "processing_request" "Host hotspot recovery is already running; reusing the active recovery attempt."
   log "Host hotspot recovery is already running; reusing the active recovery attempt"
   exit 0
 fi
 
 skip_visibility_check="false"
+recovery_write_status "running" "processing_request" "Host hotspot recovery started."
 move_client_wifi_off_hotspot_adapter
 
+recovery_write_status "running" "ensuring_profile" "Checking and repairing the managed Sentinel hotspot profile."
 if ensure_host_hotspot_profile; then
   :
 else
@@ -294,6 +379,7 @@ log "Driver: ${DRIVER_NAME:-unknown}"
 log "Security mode: ${KEY_MGMT:-unknown}"
 
 log "Reapplying known-good hotspot radio settings"
+recovery_write_status "running" "ensuring_profile" "Reapplying known-good hotspot radio settings."
 nmcli connection modify "${CONNECTION_NAME}" \
   802-11-wireless.band "${HOTSPOT_BAND}" \
   802-11-wireless.channel "${HOTSPOT_CHANNEL}" \
@@ -305,7 +391,6 @@ fi
 
 stop_hotspot
 
-hardware_reset_applied="false"
 if [[ -n "${USB_FUNCTION_NAME}" && -n "${DRIVER_NAME}" ]] && reset_driver_binding "${DRIVER_UNBIND}" "${DRIVER_BIND}" "${USB_FUNCTION_NAME}"; then
   hardware_reset_applied="true"
 elif [[ -n "${USB_DEVICE_NAME}" ]]; then
@@ -323,9 +408,11 @@ if [[ "${hardware_reset_applied}" == "true" ]] && have_command udevadm; then
   udevadm settle || true
 fi
 
+recovery_write_status "running" "waiting_for_adapter" "Waiting for the USB AP dongle to reappear after reset. This can take about 10 seconds."
 wait_for_path "/sys/class/net/${DEVICE}" 20 || die "Interface ${DEVICE} did not come back after recovery"
 wait_for_nm_device "${DEVICE}" 20 || die "NetworkManager did not rediscover ${DEVICE} after recovery"
 
+recovery_write_status "running" "starting_hotspot" "Starting the Sentinel hotspot on the USB AP dongle."
 if ! start_hotspot "${DEVICE}"; then
   die "Failed to bring hotspot connection ${CONNECTION_NAME} up on ${DEVICE}"
 fi
@@ -340,17 +427,21 @@ fi
 
 if [[ "${skip_visibility_check}" == "true" || -z "${SCAN_DEVICE}" || -z "${SSID}" ]]; then
   log "Host hotspot recovery complete without a scan-radio visibility check"
+  recovery_write_status "completed" "completed" "Host hotspot recovery completed without a scan-radio visibility check." "true"
   exit 0
 fi
 
 if [[ -n "${SCAN_DEVICE}" && -n "${SSID}" ]]; then
   log "Waiting up to ${SSID_WAIT_TIMEOUT}s for ${SSID} to appear on ${SCAN_DEVICE}"
+  recovery_write_status "running" "verifying_visibility" "Checking whether the scan radio can see the Sentinel hotspot."
   if wait_for_ssid "${SCAN_DEVICE}" "${SSID}" "${SSID_WAIT_TIMEOUT}" "${SSID_POLL_INTERVAL}"; then
     log "The SSID ${SSID} is visible from ${SCAN_DEVICE}"
   else
     log "The hotspot restarted, but ${SCAN_DEVICE} still cannot see ${SSID} after ${SSID_WAIT_TIMEOUT}s"
+    recovery_write_status "failed" "failed" "The hotspot restarted, but the scan radio still cannot see ${SSID} after ${SSID_WAIT_TIMEOUT}s." "true"
     exit 2
   fi
 fi
 
 log "Host hotspot recovery complete"
+recovery_write_status "completed" "completed" "Host hotspot recovery completed. The Sentinel hotspot is visible from the scan radio." "true"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.3.7",
+  "version": "3.3.8",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.3.7",
+  "version": "3.3.8",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/contracts/src/schemas/system-status.schema.ts
+++ b/packages/contracts/src/schemas/system-status.schema.ts
@@ -35,6 +35,45 @@ export const NetworkIssueCodeSchema = v.picklist(
   'Choose a valid network issue code'
 )
 
+export const HostHotspotRecoveryStateSchema = v.picklist(
+  ['queued', 'running', 'completed', 'failed'],
+  'Choose a valid host hotspot recovery state'
+)
+
+export const HostHotspotRecoveryStageSchema = v.picklist(
+  [
+    'request_queued',
+    'processing_request',
+    'moving_internet_wifi',
+    'ensuring_profile',
+    'stopping_hotspot',
+    'resetting_driver',
+    'resetting_usb',
+    'waiting_for_adapter',
+    'starting_hotspot',
+    'verifying_visibility',
+    'completed',
+    'failed',
+  ],
+  'Choose a valid host hotspot recovery stage'
+)
+
+export const HostHotspotRecoveryStatusSchema = v.object({
+  state: HostHotspotRecoveryStateSchema,
+  stage: HostHotspotRecoveryStageSchema,
+  message: v.string(),
+  requestId: v.nullable(v.string()),
+  connectionName: v.nullable(v.string()),
+  hotspotSsid: v.nullable(v.string()),
+  hotspotDevice: v.nullable(v.string()),
+  scanDevice: v.nullable(v.string()),
+  usbDevice: v.nullable(v.string()),
+  hardwareResetApplied: v.nullable(v.boolean()),
+  startedAt: v.nullable(v.string()),
+  updatedAt: v.string(),
+  completedAt: v.nullable(v.string()),
+})
+
 export const NetworkFactsSchema = v.object({
   status: SystemHealthStatusSchema,
   telemetryAvailable: v.boolean(),
@@ -60,6 +99,7 @@ export const NetworkFactsSchema = v.object({
   remoteTarget: v.nullable(v.string()),
   remoteReachable: v.nullable(v.boolean()),
   portalRecoveryLikely: v.nullable(v.boolean()),
+  hostHotspotRecovery: v.optional(v.nullable(HostHotspotRecoveryStatusSchema)),
   generatedAt: v.nullable(v.string()),
 })
 
@@ -101,6 +141,9 @@ export type SystemHealthStatus = v.InferOutput<typeof SystemHealthStatusSchema>
 export type BackendHealth = v.InferOutput<typeof BackendHealthSchema>
 export type DatabaseHealth = v.InferOutput<typeof DatabaseHealthSchema>
 export type NetworkIssueCode = v.InferOutput<typeof NetworkIssueCodeSchema>
+export type HostHotspotRecoveryState = v.InferOutput<typeof HostHotspotRecoveryStateSchema>
+export type HostHotspotRecoveryStage = v.InferOutput<typeof HostHotspotRecoveryStageSchema>
+export type HostHotspotRecoveryStatus = v.InferOutput<typeof HostHotspotRecoveryStatusSchema>
 export type NetworkFacts = v.InferOutput<typeof NetworkFactsSchema>
 export type ActiveRemoteSession = v.InferOutput<typeof ActiveRemoteSessionSchema>
 export type ActiveRemoteSystemsSummary = v.InferOutput<typeof ActiveRemoteSystemsSummarySchema>

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.3.7",
+  "version": "3.3.8",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.3.7",
+  "version": "3.3.8",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Adds live host hotspot recovery telemetry so Sentinel can show what the USB AP dongle is doing after Repair Host Hotspot is queued.
- Updates the Repair Host Hotspot dialog with a Watch reset step, progress bar, reset countdown, and AP dongle / USB device / scan-radio details.
- Writes host-side recovery stages from the deployment scripts while they move internet Wi-Fi, reset the USB adapter, restart the hotspot, and verify scan-radio visibility.
- Exposes recent recovery status through System Status and refreshes it more frequently while the repair dialog is open.
- Prepares Sentinel v3.3.8 as the next patch release.

## Why this change was needed

The host hotspot repair flow queued a repair request, but the UI did not show what was happening while the USB AP dongle reset. Operators could think nothing was happening and unplug the adapter too early, even though the dongle can take around 10 seconds to disappear, reset, and come back.

## What changed

### User-facing

- The repair dialog now shows a Watch reset step after Run repair.
- The Watch reset step tells the operator not to unplug the adapter yet while Sentinel waits for the USB AP dongle to return.
- The dialog shows a live activity panel with the current recovery stage, progress, AP dongle, USB device, scan radio, and last update time.
- The next manual reseat step stays disabled during the reset wait so the user has a clear reason to pause.

### Admin/operator-facing

- System Status can now include the most recent host hotspot recovery status.
- The recovery status is ignored after it becomes stale so old repair runs do not keep appearing as current activity.
- Docker configuration now passes the recovery status file path into the backend container.

### Backend/API

- Adds `hostHotspotRecovery` to the System Status network facts contract.
- Adds backend parsing for the recovery status JSON written by the host scripts.
- Regenerates OpenAPI documentation for the expanded System Status response.

### Database

- No database changes.

### Deployment/update

- Updates the host hotspot recovery processor to pass the request id into the recovery script.
- Updates `recover-host-hotspot.sh` to write stage updates such as resetting USB, waiting for adapter, starting hotspot, and verifying visibility.
- Bumps workspace versions to `3.3.8`.

### Tests

- Adds frontend logic coverage for the new reset-watch step.
- Adds backend service coverage for queued recovery status telemetry.

## User impact

Admins and operators will see visible progress after clicking Repair Host Hotspot. The flow now better explains that the USB AP dongle may briefly disappear and can take about 10 seconds to return before anyone should unplug or reseat hardware.

## Operator impact

Operators should use the normal Sentinel update flow. No manual configuration change is required. After update, host hotspot recovery writes `/opt/sentinel/deploy/runtime/hotspot-recovery/status.json` and the backend reads that status through the existing mounted runtime directory.

## Upgrade or migration notes

No database migration is required.

No manual operator action is required beyond the normal Sentinel update process and service restart.

## Risk and rollback notes

The main risk is that the recovery status file is best-effort telemetry. If the status file cannot be written or read, the repair request still queues and runs; the UI simply falls back to less detailed progress.

Rollback is safe because this change does not alter persistent database data. Older versions will ignore the recovery status file.

Verify by opening Repair Host Hotspot, queueing repair, and confirming the Watch reset step shows the running recovery stage before the antenna reseat step.

## Testing performed

- `pnpm --filter @sentinel/contracts build`
- `pnpm --filter backend typecheck`
- `pnpm --filter frontend-admin typecheck`
- `pnpm --filter backend lint`
- `pnpm --filter frontend-admin lint`
- `pnpm --filter frontend-admin exec vitest run src/components/network/host-hotspot-repair-dialog.logic.test.ts`
- `bash -n deploy/recover-host-hotspot.sh deploy/process-host-hotspot-recovery-requests.sh`
- `pnpm --filter backend openapi`
- `git diff --check`
- Playwright visual check at `1920x1080` for the Repair Host Hotspot dialog and Watch reset state.

Backend Vitest could not be run directly because the backend package does not currently expose a `vitest` binary in this workspace.

## Changelog candidates

- Added live Repair Host Hotspot progress so operators can see when the USB AP dongle is resetting, returning, restarting the hotspot, and being verified.
- Added a Watch reset step that pauses before asking an operator to unplug or reseat the adapter.
- Added host-side recovery status telemetry to System Status without requiring a database migration.
