### PR TITLE
Fix visitor event options in sign-in

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.3.11",
+  "version": "3.3.12",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.3.11",
+  "version": "3.3.12",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/components/kiosk/kiosk-member-scan-panel.tsx
+++ b/apps/frontend-admin/src/components/kiosk/kiosk-member-scan-panel.tsx
@@ -305,7 +305,7 @@ export function KioskMemberScanPanel({
                 if (scanningDisabled) return
                 onSubmitScan()
               }}
-              className="mt-(--space-4) grid gap-(--space-4) rounded-box border border-base-300 bg-base-200/50 p-(--space-4) xl:grid-cols-[minmax(0,1fr)_auto]"
+              className="mt-auto grid gap-(--space-4) rounded-box border border-base-300 bg-base-200/50 p-(--space-4) xl:grid-cols-[minmax(0,1fr)_auto]"
             >
               <div className="space-y-(--space-3)">
                 <div>

--- a/apps/frontend-admin/src/components/kiosk/visitor-self-signin-flow.tsx
+++ b/apps/frontend-admin/src/components/kiosk/visitor-self-signin-flow.tsx
@@ -268,6 +268,39 @@ export function VisitorSelfSigninFlow({
     })
   }, [eventListQuery.data, normalizedEventSearch])
 
+  const selectedEventDetailsQuery = useQuery({
+    queryKey: ['kiosk-unit-event', selectedEvent?.id],
+    enabled: requiresEventSelection && Boolean(selectedEvent?.id),
+    queryFn: async (): Promise<EventOption> => {
+      if (!selectedEvent?.id) {
+        throw new Error('Select an event before loading event options')
+      }
+
+      const response = await apiClient.unitEvents.getUnitEvent({
+        params: { id: selectedEvent.id },
+      })
+
+      if (response.status !== 200) {
+        throw new Error('Failed to fetch event options')
+      }
+
+      return {
+        id: response.body.id,
+        title: response.body.title,
+        eventDateLabel: formatUnitEventDateRange(response.body, 'MMM d, yyyy'),
+        visitorOptions: response.body.visitorOptions.map((option) => ({
+          id: option.id,
+          title: option.title,
+          maxSelections: option.maxSelections,
+          selectedCount: option.selectedCount,
+        })),
+      }
+    },
+  })
+
+  const selectedEventForDisplay = selectedEventDetailsQuery.data ?? selectedEvent
+  const selectedEventVisitorOptions = selectedEventForDisplay?.visitorOptions ?? []
+
   const focusKeyboardField = (name: KeyboardFieldName, nextValueLength?: number) => {
     const fieldElement = fieldRefs.current[name]
     if (!fieldElement) return
@@ -860,10 +893,10 @@ export function VisitorSelfSigninFlow({
         hostMemberId: values.hostMemberId,
         hostDisplayName: selectedHost?.displayName,
         eventId: values.eventId,
-        eventTitle: selectedEvent?.title,
-        eventDateLabel: selectedEvent?.eventDateLabel,
+        eventTitle: selectedEventForDisplay?.title,
+        eventDateLabel: selectedEventForDisplay?.eventDateLabel,
         eventOptionId: values.unitEventVisitorOptionId,
-        eventOptionTitle: selectedEvent?.visitorOptions.find(
+        eventOptionTitle: selectedEventForDisplay?.visitorOptions.find(
           (option) => option.id === values.unitEventVisitorOptionId
         )?.title,
       })
@@ -932,9 +965,9 @@ export function VisitorSelfSigninFlow({
   const reviewOrganization = trimValue(organization)
   const reviewWorkDescription = trimValue(workDescription)
   const reviewHostName = selectedHost?.displayName
-  const reviewEventTitle = selectedEvent?.title
-  const reviewEventDate = selectedEvent?.eventDateLabel
-  const selectedEventOption = selectedEvent?.visitorOptions.find(
+  const reviewEventTitle = selectedEventForDisplay?.title
+  const reviewEventDate = selectedEventForDisplay?.eventDateLabel
+  const selectedEventOption = selectedEventForDisplay?.visitorOptions.find(
     (option) => option.id === unitEventVisitorOptionId
   )
   const hasCurrentMemberForReview = followsMilitaryPath
@@ -1304,7 +1337,8 @@ export function VisitorSelfSigninFlow({
                                 <div>
                                   <p className="font-semibold">{selectedEvent.title}</p>
                                   <p className="text-sm text-base-content/70">
-                                    {selectedEvent.eventDateLabel}
+                                    {selectedEventForDisplay?.eventDateLabel ??
+                                      selectedEvent.eventDateLabel}
                                   </p>
                                 </div>
                               </div>
@@ -1318,7 +1352,9 @@ export function VisitorSelfSigninFlow({
                               </button>
                             </div>
 
-                            {selectedEvent.visitorOptions.length > 0 && (
+                            {(selectedEventDetailsQuery.isLoading ||
+                              selectedEventDetailsQuery.isError ||
+                              selectedEventVisitorOptions.length > 0) && (
                               <div
                                 className="rounded-box border border-base-300 bg-base-100"
                                 style={{ padding: 'var(--space-3)' }}
@@ -1330,69 +1366,86 @@ export function VisitorSelfSigninFlow({
                                   You can continue without an option. Full options are only blocked
                                   for that choice.
                                 </p>
-                                <div className="mt-2 grid grid-cols-1 gap-2">
-                                  <button
-                                    type="button"
-                                    className={cn(
-                                      'btn btn-outline btn-md h-auto justify-between border-base-300 bg-base-100 text-left text-base-content hover:border-primary hover:bg-base-200',
-                                      !unitEventVisitorOptionId && 'border-primary bg-base-200'
-                                    )}
-                                    style={{
-                                      minHeight: '3rem',
-                                      padding: 'var(--space-2) var(--space-3)',
-                                    }}
-                                    onClick={() => {
-                                      setValue('unitEventVisitorOptionId', '', {
-                                        shouldValidate: true,
-                                      })
-                                      clearErrors('unitEventVisitorOptionId')
-                                    }}
+                                {selectedEventDetailsQuery.isLoading && (
+                                  <div
+                                    className="mt-2 flex items-center text-sm text-base-content/70"
+                                    style={{ gap: 'var(--space-2)' }}
                                   >
-                                    <span className="truncate">General event visitor</span>
-                                    <span className="text-sm font-normal text-base-content/70">
-                                      No option
-                                    </span>
-                                  </button>
-                                  {selectedEvent.visitorOptions.map((option) => {
-                                    const remaining =
-                                      option.maxSelections === null
-                                        ? null
-                                        : Math.max(option.maxSelections - option.selectedCount, 0)
-                                    const isFull = remaining === 0
-                                    const isSelected = unitEventVisitorOptionId === option.id
+                                    <span className="loading loading-spinner loading-xs" />
+                                    Loading event options.
+                                  </div>
+                                )}
+                                {selectedEventDetailsQuery.isError && (
+                                  <p className="mt-2 text-sm text-error">
+                                    Event options could not be loaded. Clear the event and try
+                                    again.
+                                  </p>
+                                )}
+                                {selectedEventVisitorOptions.length > 0 && (
+                                  <div className="mt-2 grid grid-cols-1 gap-2">
+                                    <button
+                                      type="button"
+                                      className={cn(
+                                        'btn btn-outline btn-md h-auto justify-between border-base-300 bg-base-100 text-left text-base-content hover:border-primary hover:bg-base-200',
+                                        !unitEventVisitorOptionId && 'border-primary bg-base-200'
+                                      )}
+                                      style={{
+                                        minHeight: '3rem',
+                                        padding: 'var(--space-2) var(--space-3)',
+                                      }}
+                                      onClick={() => {
+                                        setValue('unitEventVisitorOptionId', '', {
+                                          shouldValidate: true,
+                                        })
+                                        clearErrors('unitEventVisitorOptionId')
+                                      }}
+                                    >
+                                      <span className="truncate">General event visitor</span>
+                                      <span className="text-sm font-normal text-base-content/70">
+                                        No option
+                                      </span>
+                                    </button>
+                                    {selectedEventVisitorOptions.map((option) => {
+                                      const remaining =
+                                        option.maxSelections === null
+                                          ? null
+                                          : Math.max(option.maxSelections - option.selectedCount, 0)
+                                      const isFull = remaining === 0
+                                      const isSelected = unitEventVisitorOptionId === option.id
 
-                                    return (
-                                      <button
-                                        key={option.id}
-                                        type="button"
-                                        className={cn(
-                                          'btn btn-outline btn-md h-auto justify-between border-base-300 bg-base-100 text-left text-base-content hover:border-primary hover:bg-base-200',
-                                          isSelected && 'border-primary bg-base-200'
-                                        )}
-                                        style={{
-                                          minHeight: '3rem',
-                                          padding: 'var(--space-2) var(--space-3)',
-                                        }}
-                                        onClick={() => {
-                                          setValue('unitEventVisitorOptionId', option.id, {
-                                            shouldValidate: true,
-                                          })
-                                          clearErrors('unitEventVisitorOptionId')
-                                        }}
-                                        disabled={isFull}
-                                      >
-                                        <span className="truncate">{option.title}</span>
-                                        <span className="text-sm font-normal text-base-content/70">
-                                          {remaining === null
-                                            ? 'No limit'
-                                            : isFull
-                                              ? 'Full'
-                                              : `${remaining} available`}
-                                        </span>
-                                      </button>
-                                    )
-                                  })}
-                                </div>
+                                      return (
+                                        <button
+                                          key={option.id}
+                                          type="button"
+                                          className={cn(
+                                            'btn btn-outline btn-md h-auto justify-between border-base-300 bg-base-100 text-left text-base-content hover:border-primary hover:bg-base-200',
+                                            isSelected && 'border-primary bg-base-200'
+                                          )}
+                                          style={{
+                                            minHeight: '3rem',
+                                            padding: 'var(--space-2) var(--space-3)',
+                                          }}
+                                          onClick={() => {
+                                            setValue('unitEventVisitorOptionId', option.id, {
+                                              shouldValidate: true,
+                                            })
+                                            clearErrors('unitEventVisitorOptionId')
+                                          }}
+                                          disabled={isFull}
+                                        >
+                                          <span className="truncate">{option.title}</span>
+                                          <span className="text-sm font-normal text-base-content/70">
+                                            {remaining === null
+                                              ? 'No limit'
+                                              : isFull
+                                                ? 'Full'
+                                                : `${remaining} available`}
+                                          </span>
+                                        </button>
+                                      )
+                                    })}
+                                  </div>
+                                )}
                                 {errors.unitEventVisitorOptionId && (
                                   <p className="mt-2 text-sm text-error">
                                     {errors.unitEventVisitorOptionId.message}

--- a/apps/frontend-admin/src/components/visitors/visitor-signin-modal.tsx
+++ b/apps/frontend-admin/src/components/visitors/visitor-signin-modal.tsx
@@ -1,11 +1,12 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import { useForm } from 'react-hook-form'
 import { useCreateVisitor, useAvailableTemporaryBadges } from '@/hooks/use-visitors'
 import { useMembers } from '@/hooks/use-members'
 import { useUnitEvents } from '@/hooks/use-events'
 import { useAuthStore } from '@/store/auth-store'
+import { cn } from '@/lib/utils'
 import { Search, X } from 'lucide-react'
 import type { CreateVisitorInput } from '@sentinel/contracts'
 
@@ -23,6 +24,7 @@ interface FormData {
   visitReason: string
   hostMemberId: string
   eventId: string
+  unitEventVisitorOptionId: string
   temporaryBadgeId: string
   adminNotes: string
 }
@@ -76,14 +78,24 @@ export function VisitorSigninModal({ open, onOpenChange }: VisitorSigninModalPro
       visitReason: '',
       hostMemberId: '',
       eventId: '',
+      unitEventVisitorOptionId: '',
       temporaryBadgeId: '',
       adminNotes: '',
     },
   })
 
   const selectedBadgeId = watch('temporaryBadgeId')
+  const selectedEventId = watch('eventId')
+  const selectedEventOptionId = watch('unitEventVisitorOptionId')
   const firstNameRegister = register('firstName', { required: 'First name is required' })
   const lastNameRegister = register('lastName', { required: 'Last name is required' })
+  const eventIdRegister = register('eventId')
+  const eventOptionRegister = register('unitEventVisitorOptionId')
+  const selectedEvent = useMemo(
+    () => eventsData?.data.find((event) => event.id === selectedEventId) ?? null,
+    [eventsData?.data, selectedEventId]
+  )
+  const selectedEventVisitorOptions = selectedEvent?.visitorOptions ?? []
 
   // Sync open prop with dialog element
   useEffect(() => {
@@ -133,6 +145,9 @@ export function VisitorSigninModal({ open, onOpenChange }: VisitorSigninModalPro
       if (data.visitReason) visitorData.visitReason = data.visitReason
       if (data.hostMemberId) visitorData.hostMemberId = data.hostMemberId
       if (data.eventId) visitorData.unitEventId = data.eventId
+      if (data.unitEventVisitorOptionId) {
+        visitorData.unitEventVisitorOptionId = data.unitEventVisitorOptionId
+      }
       if (data.temporaryBadgeId) visitorData.temporaryBadgeId = data.temporaryBadgeId
       if (data.adminNotes) visitorData.adminNotes = data.adminNotes
 
@@ -317,17 +332,84 @@ export function VisitorSigninModal({ open, onOpenChange }: VisitorSigninModalPro
 
           {/* Event */}
           {eventsData?.data && eventsData.data.length > 0 && (
-            <label className="select select-neutral w-full">
-              <span className="label">Event</span>
-              <select {...register('eventId')} disabled={isSubmitting}>
-                <option value="">No event</option>
-                {eventsData.data.map((event) => (
-                  <option key={event.id} value={event.id}>
-                    {event.title}
-                  </option>
-                ))}
-              </select>
-            </label>
+            <div className="space-y-2">
+              <label className="select select-neutral w-full">
+                <span className="label">Event</span>
+                <select
+                  {...eventIdRegister}
+                  disabled={isSubmitting}
+                  onChange={(event) => {
+                    void eventIdRegister.onChange(event)
+                    setValue('unitEventVisitorOptionId', '')
+                  }}
+                >
+                  <option value="">No event</option>
+                  {eventsData.data.map((event) => (
+                    <option key={event.id} value={event.id}>
+                      {event.title}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <input type="hidden" {...eventOptionRegister} />
+
+              {selectedEventVisitorOptions.length > 0 && (
+                <section className="rounded-box border border-base-300 bg-base-200 p-(--space-3)">
+                  <div>
+                    <p className="text-sm font-semibold text-base-content">Event option</p>
+                    <p className="text-xs text-base-content/65">
+                      Select one if it applies. Visitors can still sign in without choosing an
+                      option.
+                    </p>
+                  </div>
+                  <div className="mt-(--space-2) grid gap-(--space-2)">
+                    <button
+                      type="button"
+                      className={cn(
+                        'btn btn-outline h-auto justify-between border-base-300 bg-base-100 px-(--space-3) py-(--space-2) text-left',
+                        !selectedEventOptionId && 'border-primary bg-primary-fadded'
+                      )}
+                      onClick={() => setValue('unitEventVisitorOptionId', '')}
+                      disabled={isSubmitting}
+                    >
+                      <span className="truncate">General event visitor</span>
+                      <span className="text-xs font-normal text-base-content/65">No option</span>
+                    </button>
+
+                    {selectedEventVisitorOptions.map((option) => {
+                      const remaining =
+                        option.maxSelections === null
+                          ? null
+                          : Math.max(option.maxSelections - option.selectedCount, 0)
+                      const isFull = remaining === 0
+                      const isSelected = selectedEventOptionId === option.id
+
+                      return (
+                        <button
+                          key={option.id}
+                          type="button"
+                          className={cn(
+                            'btn btn-outline h-auto justify-between border-base-300 bg-base-100 px-(--space-3) py-(--space-2) text-left',
+                            isSelected && 'border-primary bg-primary-fadded'
+                          )}
+                          onClick={() => setValue('unitEventVisitorOptionId', option.id)}
+                          disabled={isSubmitting || isFull}
+                        >
+                          <span className="truncate">{option.title}</span>
+                          <span className="text-xs font-normal text-base-content/65">
+                            {remaining === null
+                              ? 'No limit'
+                              : isFull
+                                ? 'Full'
+                                : `${remaining} available`}
+                          </span>
+                        </button>
+                      )
+                    })}
+                  </div>
+                </section>
+              )}
+            </div>
           )}
 
           {/* Temporary Badge */}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.3.11",
+  "version": "3.3.12",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.3.11",
+  "version": "3.3.12",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.3.11",
+  "version": "3.3.12",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.3.11",
+  "version": "3.3.12",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Shows configured event sign-in options after a visitor selects an event during kiosk sign-in.
- Adds the same event option picker to Admin visitor sign-in so Admin-entered visitors can be assigned to an event option.
- Moves the kiosk Staff fallback only manual badge entry to the bottom of the member scan panel so it is visually separated from normal scanner use.
- Prepares Sentinel v3.3.12 as the next patch release.

## Why this change was needed

Visitors were able to select an event, but the event-specific visitor options were not reliably appearing in the sign-in flow. That made capped choices such as Gallery Attendee or wedding-side selections unavailable at the moment visitors needed them. The kiosk fallback input was also sitting too close to the scanner status, which made the manual staff-only path feel more prominent than intended.

## What changed

### User-facing

- Kiosk Visitor Sign-in now refreshes selected event details and shows event options below Select Event.
- Visitors can still continue as a general event visitor without choosing a capped option.
- Full event options are disabled while still showing that they are full.
- The Staff fallback only panel now sits at the bottom of the member scan column.

### Admin/operator-facing

- Admin Visitor Sign-in now shows event options under the Event selector and submits the selected event option when one is chosen.
- Kiosk operators will see clearer separation between normal scanner operation and manual staff fallback entry.

### Backend/API

- No backend or API changes.

### Database

- No database schema changes or migrations.

### Deployment/update

- Package versions were synchronized to 3.3.12 for the patch release.

### Documentation

- No documentation changes.

### Tests

- Ran visitor sign-in unit tests, frontend typecheck, frontend lint, version sync check, and whitespace checks.

## User impact

Visitors selecting an event will now see the event options that were configured for that event. They can choose one when appropriate or continue without selecting one.

## Operator impact

Admins can assign manually signed-in visitors to event options. Kiosk staff will see the manual badge fallback lower on the page, making it clearer that members should use the external scanner first.

## Upgrade or migration notes

No upgrade action required. No database migration or configuration change is required.

## Risk and rollback notes

The main risk is limited to frontend display and form submission in visitor sign-in flows. Rollback is safe by reverting this patch release; no data compatibility concerns are introduced.

## Testing performed

- `pnpm version:check`
- `pnpm --filter frontend-admin exec vitest run src/lib/visitor-self-signin.test.ts`
- `pnpm --filter frontend-admin typecheck`
- `pnpm --filter frontend-admin lint` passed with existing warnings
- `git diff --check`

## Changelog candidates

- Fixed visitor event options so they appear after an event is selected during visitor sign-in.
- Added event option selection to Admin visitor sign-in.
- Moved the kiosk staff fallback badge entry to the bottom of the scan panel so normal scanner use stays visually primary.
