### PR TITLE
Fix manual in/out modal alignment

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.3.10",
+  "version": "3.3.11",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.3.10",
+  "version": "3.3.11",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/components/checkins/manual-checkin-modal.tsx
+++ b/apps/frontend-admin/src/components/checkins/manual-checkin-modal.tsx
@@ -356,13 +356,13 @@ export function ManualCheckinModal({ open, onOpenChange }: ManualCheckinModalPro
             </div>
 
             {selectedMemberInfo ? (
-              <AppCard className="border border-base-300 bg-base-200/50">
-                <AppCardContent className="flex items-center gap-(--space-3) p-(--space-3)">
+              <div className="rounded-box border border-base-300 bg-base-200/50 p-(--space-3)">
+                <div className="flex items-center gap-(--space-3)">
                   <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-primary-fadded text-primary-fadded-content">
                     <ArrowRightLeft className="size-4" />
                   </span>
                   <div className="min-w-0 flex-1">
-                    <p className="text-xs uppercase tracking-wide text-base-content/55">
+                    <p className="text-xs font-medium uppercase text-base-content/55">
                       Selected member
                     </p>
                     <p className="truncate text-sm font-semibold text-base-content">
@@ -379,8 +379,8 @@ export function ManualCheckinModal({ open, onOpenChange }: ManualCheckinModalPro
                     <X className="size-3.5" />
                     <span className="sr-only">Clear selected member</span>
                   </button>
-                </AppCardContent>
-              </AppCard>
+                </div>
+              </div>
             ) : null}
 
             <div className="min-h-64 overflow-hidden rounded-box border border-base-300 bg-base-100">
@@ -415,12 +415,12 @@ export function ManualCheckinModal({ open, onOpenChange }: ManualCheckinModalPro
                   </p>
                 </div>
               ) : (
-                <ul className="menu max-h-64 overflow-y-auto p-(--space-2)">
+                <ul className="max-h-64 overflow-y-auto p-(--space-2)">
                   {eligibility.eligibleMembers.map((member) => (
                     <li key={member.id}>
                       <button
                         type="button"
-                        className="flex items-center justify-between gap-(--space-3)"
+                        className="flex w-full items-center justify-between gap-(--space-3) rounded-md px-(--space-3) py-(--space-2) text-left transition-colors hover:bg-base-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
                         data-testid={TID.checkins.manualModal.memberOption(member.id)}
                         onClick={() => {
                           setSelectedMemberInfo({
@@ -435,7 +435,7 @@ export function ManualCheckinModal({ open, onOpenChange }: ManualCheckinModalPro
                           setSubmitError(null)
                         }}
                       >
-                        <span className="min-w-0 text-left">
+                        <span className="min-w-0 flex-1">
                           <span className="block truncate text-sm font-medium text-base-content">
                             {member.displayName ??
                               `${member.rank} ${member.lastName}, ${member.firstName}`}
@@ -444,7 +444,11 @@ export function ManualCheckinModal({ open, onOpenChange }: ManualCheckinModalPro
                             {member.serviceNumber.slice(-3)}
                           </span>
                         </span>
-                        <AppBadge status={direction === 'in' ? 'success' : 'neutral'} size="sm">
+                        <AppBadge
+                          status={direction === 'in' ? 'success' : 'neutral'}
+                          size="sm"
+                          className="shrink-0"
+                        >
                           {direction === 'in' ? 'Ready in' : 'Present'}
                         </AppBadge>
                       </button>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.3.10",
+  "version": "3.3.11",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.3.10",
+  "version": "3.3.11",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.3.10",
+  "version": "3.3.11",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.3.10",
+  "version": "3.3.11",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Fixes the manual in/out modal so the selected member panel stays in one clean row.
- Fixes the member picker list so names, service numbers, and readiness badges no longer split into stray columns.
- Prepares Sentinel v3.3.11 as the next patch release.

## Why this change was needed

The manual in/out modal was using layout helpers that conflicted with the intended row layout. Admins could see member names, service numbers, and status badges broken into awkward columns, making the correction flow harder to read.

## What changed

### User-facing

- The selected member area now uses a simple modal surface with explicit horizontal alignment.
- The eligible member list now uses full-width selectable buttons instead of a DaisyUI menu layout.

### Admin/operator-facing

- Admins and DDS users should see a cleaner manual in/out correction flow when recording missed check-ins or check-outs.

### Backend/API

- No backend or API changes.

### Database

- No database changes or migrations.

### Deployment/update

- Package versions were synchronized to 3.3.11 for the patch release.

### Documentation

- No documentation changes.

### Tests

- Ran focused modal logic tests, frontend typecheck, frontend lint, version sync check, and git diff whitespace checks.

## User impact

Admins using Manual in/out will see member rows stay readable and aligned. The change does not alter the correction workflow or recorded check-in data.

## Operator impact

No operational action is required beyond applying the normal Sentinel update.

## Upgrade or migration notes

No upgrade action required. No database migration or configuration change is required.

## Risk and rollback notes

The risk is limited to frontend presentation inside the manual in/out modal. Rollback is safe by reverting this patch release; no data compatibility concerns are introduced.

## Testing performed

- `pnpm version:check`
- `pnpm --filter frontend-admin exec vitest run src/components/checkins/manual-checkin-modal.logic.test.ts`
- `pnpm --filter frontend-admin typecheck`
- `pnpm --filter frontend-admin lint` passed with existing warnings
- `git diff --check`

## Changelog candidates

- Fixed the manual in/out modal so member names, service numbers, and readiness badges stay aligned while Admins record missed check-ins or check-outs.
