### PR TITLE
fix(network): support closed local Sentinel operation

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.3.13",
+  "version": "3.3.14",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/services/system-status-service.test.ts
+++ b/apps/backend/src/services/system-status-service.test.ts
@@ -177,7 +177,7 @@ describe('SystemStatusService', () => {
     ).toBe(true)
   })
 
-  it('keeps network status healthy when internet reachability is unavailable but Wi-Fi is approved', async () => {
+  it('keeps network status healthy when captive portal blocks internet but hotspot is visible', async () => {
     const { service } = createService({
       approvedSsids: ['GC Public'],
       telemetryResult: {
@@ -200,8 +200,8 @@ describe('SystemStatusService', () => {
           internetReachable: false,
           remoteTarget: null,
           remoteReachable: null,
-          portalRecoveryLikely: false,
-          message: 'Connected to approved internet Wi-Fi',
+          portalRecoveryLikely: true,
+          message: 'Internet reachability failed while internet Wi-Fi is connected',
         },
         error: null,
       },
@@ -212,8 +212,12 @@ describe('SystemStatusService', () => {
     expect(result.network.status).toBe('healthy')
     expect(result.network.issueCode).toBe('none')
     expect(result.network.approvedSsid).toBe(true)
+    expect(result.network.internetReachable).toBe(false)
+    expect(result.network.portalRecoveryLikely).toBe(true)
+    expect(result.network.hotspotSsidVisibleFromLaptop).toBe(true)
     expect(result.network.hostIpAddress).toBe('192.168.8.1')
-    expect(result.network.message).toBe('Connected to approved internet Wi-Fi')
+    expect(result.network.message).toContain('internet access likely needs portal acceptance')
+    expect(result.network.message).toContain('"Stone Frigate" hotspot is still visible')
     expect(result.overall.status).toBe('healthy')
   })
 
@@ -257,6 +261,48 @@ describe('SystemStatusService', () => {
     expect(result.network.hotspotSsidVisibleFromLaptop).toBe(true)
     expect(result.network.message).toBe(
       'Sentinel hotspot is visible; internet Wi-Fi is not connected'
+    )
+  })
+
+  it('keeps network status healthy when internet reachability checks are disabled', async () => {
+    const { service } = createService({
+      approvedSsids: ['GC Public'],
+      telemetryResult: {
+        telemetry: {
+          generatedAt: new Date('2026-04-01T11:59:40.000Z'),
+          issueCode: 'none',
+          wifiConnected: true,
+          currentSsid: 'GC Public',
+          hostIpAddress: '10.42.0.1',
+          hotspotProfilePresent: true,
+          hotspotAdapterApproved: true,
+          scanAdapterPresent: true,
+          hotspotDevice: 'wlxb8fbb3c4e8ae',
+          hotspotSsid: 'Stone Frigate',
+          hotspotScanDevice: 'wlp0s20f3',
+          hotspotSsidVisibleFromLaptop: true,
+          hotspotAdapterBusy: false,
+          internetWifiConnection: null,
+          internetWifiSsid: null,
+          internetReachable: null,
+          remoteTarget: null,
+          remoteReachable: null,
+          portalRecoveryLikely: null,
+          message: 'Sentinel hotspot is visible; internet reachability check is not configured',
+        },
+        error: null,
+      },
+    })
+
+    const result = await service.getSystemStatus()
+
+    expect(result.network.status).toBe('healthy')
+    expect(result.network.issueCode).toBe('none')
+    expect(result.network.approvedSsid).toBe(true)
+    expect(result.network.internetReachable).toBeNull()
+    expect(result.network.hotspotSsidVisibleFromLaptop).toBe(true)
+    expect(result.network.message).toBe(
+      'Sentinel hotspot is visible; internet reachability check is not configured'
     )
   })
 

--- a/apps/backend/src/services/system-status-service.ts
+++ b/apps/backend/src/services/system-status-service.ts
@@ -121,6 +121,9 @@ function resolveNetworkStatusMessage(input: {
   approvedSsidsConfigured: boolean
   wifiConnected: boolean | null
   approvedSsid: boolean | null
+  internetReachable: boolean | null
+  portalRecoveryLikely: boolean | null
+  hotspotSsidVisibleFromLaptop: boolean | null
   hotspotSsid: string | null
   remoteTarget: string | null
   fallbackMessage: string | null
@@ -163,6 +166,22 @@ function resolveNetworkStatusMessage(input: {
     case 'none':
     default:
       break
+  }
+
+  if (input.portalRecoveryLikely === true && input.internetReachable === false) {
+    if (input.hotspotSsidVisibleFromLaptop === true && input.hotspotSsid) {
+      return `Connected to approved internet Wi-Fi, but internet access likely needs portal acceptance. The "${input.hotspotSsid}" hotspot is still visible.`
+    }
+
+    return 'Connected to approved internet Wi-Fi, but internet access likely needs portal acceptance.'
+  }
+
+  if (
+    input.internetReachable === null &&
+    input.hotspotSsidVisibleFromLaptop === true &&
+    input.fallbackMessage?.includes('internet reachability check is not configured')
+  ) {
+    return input.fallbackMessage
   }
 
   if (input.approvedSsidsConfigured && input.approvedSsid === true) {
@@ -373,6 +392,9 @@ export class SystemStatusService {
           approvedSsidsConfigured: approvedSsids.length > 0,
           wifiConnected: telemetry?.wifiConnected ?? null,
           approvedSsid,
+          internetReachable: telemetry?.internetReachable ?? null,
+          portalRecoveryLikely: telemetry?.portalRecoveryLikely ?? null,
+          hotspotSsidVisibleFromLaptop: telemetry?.hotspotSsidVisibleFromLaptop ?? null,
           hotspotSsid: telemetry?.hotspotSsid ?? null,
           remoteTarget: telemetry?.remoteTarget ?? null,
           fallbackMessage: telemetry?.message ?? null,

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.3.13",
+  "version": "3.3.14",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/app/globals.css
+++ b/apps/frontend-admin/src/app/globals.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&family=Roboto+Mono:ital,wght@0,100..700;1,100..700&family=Roboto+Slab:wght@100..900&display=swap');
-
 @import '../styles/tokens.css';
 @import 'driver.js/dist/driver.css';
 @import 'react-simple-keyboard/build/css/index.css';
@@ -68,10 +66,10 @@
 
 /* Custom Tailwind theme extensions */
 @theme {
-  --font-display: 'DM Sans', ui-sans-serif, system-ui, sans-serif;
-  --font-sans: 'Roboto', ui-sans-serif, system-ui, sans-serif;
-  --font-mono: 'Roboto Mono', ui-monospace, monospace;
-  --font-serif: 'Roboto Slab', ui-serif, Georgia, serif;
+  --font-display: ui-sans-serif, system-ui, sans-serif;
+  --font-sans: ui-sans-serif, system-ui, sans-serif;
+  --font-mono: ui-monospace, 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
+  --font-serif: ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
 }
 
 /* Apply font families globally */

--- a/apps/frontend-admin/src/components/admin/admin-control-center.tsx
+++ b/apps/frontend-admin/src/components/admin/admin-control-center.tsx
@@ -237,6 +237,15 @@ function getApprovedWifiTelemetry(
     }
   }
 
+  if (network.hotspotSsidVisibleFromLaptop === true && network.internetReachable !== true) {
+    return {
+      value: network.currentSsid ? `${network.currentSsid} optional` : 'Internet optional',
+      detail: `${network.hotspotSsid ?? 'Sentinel hotspot'} is visible; external internet is not required for Sentinel access.`,
+      badge: 'Local',
+      badgeStatus: 'info',
+    }
+  }
+
   if (network.approvedSsid === true) {
     return {
       value: network.currentSsid ?? network.approvedSsids[0] ?? 'Approved network',
@@ -549,6 +558,35 @@ function getSyncActionableSignal(
       routeId: 'network',
       badge: 'Ready',
       badgeStatus: 'success',
+    }
+  }
+
+  if (network.internetReachable === null && network.hotspotSsidVisibleFromLaptop === true) {
+    return {
+      id: 'sync-status',
+      label: 'Sync path',
+      value: 'Closed local',
+      detail: 'Internet reachability is not checked; Sentinel local access is available.',
+      href: '/admin/network',
+      routeId: 'network',
+      badge: 'Local',
+      badgeStatus: 'info',
+    }
+  }
+
+  if (network.internetReachable === false && network.hotspotSsidVisibleFromLaptop === true) {
+    return {
+      id: 'sync-status',
+      label: 'Sync path',
+      value: network.portalRecoveryLikely === true ? 'Portal pending' : 'Local only',
+      detail:
+        network.portalRecoveryLikely === true
+          ? 'Internet access likely needs daily portal acceptance; Sentinel local access is still available.'
+          : 'External internet is unavailable; Sentinel local access is still available.',
+      href: '/admin/network',
+      routeId: 'network',
+      badge: 'Local',
+      badgeStatus: 'info',
     }
   }
 

--- a/apps/frontend-admin/src/components/layout/app-navbar.tsx
+++ b/apps/frontend-admin/src/components/layout/app-navbar.tsx
@@ -4,12 +4,7 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useState, useSyncExternalStore } from 'react'
-import type {
-  SystemHealthStatus,
-  SystemUpdateJob,
-  SystemStatusResponse,
-  SystemUpdateJobStatus,
-} from '@sentinel/contracts'
+import type { SystemHealthStatus, SystemStatusResponse } from '@sentinel/contracts'
 import { Menu, PanelLeftOpen } from 'lucide-react'
 import { AppBadge, type AppBadgeStatus } from '@/components/ui/AppBadge'
 import { Chip } from '@/components/ui/chip'
@@ -19,7 +14,6 @@ import { UserMenu } from '@/components/layout/user-menu'
 import { HelpButton } from '@/components/help/HelpButton'
 import { HostHotspotRepairDialog } from '@/components/network/host-hotspot-repair-dialog'
 import { useSystemStatus } from '@/hooks/use-system-status'
-import { useSystemUpdateStatus } from '@/hooks/use-system-update'
 import { TID } from '@/lib/test-ids'
 import { AccountLevel, useAuthStore } from '@/store/auth-store'
 import { getWirelessRecoveryState, resolveWikiBaseUrl } from './app-navbar.logic'
@@ -46,12 +40,7 @@ export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
   const authSession = useAuthStore((state) => state.session)
   const [hostHotspotRepairOpen, setHostHotspotRepairOpen] = useState(false)
   const systemStatusQuery = useSystemStatus({ enabled: isAuthenticated })
-  const systemUpdateQuery = useSystemUpdateStatus({
-    enabled: isAuthenticated,
-    refetchIntervalMs: 30_000,
-  })
   const systemStatus = systemStatusQuery.data ?? null
-  const systemUpdateStatus = systemUpdateQuery.data ?? null
   const isStatusLoading = !isAuthenticated || systemStatusQuery.isLoading
   const { dot, label, badgeStatus } = getSystemSummaryBadge({
     systemStatus,
@@ -124,16 +113,10 @@ export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
     isError: systemStatusQuery.isError,
     hasAdminAccess,
   })
-  const currentVersion =
-    systemUpdateStatus?.currentVersion ??
-    normalizeVersionTag(systemStatus?.backend.version ?? null) ??
-    'unknown'
-  const latestVersion = systemUpdateStatus?.latestVersion ?? null
+  const currentVersion = normalizeVersionTag(systemStatus?.backend.version ?? null) ?? 'unknown'
+  const latestVersion = null
   const versionStatusLabel = getVersionStatus(currentVersion, latestVersion)
-  const updateAvailable = systemUpdateStatus?.updateAvailable ?? false
-  const currentSystemUpdateJob = systemUpdateStatus?.currentJob ?? null
-  const hasActiveSystemUpdate =
-    currentSystemUpdateJob !== null && !isSystemUpdateJobTerminal(currentSystemUpdateJob)
+  const updateAvailable = false
 
   return (
     <div
@@ -432,21 +415,14 @@ export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
                 >
                   <p className="text-xs font-semibold uppercase tracking-wide">Updates</p>
                   <p className="mt-1 text-xs leading-relaxed">
-                    {hasActiveSystemUpdate && currentSystemUpdateJob
-                      ? `Update ${currentSystemUpdateJob.targetVersion} is ${formatSystemUpdateStatus(currentSystemUpdateJob.status).toLowerCase()}.`
-                      : updateAvailable && latestVersion
-                        ? `${latestVersion} is available for this appliance.`
-                        : 'Sentinel is on the latest known stable release.'}
+                    {updateAvailable && latestVersion
+                      ? `${latestVersion} is available for this appliance.`
+                      : 'Release lookup is only checked from the Updates page.'}
                   </p>
                   <div className="mt-2 flex flex-wrap items-center gap-(--space-2)">
                     <Link href="/admin/updates" className="btn btn-xs btn-outline">
                       Open updates
                     </Link>
-                    {hasActiveSystemUpdate && currentSystemUpdateJob && (
-                      <AppBadge status="warning" size="sm">
-                        {formatSystemUpdateStatus(currentSystemUpdateJob.status)}
-                      </AppBadge>
-                    )}
                   </div>
                 </div>
                 <p>
@@ -622,6 +598,23 @@ function getWirelessRecoveryCopy(
   const approvedSsidLabel =
     primaryApprovedSsid ?? systemStatus.network.hotspotSsid ?? 'the approved Wi-Fi network'
   const hotspotSsidLabel = systemStatus.network.hotspotSsid ?? 'the hosted Sentinel hotspot'
+
+  if (
+    systemStatus.network.issueCode === 'none' &&
+    systemStatus.network.portalRecoveryLikely === true &&
+    systemStatus.network.internetReachable === false
+  ) {
+    return `${approvedSsidLabel} is connected, but internet access likely needs the daily portal acceptance. Sentinel can still verify ${hotspotSsidLabel} as long as AP visibility is shown as visible.`
+  }
+
+  if (
+    systemStatus.network.issueCode === 'none' &&
+    systemStatus.network.internetReachable === null &&
+    systemStatus.network.hotspotSsidVisibleFromLaptop === true
+  ) {
+    return `${hotspotSsidLabel} is visible. Internet reachability checks are not configured, which is expected for a closed local deployment.`
+  }
+
   switch (systemStatus.network.issueCode) {
     case 'wifi_disconnected':
       return `Internet Wi-Fi is disconnected. Reconnect this laptop to ${approvedSsidLabel} if internet access is needed, then requeue a host repair if the hotspot still needs attention.`
@@ -1028,6 +1021,15 @@ function getNetworkTooltip(
     if (network.approvedSsids.length === 0) {
       reason =
         'Green because Sentinel Wi-Fi is operational and no approved internet SSID allowlist is configured.'
+    } else if (network.portalRecoveryLikely === true && network.internetReachable === false) {
+      const hotspotSsidLabel = network.hotspotSsid ?? 'hosted Sentinel hotspot'
+      reason = `Green because Sentinel can still verify "${hotspotSsidLabel}" even though internet access likely needs daily portal acceptance.`
+    } else if (
+      network.internetReachable === null &&
+      network.hotspotSsidVisibleFromLaptop === true
+    ) {
+      const hotspotSsidLabel = network.hotspotSsid ?? 'hosted Sentinel hotspot'
+      reason = `Green because Sentinel can verify "${hotspotSsidLabel}" and no Internet reachability check is configured.`
     } else if (network.approvedSsid === true) {
       reason = `Green because internet Wi-Fi "${currentSsid}" is approved.`
     } else {
@@ -1098,24 +1100,6 @@ function formatBooleanLabel(value: boolean | null): string {
 
 function stripUrlProtocol(value: string): string {
   return value.replace(/^https?:\/\//, '')
-}
-
-function isSystemUpdateJobTerminal(
-  job: Pick<SystemUpdateJob, 'status' | 'finishedAt'> | null
-): boolean {
-  if (!job) {
-    return true
-  }
-
-  if (job.status === 'rollback_attempted') {
-    return job.finishedAt !== null
-  }
-
-  return job.status === 'completed' || job.status === 'failed' || job.status === 'rolled_back'
-}
-
-function formatSystemUpdateStatus(status: SystemUpdateJobStatus): string {
-  return status.replace(/_/g, ' ').replace(/\b\w/g, (character) => character.toUpperCase())
 }
 
 function getVersionStatus(currentVersion: string, latestTag: string | null): string {

--- a/deploy/README_DEPLOY.md
+++ b/deploy/README_DEPLOY.md
@@ -117,9 +117,21 @@ Port defaults in `.env`:
 - `HOTSPOT_APPROVED_DONGLES_FILE=hardware/approved-hotspot-dongles.json` (approved external AP dongle allowlist)
 - `APPROVED_WIFI_SSIDS=GC Public` (comma-separated approved internet Wi-Fi SSIDs for host-network status)
 - `SENTINEL_KIOSK_DEVICE_API_KEY=sk_...` (shared kiosk device auth key used by frontend and backend for kiosk no-user-login mode)
-- `NETWORK_REACHABILITY_CHECK_URL=https://connectivitycheck.gstatic.com/generate_204` (host-level internet probe)
+- `NETWORK_REACHABILITY_CHECK_URL=` optional host-level internet probe. Leave empty for closed local deployments.
 - `NETWORK_REMOTE_REACHABILITY_TARGET=` optional extra reachability target, such as a Tailscale IP or HTTPS health URL
 - `NETWORK_STATUS_SNAPSHOT_INTERVAL_SECONDS=30` (how often the Ubuntu host writes Wi-Fi/internet telemetry for Sentinel)
+
+### Offline / closed-system operation
+
+Sentinel is designed to keep operating on the local appliance network without Internet access after installation and updates are complete.
+
+- `Stone Frigate` is the operational Sentinel hotspot. It is the network other laptops use to reach Sentinel in a browser.
+- `GC Public` is only an optional Internet path for development, Codex work, install/update downloads, and other maintenance tasks.
+- If `GC Public` is disconnected, blocked by the daily captive portal, or intentionally not used, Sentinel should still report healthy local network status when the managed hotspot profile, approved AP dongle, scan radio, and `Stone Frigate` visibility are healthy.
+- The frontend does not depend on Internet-hosted fonts during normal operation.
+- The navbar does not poll GitHub release metadata during normal operation. Open **Admin > Updates** only when intentionally checking or applying updates.
+- Leave `NETWORK_REACHABILITY_CHECK_URL=` empty for a closed local deployment. Configure an external URL only during development or maintenance when you intentionally want Sentinel to report Internet reachability.
+- Leave `NETWORK_REMOTE_REACHABILITY_TARGET=` empty for a closed local deployment unless there is a specific internal target that should be checked.
 
 Canonical Sentinel port allocation policy (host/LAN):
 
@@ -201,7 +213,7 @@ What it checks:
 - which hotspot adapter and scan adapter Sentinel selected
 - whether the approved AP dongle is incorrectly busy on an internet Wi-Fi profile
 - whether the configured Sentinel hotspot SSID is visible from the laptop's non-host Wi-Fi adapter (when available)
-- whether the configured internet reachability URL succeeds
+- whether the configured internet reachability URL succeeds, when one is configured
 - whether the optional `NETWORK_REMOTE_REACHABILITY_TARGET` is reachable
 
 Where it lives:

--- a/deploy/_common.sh
+++ b/deploy/_common.sh
@@ -493,7 +493,7 @@ bootstrap_env_defaults() {
   fi
 
   if is_placeholder_env_value "$(env_value NETWORK_REACHABILITY_CHECK_URL)"; then
-    upsert_env "NETWORK_REACHABILITY_CHECK_URL" "https://connectivitycheck.gstatic.com/generate_204"
+    upsert_env "NETWORK_REACHABILITY_CHECK_URL" ""
   fi
 
   if is_placeholder_env_value "$(env_value NETWORK_REMOTE_REACHABILITY_TARGET)"; then

--- a/deploy/write-network-status.sh
+++ b/deploy/write-network-status.sh
@@ -7,7 +7,7 @@ source "${SCRIPT_DIR}/_common.sh"
 
 OUTPUT_DIR="${SCRIPT_DIR}/runtime/network-status"
 OUTPUT_FILE="${OUTPUT_DIR}/network-status.json"
-CHECK_URL="$(env_value NETWORK_REACHABILITY_CHECK_URL "$(env_value CAPTIVE_PORTAL_RECOVERY_CHECK_URL https://connectivitycheck.gstatic.com/generate_204)")"
+CHECK_URL="$(env_value NETWORK_REACHABILITY_CHECK_URL "$(env_value CAPTIVE_PORTAL_RECOVERY_CHECK_URL)")"
 REMOTE_TARGET="$(env_value NETWORK_REMOTE_REACHABILITY_TARGET "$(env_value CAPTIVE_PORTAL_TAILSCALE_TARGET)")"
 HOTSPOT_CONNECTION_NAME="$(env_value HOTSPOT_CONNECTION_NAME 'Sentinel Hotspot')"
 BACKEND_READER_GROUP="${BACKEND_READER_GROUP:-sentinel-backend}"
@@ -281,15 +281,17 @@ fi
 
 current_ssid_value="${internet_wifi_ssid_value}"
 
-if check_url "${CHECK_URL}"; then
-  internet_reachable_value="true"
-elif command -v curl >/dev/null 2>&1; then
-  internet_reachable_value="false"
-  if [[ -n "${current_ssid_value}" && "${hotspot_issue_code_value}" == "none" ]]; then
-    portal_recovery_likely_value="true"
-    message_value="Internet reachability failed while internet Wi-Fi is connected"
-  elif [[ "${hotspot_issue_code_value}" == "none" ]]; then
-    message_value="Sentinel hotspot is visible; internet Wi-Fi is not connected"
+if [[ -n "${CHECK_URL}" ]]; then
+  if check_url "${CHECK_URL}"; then
+    internet_reachable_value="true"
+  elif command -v curl >/dev/null 2>&1; then
+    internet_reachable_value="false"
+    if [[ -n "${current_ssid_value}" && "${hotspot_issue_code_value}" == "none" ]]; then
+      portal_recovery_likely_value="true"
+      message_value="Internet reachability failed while internet Wi-Fi is connected"
+    elif [[ "${hotspot_issue_code_value}" == "none" ]]; then
+      message_value="Sentinel hotspot is visible; internet Wi-Fi is not connected"
+    fi
   fi
 fi
 
@@ -308,6 +310,8 @@ if [[ -n "${current_ssid_value}" && "${internet_reachable_value}" == "true" && "
   message_value="Connected to internet Wi-Fi and internet is reachable"
 elif [[ -z "${current_ssid_value}" && "${hotspot_issue_code_value}" == "none" && "${hotspot_ssid_visible_from_laptop_value}" == "true" ]]; then
   message_value="Sentinel hotspot is visible; internet Wi-Fi is not connected"
+elif [[ -n "${current_ssid_value}" && "${internet_reachable_value}" == "null" && "${hotspot_issue_code_value}" == "none" && "${hotspot_ssid_visible_from_laptop_value}" == "true" ]]; then
+  message_value="Sentinel hotspot is visible; internet reachability check is not configured"
 fi
 
 tmp_file="$(mktemp "${OUTPUT_DIR}/network-status.XXXXXX")"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.3.13",
+  "version": "3.3.14",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.3.13",
+  "version": "3.3.14",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.3.13",
+  "version": "3.3.14",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.3.13",
+  "version": "3.3.14",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Makes Sentinel safe to run as a closed local appliance without Internet access after installation and updates are complete.
- Changes the host Internet reachability probe from default-on to opt-in, so normal network telemetry no longer calls an external Google connectivity URL.
- Keeps System Status and Admin Control Center healthy when `Stone Frigate` is visible, even if `GC Public` is disconnected, captive-portal blocked, or intentionally unused.
- Removes normal navbar release polling and Internet-hosted frontend fonts from day-to-day operation.
- Prepares the patch release version `v3.3.14`.

## Why this change was needed

Sentinel needs to keep working when the appliance is no longer connected to public Internet. `GC Public` is useful during development, Codex work, and maintenance updates, but it should not be required for daily Sentinel operations. The local `Stone Frigate` hotspot is the operational network that other laptops use to reach Sentinel.

## What changed

### User-facing

- System Status now explains captive portal and closed-local network states in plain language.
- Network status remains healthy when the Sentinel hotspot is visible and the only missing piece is optional external Internet access.
- The frontend uses local/system fonts instead of Google-hosted fonts.

### Admin/operator-facing

- Admin Control Center now shows local/closed-network status instead of treating missing Internet as an operator problem when Sentinel local access is available.
- The navbar no longer polls release metadata during normal use. Operators can still check updates intentionally from **Admin > Updates**.

### Backend/API

- System status message resolution now understands captive portal and disabled Internet-probe states.
- Added backend test coverage for captive portal and disabled Internet reachability check scenarios.

### Deployment/update

- `NETWORK_REACHABILITY_CHECK_URL` now defaults to blank for closed local deployments.
- The network snapshot script skips the Internet probe when no URL is configured.
- Deployment documentation now describes `Stone Frigate` as the operational hotspot and `GC Public` as optional maintenance Internet.

### Documentation

- Updated deployment docs with closed-system operation guidance and expected environment settings.

### Tests

- Full workspace build completed.
- Full workspace typecheck completed.
- Full workspace lint completed with existing warning-only debt.
- Focused frontend behavior tests completed.
- Shell syntax and diff whitespace checks completed.

## User impact

Normal Sentinel users should still reach Sentinel through the `Stone Frigate` hotspot even when the appliance has no Internet access.

## Operator impact

Operators should no longer see a network warning just because the `GC Public` captive portal has not been accepted or Internet has intentionally been disconnected. If update checks are needed, open **Admin > Updates** during a maintenance window with Internet available.

## Upgrade or migration notes

No database migration is required.

Configuration change: closed local deployments should keep `NETWORK_REACHABILITY_CHECK_URL=` blank. Existing appliances that still have an external URL configured can clear it to avoid intentional Internet reachability checks during normal operation.

## Risk and rollback notes

Main risk: appliances that depended on the old external Internet probe as an operational signal will no longer check it unless `NETWORK_REACHABILITY_CHECK_URL` is explicitly configured.

Verification: after update, confirm System Status shows the local hotspot path as healthy when `Stone Frigate` is visible, even without Internet access from `GC Public`.

Rollback is safe with the normal Sentinel rollback process. No database compatibility changes are included.

## Testing performed

- `bash -n deploy/write-network-status.sh deploy/_common.sh`
- `git diff --check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter frontend-admin exec vitest run src/components/layout/app-navbar.logic.test.ts src/components/kiosk/kiosk-domain.test.ts src/lib/admin-issues.test.ts`
- `pnpm version:check`
- Browser sanity check at `1920x1080` for frontend login rendering with the local font stack

## Changelog candidates

- Changed Sentinel network telemetry so external Internet reachability checks are opt-in for closed local deployments.
- Fixed System Status so a missing captive portal login does not make Sentinel look unhealthy when the `Stone Frigate` hotspot is visible.
- Changed the navbar so release metadata is checked only from **Admin > Updates**, not during normal navigation.
- Removed Internet-hosted frontend fonts so the admin app can render normally without public Internet.