### PR TITLE
fix(kiosk): keep device auth redirects on the public host

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/app/kiosk/device-auth/route.ts
+++ b/apps/frontend-admin/src/app/kiosk/device-auth/route.ts
@@ -4,6 +4,7 @@ import { KIOSK_DEVICE_COOKIE_NAME, resolveKioskBootstrapNext } from '@/lib/kiosk
 import {
   getConfiguredKioskDeviceApiKey,
   getKioskDeviceCookieMaxAgeSeconds,
+  resolvePublicRequestUrl,
 } from '@/lib/kiosk-device-auth.server'
 
 function shouldUseSecureCookie(request: NextRequest): boolean {
@@ -12,7 +13,8 @@ function shouldUseSecureCookie(request: NextRequest): boolean {
 
 export async function GET(request: NextRequest) {
   const nextPath = resolveKioskBootstrapNext(request.nextUrl.searchParams.get('next'))
-  const loginUrl = new globalThis.URL(buildLoginUrl('/kiosk'), request.url)
+  const publicRequestUrl = resolvePublicRequestUrl(request)
+  const loginUrl = new globalThis.URL(buildLoginUrl('/kiosk'), publicRequestUrl)
   const configuredApiKey = getConfiguredKioskDeviceApiKey()
 
   if (!configuredApiKey) {
@@ -21,7 +23,7 @@ export async function GET(request: NextRequest) {
     return response
   }
 
-  const response = NextResponse.redirect(new globalThis.URL(nextPath, request.url))
+  const response = NextResponse.redirect(new globalThis.URL(nextPath, publicRequestUrl))
   response.cookies.set(KIOSK_DEVICE_COOKIE_NAME, configuredApiKey, {
     httpOnly: true,
     sameSite: 'lax',

--- a/apps/frontend-admin/src/lib/kiosk-device-auth.server.test.ts
+++ b/apps/frontend-admin/src/lib/kiosk-device-auth.server.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { resolvePublicRequestUrl } from './kiosk-device-auth.server'
+
+describe('kiosk device auth server helpers', () => {
+  it('uses reverse-proxy host and protocol for public redirects', () => {
+    const request = new Request('http://localhost:3001/kiosk/device-auth?next=%2Fkiosk', {
+      headers: {
+        host: 'localhost:3001',
+        'x-forwarded-host': 'sentinel.local',
+        'x-forwarded-proto': 'http',
+      },
+    })
+
+    expect(resolvePublicRequestUrl(request).toString()).toBe(
+      'http://sentinel.local/kiosk/device-auth?next=%2Fkiosk'
+    )
+  })
+
+  it('falls back to the request host when no forwarded host exists', () => {
+    const request = new Request('http://10.42.0.1/kiosk/device-auth?next=%2Fkiosk', {
+      headers: {
+        host: '10.42.0.1',
+      },
+    })
+
+    expect(resolvePublicRequestUrl(request).toString()).toBe(
+      'http://10.42.0.1/kiosk/device-auth?next=%2Fkiosk'
+    )
+  })
+})

--- a/apps/frontend-admin/src/lib/kiosk-device-auth.server.ts
+++ b/apps/frontend-admin/src/lib/kiosk-device-auth.server.ts
@@ -1,4 +1,4 @@
-/* global process */
+/* global Headers, Request, URL, process */
 
 const KIOSK_DEVICE_API_KEY_ENV = 'SENTINEL_KIOSK_DEVICE_API_KEY'
 const KIOSK_DEVICE_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30
@@ -18,4 +18,40 @@ export function isKioskDeviceAuthConfigured(): boolean {
 
 export function getKioskDeviceCookieMaxAgeSeconds(): number {
   return KIOSK_DEVICE_COOKIE_MAX_AGE_SECONDS
+}
+
+function getForwardedHeaderValue(headers: Headers, name: string): string | null {
+  const value = headers.get(name)?.split(',')[0]?.trim()
+  return value && value.length > 0 ? value : null
+}
+
+function applyPublicHost(publicUrl: URL, host: string): void {
+  try {
+    const hostUrl = new URL(`http://${host}`)
+    publicUrl.hostname = hostUrl.hostname
+    publicUrl.port = hostUrl.port
+  } catch {
+    publicUrl.host = host
+  }
+}
+
+export function resolvePublicRequestUrl(request: Request): URL {
+  const publicUrl = new URL(request.url)
+  const forwardedHost =
+    getForwardedHeaderValue(request.headers, 'x-forwarded-host') ??
+    getForwardedHeaderValue(request.headers, 'host')
+
+  if (forwardedHost) {
+    applyPublicHost(publicUrl, forwardedHost)
+  }
+
+  const forwardedProtocol = getForwardedHeaderValue(request.headers, 'x-forwarded-proto')
+
+  if (forwardedProtocol) {
+    publicUrl.protocol = forwardedProtocol.endsWith(':')
+      ? forwardedProtocol
+      : `${forwardedProtocol}:`
+  }
+
+  return publicUrl
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Fixes kiosk device-auth redirects so kiosks stay on the public Sentinel host after receiving their device cookie.
- Prevents kiosk laptops from being sent to the internal Next.js runtime URL, such as `localhost:3001`.
- Adds focused test coverage for reverse-proxy host and protocol handling.
- Prepares Sentinel `v3.3.13` as a patch release.

## Why this change was needed

A kiosk could show `Disconnected` even when the Server/System Status looked healthy. The kiosk bootstrap route was setting the kiosk device cookie, then redirecting to the internal frontend runtime host. On another laptop, that host is not the Sentinel appliance, so the kiosk could lose the working host context and fail its own status checks.

## What changed

### User-facing

- Kiosk laptops should remain on the same public Sentinel address they used to open `/kiosk`.
- The kiosk should no longer be redirected to `localhost:3001` after device bootstrap.

### Admin/operator-facing

- Operators should see fewer false `Disconnected` kiosk states when the server itself is healthy.
- Existing kiosk device auth configuration continues to work.

### Backend/API

- No backend API change.

### Database

- No database change.

### Deployment/update

- Bumps workspace versions to `3.3.13`.
- No new environment variables are required.

### Documentation

- No documentation change.

### Tests

- Adds tests for kiosk public URL resolution behind the reverse proxy.

## User impact

Kiosk users should stay on the correct Sentinel appliance URL after opening the kiosk page. If the server is healthy, the kiosk is less likely to report a confusing disconnected state caused by a bad redirect.

## Operator impact

After updating, operators should refresh or reopen the kiosk page. No configuration changes are required.

## Upgrade or migration notes

No upgrade action required beyond the normal Sentinel appliance update to `v3.3.13`. No database migration is required.

## Risk and rollback notes

Risk is low. The change only affects the kiosk device-auth redirect target. Rollback to `v3.3.12` is safe if needed, but the kiosk redirect bug may return. Verify by opening `http://sentinel.local/kiosk` from a kiosk laptop and confirming it stays on the public Sentinel host.

## Testing performed

- `pnpm --filter frontend-admin exec vitest run src/lib/kiosk-device-auth.test.ts src/lib/kiosk-device-auth.server.test.ts`
- `pnpm --filter frontend-admin typecheck`
- `pnpm --filter frontend-admin lint` passed with existing warnings only.
- `pnpm version:check`
- `git diff --check`

## Changelog candidates

- Fixed kiosk device-auth redirects so kiosk laptops stay on the public Sentinel host instead of being sent to `localhost:3001`.
- Added coverage for reverse-proxy-aware kiosk bootstrap URL handling.
