### PR TITLE
Release v3.3.17

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.3.16",
+  "version": "3.3.17",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/jobs/host-hotspot-recovery.ts
+++ b/apps/backend/src/jobs/host-hotspot-recovery.ts
@@ -1,0 +1,36 @@
+import { logger } from '../lib/logger.js'
+import { HostHotspotRecoveryService } from '../services/host-hotspot-recovery-service.js'
+
+/**
+ * Scheduled Host Hotspot Recovery Job
+ *
+ * Queues the same host-side hotspot repair request used by the manual recovery UI.
+ * The host processor remains responsible for performing the actual adapter/profile work.
+ */
+export async function runScheduledHostHotspotRecovery(): Promise<void> {
+  const jobLogger = logger.child({ job: 'host-hotspot-recovery' })
+  const recoveryService = new HostHotspotRecoveryService()
+  const currentStatus = await recoveryService.readLatestStatus()
+
+  if (currentStatus?.state === 'queued' || currentStatus?.state === 'running') {
+    jobLogger.info('Host hotspot recovery already queued or running, skipping scheduled request', {
+      state: currentStatus.state,
+      stage: currentStatus.stage,
+      requestId: currentStatus.requestId,
+    })
+    return
+  }
+
+  const queued = await recoveryService.queueRecoveryRequest({
+    requestedByMemberId: 'system',
+    requestedByMemberName: 'Sentinel scheduled maintenance',
+    requestedByRemoteSystemName: 'Scheduled job',
+    requestedFromIp: null,
+    requestedFromUserAgent: null,
+    source: 'backend-scheduler',
+  })
+
+  jobLogger.info('Scheduled host hotspot recovery request queued', {
+    requestId: queued.requestId,
+  })
+}

--- a/apps/backend/src/jobs/index.ts
+++ b/apps/backend/src/jobs/index.ts
@@ -3,6 +3,7 @@ import type { DutyWatchRule } from '@sentinel/contracts'
 import { logger } from '../lib/logger.js'
 import { checkMissedDailyReset, runDailyReset } from './daily-reset.js'
 import { runDutyWatchAlerts } from './duty-watch-alerts.js'
+import { runScheduledHostHotspotRecovery } from './host-hotspot-recovery.js'
 import { runLockupAlerts } from './lockup-alerts.js'
 
 // ============================================================================
@@ -15,6 +16,7 @@ export interface JobScheduleConfig {
   dutyWatchRules: DutyWatchRule[]
   lockupWarningTime: string // HH:MM format, e.g., "22:00"
   lockupCriticalTime: string // HH:MM format, e.g., "23:00"
+  hostHotspotRecoveryTime: string // HH:MM format, e.g., "06:00"
 }
 
 const DEFAULT_CONFIG: JobScheduleConfig = {
@@ -23,6 +25,7 @@ const DEFAULT_CONFIG: JobScheduleConfig = {
   dutyWatchRules: [],
   lockupWarningTime: '22:00',
   lockupCriticalTime: '23:00',
+  hostHotspotRecoveryTime: '06:00',
 }
 
 // ============================================================================
@@ -99,6 +102,11 @@ export async function startJobScheduler(customConfig?: Partial<JobScheduleConfig
         cronExpr: toCron(config.lockupCriticalTime),
         fn: () => runLockupAlerts('critical'),
       },
+      {
+        name: 'host-hotspot-recovery',
+        cronExpr: toCron(config.hostHotspotRecoveryTime),
+        fn: runScheduledHostHotspotRecovery,
+      },
     ]
 
     for (const job of jobs) {
@@ -153,7 +161,12 @@ export async function stopJobScheduler(): Promise<void> {
  * Manually trigger a job (for testing/admin purposes)
  */
 export async function triggerJob(
-  jobName: 'daily-reset' | 'duty-watch-alerts' | 'lockup-warning' | 'lockup-critical'
+  jobName:
+    | 'daily-reset'
+    | 'duty-watch-alerts'
+    | 'lockup-warning'
+    | 'lockup-critical'
+    | 'host-hotspot-recovery'
 ): Promise<void> {
   logger.info(`Manually triggering job: ${jobName}`)
 
@@ -169,6 +182,9 @@ export async function triggerJob(
       break
     case 'lockup-critical':
       await runLockupAlerts('critical')
+      break
+    case 'host-hotspot-recovery':
+      await runScheduledHostHotspotRecovery()
       break
     default:
       throw new Error(`Unknown job: ${jobName}`)

--- a/apps/backend/src/routes/network-settings.test.ts
+++ b/apps/backend/src/routes/network-settings.test.ts
@@ -49,22 +49,22 @@ describe('networkSettingsRouter', () => {
     }
   })
 
-  it('requires admin access for host hotspot recovery', async () => {
-    const app = createTestApp(1)
+  it('requires authentication for host hotspot recovery', async () => {
+    const app = createTestApp()
     const response = await request(app).post('/api/network-settings/host-hotspot-recovery')
 
-    expect(response.status).toBe(403)
+    expect(response.status).toBe(401)
     expect(response.body).toMatchObject({
-      error: 'FORBIDDEN',
+      error: 'UNAUTHORIZED',
     })
   })
 
-  it('queues a host hotspot recovery request for admins', async () => {
+  it('queues a host hotspot recovery request for any authenticated member', async () => {
     const rootDir = await mkdtemp(join(tmpdir(), 'sentinel-hotspot-recovery-'))
     const requestDir = join(rootDir, 'requests')
     process.env.HOST_HOTSPOT_RECOVERY_REQUEST_DIR = requestDir
 
-    const app = createTestApp(5)
+    const app = createTestApp(1)
     const response = await request(app)
       .post('/api/network-settings/host-hotspot-recovery')
       .set('user-agent', 'vitest')

--- a/apps/backend/src/routes/network-settings.ts
+++ b/apps/backend/src/routes/network-settings.ts
@@ -123,7 +123,7 @@ export const networkSettingsRouter = s.router(networkSettingContract, {
   },
 
   hostHotspotRecovery: async ({ req }) => {
-    const auth = requireAdmin(req)
+    const auth = requireMember(req)
     if (auth) {
       return auth
     }

--- a/apps/backend/src/services/host-hotspot-recovery-service.test.ts
+++ b/apps/backend/src/services/host-hotspot-recovery-service.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
@@ -33,6 +33,9 @@ describe('HostHotspotRecoveryService', () => {
       requestedFromUserAgent: 'vitest',
     })
     const status = await service.readLatestStatus()
+    const payload = JSON.parse(await readFile(queued.requestPath, 'utf-8')) as {
+      source?: string
+    }
 
     expect(status).toMatchObject({
       state: 'queued',
@@ -41,6 +44,32 @@ describe('HostHotspotRecoveryService', () => {
       message: 'Host hotspot repair request queued. Waiting for the host processor to start.',
     })
     expect(status?.updatedAt).toBeTruthy()
+    expect(payload.source).toBe('frontend-admin')
+
+    await rm(rootDir, { recursive: true, force: true })
+  })
+
+  it('stores explicit request sources for scheduled repairs', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'sentinel-hotspot-recovery-'))
+    const requestDir = join(rootDir, 'requests')
+    const statusFile = join(rootDir, 'status.json')
+    const service = new HostHotspotRecoveryService(requestDir, statusFile)
+
+    const queued = await service.queueRecoveryRequest({
+      requestedByMemberId: 'system',
+      requestedByMemberName: 'Sentinel scheduled maintenance',
+      requestedByRemoteSystemName: 'Scheduled job',
+      requestedFromIp: null,
+      requestedFromUserAgent: null,
+      source: 'backend-scheduler',
+    })
+    const payload = JSON.parse(await readFile(queued.requestPath, 'utf-8')) as {
+      source?: string
+      requestedByMemberName?: string
+    }
+
+    expect(payload.source).toBe('backend-scheduler')
+    expect(payload.requestedByMemberName).toBe('Sentinel scheduled maintenance')
 
     await rm(rootDir, { recursive: true, force: true })
   })

--- a/apps/backend/src/services/host-hotspot-recovery-service.ts
+++ b/apps/backend/src/services/host-hotspot-recovery-service.ts
@@ -15,6 +15,7 @@ export interface QueueHostHotspotRecoveryInput {
   requestedByRemoteSystemName: string | null
   requestedFromIp: string | null
   requestedFromUserAgent: string | null
+  source?: string
 }
 
 export class HostHotspotRecoveryService {
@@ -39,11 +40,12 @@ export class HostHotspotRecoveryService {
   }> {
     const requestId = `host-hotspot-recovery-${Date.now()}-${randomUUID()}`
     const requestPath = join(this.requestDir, `${requestId}.json`)
+    const { source, ...requestInput } = input
     const payload = {
       requestId,
       requestedAt: new Date().toISOString(),
-      source: 'frontend-admin',
-      ...input,
+      source: source ?? 'frontend-admin',
+      ...requestInput,
     }
 
     try {

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.3.16",
+  "version": "3.3.17",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/components/kiosk/kiosk-operational-header.tsx
+++ b/apps/frontend-admin/src/components/kiosk/kiosk-operational-header.tsx
@@ -10,18 +10,12 @@ import {
   AppCardTitle,
 } from '@/components/ui/AppCard'
 import { Chip } from '@/components/ui/chip'
-import type {
-  KioskConnectivityBadge,
-  KioskHealthIndicator,
-  OperationalLead,
-  ReadinessWarning,
-} from './kiosk-domain'
+import type { KioskConnectivityBadge, OperationalLead, ReadinessWarning } from './kiosk-domain'
 
 interface KioskOperationalHeaderProps {
   fatalOperationalOutage: boolean
   connectivityBadge: KioskConnectivityBadge
   clockLabel: string
-  healthIndicator: KioskHealthIndicator
   leadDisplay: OperationalLead | null
   leadDisplayName: string | null
   leadDisplayLoading: boolean
@@ -43,7 +37,6 @@ export function KioskOperationalHeader({
   fatalOperationalOutage,
   connectivityBadge,
   clockLabel,
-  healthIndicator,
   leadDisplay,
   leadDisplayName,
   leadDisplayLoading,
@@ -98,51 +91,33 @@ export function KioskOperationalHeader({
               </AppCardDescription>
             </div>
 
-            <div className="grid gap-(--space-3) sm:grid-cols-2 xl:w-[36rem]">
-              <div className="rounded-box border border-base-300 bg-base-200/70 px-(--space-4) py-(--space-3)">
+            <div className="grid gap-(--space-3) sm:grid-cols-2 xl:w-[40rem]">
+              <div className="rounded-box border border-base-300 bg-base-200/70 px-(--space-5) py-(--space-4) shadow-[var(--shadow-1)]">
                 <div className="flex items-center gap-(--space-2)">
-                  <Clock3 className="h-4 w-4 text-base-content/55" />
+                  <Clock3 className="h-5 w-5 text-base-content/55" />
                   <p className="text-xs uppercase tracking-[0.18em] text-base-content/50">
                     Local time
                   </p>
                 </div>
                 <p
                   suppressHydrationWarning
-                  className="mt-(--space-2) font-mono text-sm leading-relaxed text-base-content/80"
+                  className="mt-(--space-2) font-mono text-lg font-semibold leading-tight text-base-content"
                 >
                   {clockLabel}
                 </p>
-                <div className="mt-(--space-3) flex items-center gap-(--space-2)">
-                  <span
-                    aria-hidden="true"
-                    className={[
-                      'status status-sm',
-                      healthIndicator.tone === 'success' && 'status-success',
-                      healthIndicator.tone === 'warning' && 'status-warning',
-                      healthIndicator.tone === 'error' && 'status-error',
-                      healthIndicator.tone === 'info' && 'status-info',
-                      healthIndicator.pulse && 'animate-status-pulse',
-                    ]
-                      .filter(Boolean)
-                      .join(' ')}
-                  />
-                  <p className="text-[0.7rem] font-medium uppercase tracking-[0.18em] text-base-content/50">
-                    Readiness {healthIndicator.label}
-                  </p>
-                </div>
               </div>
-              <div className="rounded-box border border-base-300 bg-base-200/70 px-(--space-4) py-(--space-3)">
+              <div className="rounded-box border border-base-300 bg-base-200/70 px-(--space-5) py-(--space-4) shadow-[var(--shadow-1)]">
                 <p className="text-xs uppercase tracking-[0.18em] text-base-content/50">
                   Today&apos;s lead
                 </p>
                 {leadDisplayLoading ? (
-                  <div className="mt-(--space-2) h-4 w-28 animate-pulse rounded-box bg-base-300" />
+                  <div className="mt-(--space-3) h-5 w-32 animate-pulse rounded-box bg-base-300" />
                 ) : (
                   <>
-                    <p className="mt-(--space-2) text-sm font-semibold leading-tight text-base-content">
+                    <p className="mt-(--space-2) text-lg font-semibold leading-tight text-base-content">
                       {leadDisplay?.roleLabel ?? 'No live lead yet'}
                     </p>
-                    <p className="mt-(--space-1) text-sm leading-relaxed text-base-content/78">
+                    <p className="mt-(--space-1) text-base leading-snug text-base-content/78">
                       {leadDisplayName ?? 'Waiting for the day’s assignment or watch lead.'}
                     </p>
                     {leadDisplay && (

--- a/apps/frontend-admin/src/components/kiosk/kiosk-visitor-rail.tsx
+++ b/apps/frontend-admin/src/components/kiosk/kiosk-visitor-rail.tsx
@@ -80,7 +80,7 @@ export function KioskVisitorRail({
                   </button>
                   <button
                     type="button"
-                    className={`btn btn-sm join-item ${mode === 'signout' ? 'btn-secondary' : 'btn-outline'}`}
+                    className={`btn btn-sm join-item ${mode === 'signout' ? 'btn-error' : 'btn-outline'}`}
                     onClick={() => onModeChange('signout')}
                     disabled={fatalOperationalOutage}
                   >
@@ -160,7 +160,7 @@ export function KioskVisitorRail({
                   START
                 </button>
 
-                <div className="mt-(--space-2) border-t border-base-300 pt-(--space-3)">
+                <div className="mt-(--space-2) flex min-h-0 flex-1 flex-col border-t border-base-300 pt-(--space-3)">
                   <VisitorSelfSignoutFlow
                     layout="inline"
                     presentation="embedded"

--- a/apps/frontend-admin/src/components/kiosk/visitor-self-signout-flow.tsx
+++ b/apps/frontend-admin/src/components/kiosk/visitor-self-signout-flow.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Clock3, Layers3, UserRoundMinus, Users } from 'lucide-react'
 import {
   useActiveVisitors,
@@ -71,6 +71,8 @@ export function VisitorSelfSignoutFlow({
   const [selectedByGroup, setSelectedByGroup] = useState<Record<string, string[]>>({})
   const [expandedGroupId, setExpandedGroupId] = useState<string | null>(null)
   const [selectedEventTabId, setSelectedEventTabId] = useState<string | null>(null)
+  const listScrollRef = useRef<globalThis.HTMLDivElement | null>(null)
+  const groupRefs = useRef(new Map<string, globalThis.HTMLDetailsElement>())
 
   const activeVisitors = useMemo(() => data?.visitors ?? [], [data?.visitors])
   const eventTabs = useMemo(() => buildVisitorEventTabs(activeVisitors), [activeVisitors])
@@ -153,9 +155,43 @@ export function VisitorSelfSignoutFlow({
     }
   }
 
+  const scrollExpandedGroupIntoView = (groupId: string) => {
+    const container = listScrollRef.current
+    const groupElement = groupRefs.current.get(groupId)
+    if (!container || !groupElement) {
+      groupElement?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+      return
+    }
+
+    const containerRect = container.getBoundingClientRect()
+    const groupRect = groupElement.getBoundingClientRect()
+    const topOverflow = groupRect.top - containerRect.top
+    const bottomOverflow = groupRect.bottom - containerRect.bottom
+    const padding = 8
+    let nextScrollTop = container.scrollTop
+
+    if (groupRect.height > containerRect.height - padding * 2) {
+      nextScrollTop += topOverflow - padding
+    } else if (topOverflow < 0) {
+      nextScrollTop += topOverflow - padding
+    } else if (bottomOverflow > 0) {
+      nextScrollTop += bottomOverflow + padding
+    } else {
+      return
+    }
+
+    container.scrollTo({
+      top: Math.max(0, nextScrollTop),
+      behavior: 'smooth',
+    })
+  }
+
   const handleGroupToggle = (groupId: string, nextOpen: boolean) => {
     if (nextOpen) {
       setExpandedGroupId(groupId)
+      window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => scrollExpandedGroupIntoView(groupId))
+      })
       return
     }
 
@@ -193,7 +229,7 @@ export function VisitorSelfSignoutFlow({
 
   return (
     <div
-      className={`flex min-h-0 flex-col gap-(--space-4) ${isInline && !isEmbedded ? 'h-full' : ''}`}
+      className={`flex min-h-0 flex-col gap-(--space-3) ${isInline ? 'h-full' : ''} ${isEmbedded ? 'overflow-hidden' : ''}`}
     >
       {interactionDisabled ? (
         <div className="alert alert-warning">
@@ -201,16 +237,16 @@ export function VisitorSelfSignoutFlow({
         </div>
       ) : null}
 
-      <div className="rounded-box border border-base-300 bg-base-200/50 p-(--space-4)">
+      <div className="rounded-box border border-base-300 bg-base-200/50 p-(--space-3)">
         <div className="flex flex-wrap items-center justify-between gap-(--space-3)">
           <div>
             <p className="text-xs uppercase tracking-[0.18em] text-base-content/50">
               Visitor sign-out
             </p>
-            <p className="mt-(--space-1) text-lg font-semibold leading-tight">
+            <p className="mt-(--space-1) text-base font-semibold leading-tight">
               {activeVisitorCount} active visitor{activeVisitorCount === 1 ? '' : 's'}
             </p>
-            <div className="mt-(--space-2) flex flex-wrap gap-(--space-2)">
+            <div className="mt-(--space-1) flex flex-wrap gap-(--space-2)">
               <Chip variant="faded" color="secondary" size="sm">
                 <Layers3 className="h-3.5 w-3.5" />
                 {activeGroupCount} group{activeGroupCount === 1 ? '' : 's'}
@@ -247,9 +283,8 @@ export function VisitorSelfSignoutFlow({
         </div>
       ) : (
         <div
-          className={`min-h-0 space-y-(--space-4) overflow-y-auto pr-(--space-1) ${
-            isEmbedded ? 'max-h-[26rem]' : 'flex-1'
-          }`}
+          ref={listScrollRef}
+          className="min-h-0 flex-1 space-y-(--space-3) overflow-y-auto pr-(--space-1)"
         >
           {eventTabs.length > 0 ? (
             <div
@@ -285,11 +320,11 @@ export function VisitorSelfSignoutFlow({
           ) : null}
 
           {activeGroupCount > 0 && (
-            <section className="space-y-(--space-2)">
+            <section className="space-y-(--space-1)">
               <p className="text-xs uppercase tracking-[0.18em] text-base-content/55">
                 Visitor groups
               </p>
-              <div className="space-y-(--space-2)">
+              <div className="space-y-(--space-1)">
                 {filtered.groups.map((group) => {
                   const selectedIds = selectedByGroup[group.groupId] ?? []
                   const selectedCount = selectedIds.length
@@ -299,39 +334,45 @@ export function VisitorSelfSignoutFlow({
                   return (
                     <details
                       key={group.groupId}
+                      ref={(node) => {
+                        if (node) {
+                          groupRefs.current.set(group.groupId, node)
+                        } else {
+                          groupRefs.current.delete(group.groupId)
+                        }
+                      }}
                       open={isExpanded}
                       onToggle={(event) =>
                         handleGroupToggle(group.groupId, event.currentTarget.open)
                       }
                       className={`collapse collapse-arrow border border-base-300 bg-base-100 border-l-4 ${accent.border}`}
                     >
-                      <summary className="collapse-title pr-(--space-4)">
-                        <div className="flex flex-wrap items-start justify-between gap-(--space-3)">
+                      <summary className="collapse-title px-(--space-3) py-(--space-2) pr-(--space-4)">
+                        <div className="flex flex-wrap items-center justify-between gap-(--space-2)">
                           <div className="min-w-0">
                             <div className="flex flex-wrap items-center gap-(--space-2)">
                               <Chip variant="faded" color={accent.chipColor} size="sm">
                                 {group.groupCode}
                               </Chip>
-                              <p className="truncate text-lg font-semibold">
+                              <p className="truncate text-base font-semibold leading-tight">
                                 {group.identityTitle}
                               </p>
                             </div>
                             {group.contextLine ? (
-                              <p className="mt-(--space-1) truncate text-sm font-medium text-base-content/75">
+                              <p className="mt-0.5 truncate text-sm font-medium text-base-content/75">
                                 {compactText(group.contextLine)}
                               </p>
                             ) : null}
-                            <p className="mt-(--space-1) text-sm text-base-content/70">
-                              {group.identityDetail}
-                            </p>
-                            <p className="mt-(--space-1) flex items-center gap-(--space-1) text-xs text-base-content/55">
+                            <p className="mt-0.5 flex flex-wrap items-center gap-x-(--space-2) gap-y-0.5 text-xs text-base-content/60">
+                              <span>{group.identityDetail}</span>
+                              <span aria-hidden="true">|</span>
                               <Clock3 className="h-3 w-3" />
-                              Latest check-in {formatTime(group.mostRecentCheckInTime)}
+                              <span>Latest check-in {formatTime(group.mostRecentCheckInTime)}</span>
                             </p>
                           </div>
                           <button
                             type="button"
-                            className="btn btn-sm btn-error"
+                            className="btn btn-xs btn-error"
                             disabled={!canInteract}
                             onClick={(event) => {
                               event.preventDefault()
@@ -344,34 +385,26 @@ export function VisitorSelfSignoutFlow({
                         </div>
                       </summary>
 
-                      <div className="collapse-content border-t border-base-300 bg-base-200/35 pt-(--space-3)">
-                        <div className="mb-(--space-3) flex flex-wrap gap-(--space-2)">
+                      <div className="collapse-content border-t border-base-300 bg-base-200/35 px-(--space-3) pb-(--space-3) pt-(--space-2)">
+                        <div className="mb-(--space-2) flex flex-wrap gap-(--space-2)">
                           <button
                             type="button"
-                            className="btn btn-sm btn-outline"
+                            className="btn btn-sm btn-error"
                             disabled={!canInteract || selectedCount === 0}
                             onClick={() => void handleSignoutGroup(group, selectedIds)}
                           >
                             Sign out selected ({selectedCount})
                           </button>
-                          <button
-                            type="button"
-                            className="btn btn-sm btn-error"
-                            disabled={!canInteract}
-                            onClick={() => void handleSignoutGroup(group)}
-                          >
-                            Sign out full group
-                          </button>
                         </div>
 
-                        <div className="grid gap-(--space-2)">
+                        <div className="grid gap-(--space-1)">
                           {group.members.map((visitor) => {
                             const inputId = `group-${group.groupId}-${visitor.id}`
                             return (
                               <label
                                 key={visitor.id}
                                 htmlFor={inputId}
-                                className="flex items-start gap-(--space-3) rounded-box border border-base-300 bg-base-100 px-(--space-3) py-(--space-2)"
+                                className="flex items-start gap-(--space-2) rounded-box border border-base-300 bg-base-100 px-(--space-2) py-(--space-2)"
                               >
                                 <input
                                   id={inputId}
@@ -384,10 +417,10 @@ export function VisitorSelfSignoutFlow({
                                   disabled={!canInteract}
                                 />
                                 <div className="min-w-0">
-                                  <p className="font-semibold leading-tight">
+                                  <p className="text-sm font-semibold leading-tight">
                                     {displayName(visitor)}
                                   </p>
-                                  <p className="text-sm text-base-content/70">
+                                  <p className="text-xs text-base-content/70">
                                     Checked in {formatTime(visitor.checkInTime)}
                                   </p>
                                 </div>
@@ -404,19 +437,21 @@ export function VisitorSelfSignoutFlow({
           )}
 
           {activeUngroupedCount > 0 && (
-            <section className="space-y-(--space-2)">
+            <section className="space-y-(--space-1)">
               <p className="text-xs uppercase tracking-[0.18em] text-base-content/55">
                 Ungrouped visitors
               </p>
-              <div className="grid gap-(--space-2)">
+              <div className="grid gap-(--space-1)">
                 {filtered.ungroupedVisitors.map((visitor) => (
                   <div
                     key={visitor.id}
-                    className="flex flex-wrap items-center justify-between gap-(--space-3) rounded-box border border-base-300 bg-base-100 p-(--space-3)"
+                    className="flex flex-wrap items-center justify-between gap-(--space-2) rounded-box border border-base-300 bg-base-100 px-(--space-3) py-(--space-2)"
                   >
                     <div className="min-w-0">
-                      <p className="font-semibold">{getPublicVisitorTitle(visitor)}</p>
-                      <p className="text-sm text-base-content/70">
+                      <p className="text-sm font-semibold leading-tight">
+                        {getPublicVisitorTitle(visitor)}
+                      </p>
+                      <p className="text-xs text-base-content/70">
                         {[
                           getPublicVisitorContextLine(visitor),
                           `Checked in ${formatTime(visitor.checkInTime)}`,

--- a/apps/frontend-admin/src/components/layout/app-navbar.logic.test.ts
+++ b/apps/frontend-admin/src/components/layout/app-navbar.logic.test.ts
@@ -88,7 +88,6 @@ describe('app-navbar logic', () => {
       }),
       isLoading: false,
       isError: false,
-      hasAdminAccess: false,
     })
 
     expect(result.showConnectLaptop).toBe(false)
@@ -106,31 +105,28 @@ describe('app-navbar logic', () => {
       }),
       isLoading: false,
       isError: false,
-      hasAdminAccess: false,
     })
 
     expect(result.showConnectLaptop).toBe(true)
     expect(result.connectLaptopHref).toBe('sentinel-hotspot://connect?ssid=GC%20Public')
   })
 
-  it('gates host hotspot repair to admin-capable users', () => {
+  it('shows host hotspot repair to all authenticated users once status is available', () => {
     expect(
       getWirelessRecoveryState({
         systemStatus: createSystemStatus(),
         isLoading: false,
         isError: false,
-        hasAdminAccess: false,
       }).showRepairHostHotspot
-    ).toBe(false)
+    ).toBe(true)
 
     expect(
       getWirelessRecoveryState({
         systemStatus: createSystemStatus(),
-        isLoading: false,
+        isLoading: true,
         isError: false,
-        hasAdminAccess: true,
       }).showRepairHostHotspot
-    ).toBe(true)
+    ).toBe(false)
   })
 
   it('keeps wireless recovery section visible when hotspot SSID is not visible from laptop Wi-Fi', () => {
@@ -144,11 +140,10 @@ describe('app-navbar logic', () => {
       }),
       isLoading: false,
       isError: false,
-      hasAdminAccess: false,
     })
 
     expect(result.showSection).toBe(true)
-    expect(result.showRepairHostHotspot).toBe(false)
+    expect(result.showRepairHostHotspot).toBe(true)
   })
 
   it('keeps wireless recovery section visible when the AP dongle is busy on internet Wi-Fi', () => {
@@ -164,10 +159,9 @@ describe('app-navbar logic', () => {
       }),
       isLoading: false,
       isError: false,
-      hasAdminAccess: false,
     })
 
     expect(result.showSection).toBe(true)
-    expect(result.showRepairHostHotspot).toBe(false)
+    expect(result.showRepairHostHotspot).toBe(true)
   })
 })

--- a/apps/frontend-admin/src/components/layout/app-navbar.logic.ts
+++ b/apps/frontend-admin/src/components/layout/app-navbar.logic.ts
@@ -19,9 +19,8 @@ export function getWirelessRecoveryState(input: {
   systemStatus: SystemStatusResponse | null
   isLoading: boolean
   isError: boolean
-  hasAdminAccess: boolean
 }): WirelessRecoveryState {
-  const { systemStatus, isLoading, isError, hasAdminAccess } = input
+  const { systemStatus, isLoading, isError } = input
   const primaryApprovedSsid = systemStatus?.network.approvedSsids[0] ?? null
   const issueCode = systemStatus?.network.issueCode ?? null
   const showConnectLaptop =
@@ -33,7 +32,7 @@ export function getWirelessRecoveryState(input: {
     showConnectLaptop && primaryApprovedSsid
       ? `sentinel-hotspot://connect?ssid=${encodeURIComponent(primaryApprovedSsid)}`
       : null
-  const showRepairHostHotspot = hasAdminAccess && !isLoading && !isError
+  const showRepairHostHotspot = !isLoading && !isError
   const hotspotVisibilityIssue =
     !isLoading &&
     !isError &&

--- a/apps/frontend-admin/src/components/layout/app-navbar.tsx
+++ b/apps/frontend-admin/src/components/layout/app-navbar.tsx
@@ -15,7 +15,7 @@ import { HelpButton } from '@/components/help/HelpButton'
 import { HostHotspotRepairDialog } from '@/components/network/host-hotspot-repair-dialog'
 import { useSystemStatus } from '@/hooks/use-system-status'
 import { TID } from '@/lib/test-ids'
-import { AccountLevel, useAuthStore } from '@/store/auth-store'
+import { useAuthStore } from '@/store/auth-store'
 import { getWirelessRecoveryState, resolveWikiBaseUrl } from './app-navbar.logic'
 
 const navLinks = [
@@ -36,7 +36,6 @@ const DEPLOYMENT_REMOTE_SYSTEM_CODE = 'deployment_laptop'
 export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
   const pathname = usePathname()
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
-  const member = useAuthStore((state) => state.member)
   const authSession = useAuthStore((state) => state.session)
   const [hostHotspotRepairOpen, setHostHotspotRepairOpen] = useState(false)
   const systemStatusQuery = useSystemStatus({ enabled: isAuthenticated })
@@ -106,12 +105,10 @@ export function AppNavbar({ drawerId, isDrawerOpen }: AppNavbarProps) {
   const frontendTooltip = getFrontendTooltip(browserOrigin)
   const activeRemoteSessions = systemStatus?.remoteSystems.sessions ?? []
   const remoteSystemOverflowCount = systemStatus?.remoteSystems.overflowCount ?? 0
-  const hasAdminAccess = (member?.accountLevel ?? 0) >= AccountLevel.ADMIN
   const wirelessRecovery = getWirelessRecoveryState({
     systemStatus,
     isLoading: isStatusLoading,
     isError: systemStatusQuery.isError,
-    hasAdminAccess,
   })
   const currentVersion = normalizeVersionTag(systemStatus?.backend.version ?? null) ?? 'unknown'
   const latestVersion = null

--- a/apps/frontend-admin/src/components/settings/system-update-panel.tsx
+++ b/apps/frontend-admin/src/components/settings/system-update-panel.tsx
@@ -533,15 +533,13 @@ export function SystemUpdatePanel() {
               tone="warning"
               heading="Hotspot profile needs attention"
               actions={
-                canStartUpdates ? (
-                  <button
-                    type="button"
-                    className="btn btn-xs btn-warning"
-                    onClick={() => setHotspotRepairOpen(true)}
-                  >
-                    Repair hotspot
-                  </button>
-                ) : null
+                <button
+                  type="button"
+                  className="btn btn-xs btn-warning"
+                  onClick={() => setHotspotRepairOpen(true)}
+                >
+                  Repair hotspot
+                </button>
               }
             >
               {systemStatus?.network.message ??
@@ -801,7 +799,6 @@ export function SystemUpdatePanel() {
                   type="button"
                   className="btn btn-sm btn-primary shadow-sm"
                   onClick={() => setHotspotRepairOpen(true)}
-                  disabled={!canStartUpdates}
                 >
                   <ShieldCheck className="mr-2 h-4 w-4" />
                   Repair hotspot

--- a/apps/frontend-admin/src/lib/dashboard-visitor-card-details.test.ts
+++ b/apps/frontend-admin/src/lib/dashboard-visitor-card-details.test.ts
@@ -48,12 +48,23 @@ describe('getDashboardVisitorCardDetails', () => {
 
     expect(details.title).toBe('Jane Doe')
     expect(details.subtitle).toBe('Standing Court Martial')
-    expect(details.detail).toBe(
-      'Standing Court Martial • Gallery Attendee • hosted by Lt(N) Patel • Civilian • guest'
-    )
+    expect(details.detail).toBe('Gallery Attendee • Civilian • guest')
+    expect(details.detail).not.toContain(details.subtitle as string)
+    expect(details.detail).not.toContain('Lt(N) Patel')
     expect(details.detail).not.toContain('Reason:')
     expect(details.detail).not.toContain('Category:')
     expect(details.detail).not.toContain('Event option:')
+  })
+
+  it('keeps meeting host details when the structured host field is unavailable', () => {
+    const details = getDashboardVisitorCardDetails(
+      createVisitor({
+        visitReason: 'Reason: Meeting | Category: Civilian | Meeting with: Lt(N) Patel',
+      }),
+      'Doe, Jane'
+    )
+
+    expect(details.detail).toContain('hosted by Lt(N) Patel')
   })
 
   it('shows contractor company and work description for internal dashboard cards', () => {
@@ -71,9 +82,8 @@ describe('getDashboardVisitorCardDetails', () => {
     )
 
     expect(details.subtitle).toBe('Black & MacDonald')
-    expect(details.detail).toBe(
-      'Black & MacDonald • Panel inspection in mechanical space • Civilian • contractor'
-    )
+    expect(details.detail).toBe('Panel inspection in mechanical space • Civilian • contractor')
+    expect(details.detail).not.toContain(details.subtitle as string)
   })
 
   it('keeps military rank and unit cleanly available', () => {
@@ -89,6 +99,7 @@ describe('getDashboardVisitorCardDetails', () => {
     )
 
     expect(details.subtitle).toBe('PO2 • HMCS Example')
-    expect(details.detail).toBe('Military • PO2 • HMCS Example')
+    expect(details.detail).toBe('Military')
+    expect(details.detail).not.toContain(details.subtitle as string)
   })
 })

--- a/apps/frontend-admin/src/lib/dashboard-visitor-card-details.ts
+++ b/apps/frontend-admin/src/lib/dashboard-visitor-card-details.ts
@@ -83,7 +83,9 @@ function getWorkDescription(person: PresentPerson): string | undefined {
 }
 
 function getHost(person: PresentPerson): string | undefined {
-  const hostName = clean(person.hostName) ?? extractVisitReasonField(person, 'Meeting with')
+  if (clean(person.hostName)) return undefined
+
+  const hostName = extractVisitReasonField(person, 'Meeting with')
   return hostName ? `hosted by ${hostName}` : undefined
 }
 
@@ -135,6 +137,7 @@ export function getDashboardVisitorCardDetails(
   person: PresentPerson,
   displayName: string
 ): DashboardVisitorCardDetails {
+  const subtitle = getVisitorSubtitle(person)
   const details = uniqueOrdered([
     getEventTitle(person),
     getEventOption(person),
@@ -145,11 +148,11 @@ export function getDashboardVisitorCardDetails(
     getVisitTypeName(person),
     getMilitaryContext(person),
     ...getOtherDetails(person),
-  ])
+  ]).filter((detail) => detail.toLowerCase() !== subtitle?.toLowerCase())
 
   return {
     title: getVisitorTitle(person, displayName),
-    subtitle: getVisitorSubtitle(person),
+    subtitle,
     detail: details.length > 0 ? details.join(' • ') : undefined,
   }
 }

--- a/apps/frontend-admin/src/lib/visitor-signout-grouping.test.ts
+++ b/apps/frontend-admin/src/lib/visitor-signout-grouping.test.ts
@@ -178,9 +178,19 @@ describe('buildVisitorSignoutGrouping', () => {
         checkInTime: '2026-05-04T09:00:00.000Z',
       }),
       createVisitor({
+        id: 'bbbbbbbb-2222-2222-2222-222222222222',
+        visitorGroupId: 'group-older',
+        checkInTime: '2026-05-04T09:05:00.000Z',
+      }),
+      createVisitor({
         id: 'cccccccc-1111-1111-1111-111111111111',
         visitorGroupId: 'group-newer',
         checkInTime: '2026-05-04T10:00:00.000Z',
+      }),
+      createVisitor({
+        id: 'cccccccc-2222-2222-2222-222222222222',
+        visitorGroupId: 'group-newer',
+        checkInTime: '2026-05-04T10:05:00.000Z',
       }),
     ]
 
@@ -191,9 +201,51 @@ describe('buildVisitorSignoutGrouping', () => {
     expect(second.groups.map((group) => group.groupCode)).toEqual(['G-01', 'G-02'])
     expect(first.groups[0]?.groupId).toBe('group-newer')
   })
+
+  it('treats one-person visitor groups as individual visitors for sign-out display', () => {
+    const grouping = buildVisitorSignoutGrouping([
+      createVisitor({
+        id: 'dddddddd-1111-1111-1111-111111111111',
+        visitorGroupId: 'legacy-single-person-group',
+        rankPrefix: 'MS',
+        firstName: null,
+        lastName: 'Sauk',
+        displayName: 'Sauk group',
+        visitType: 'military',
+      }),
+    ])
+
+    expect(grouping.groups).toHaveLength(0)
+    expect(grouping.ungroupedVisitors).toHaveLength(1)
+    expect(getPublicVisitorTitle(grouping.ungroupedVisitors[0] as VisitorResponse)).toBe('MS Sauk')
+  })
 })
 
 describe('public visitor kiosk display', () => {
+  it('formats individual visitor titles with rank and initials or last-name first-name order', () => {
+    expect(
+      getPublicVisitorTitle(
+        createVisitor({
+          visitType: 'military',
+          rankPrefix: 'MS',
+          firstName: null,
+          lastName: 'Sauk',
+          displayName: 'Sauk, CJW',
+        })
+      )
+    ).toBe('MS Sauk, CJW')
+
+    expect(
+      getPublicVisitorTitle(
+        createVisitor({
+          firstName: 'Alex',
+          lastName: 'Smith',
+          displayName: 'Smith, Alex',
+        })
+      )
+    ).toBe('Smith, Alex')
+  })
+
   it('uses company names as contractor primary titles without work descriptions', () => {
     const visitor = createVisitor({
       visitType: 'contractor',

--- a/apps/frontend-admin/src/lib/visitor-signout-grouping.ts
+++ b/apps/frontend-admin/src/lib/visitor-signout-grouping.ts
@@ -45,6 +45,30 @@ function visitorDisplayName(visitor: VisitorResponse): string {
   return clean(visitor.displayName) ?? clean(visitor.name) ?? 'Visitor'
 }
 
+function extractDisplayInitials(visitor: VisitorResponse): string | undefined {
+  const display = clean(visitor.displayName) ?? clean(visitor.name)
+  if (!display?.includes(',')) return undefined
+
+  const [, ...remaining] = display.split(',')
+  return clean(remaining.join(','))
+}
+
+function visitorPublicName(visitor: VisitorResponse): string {
+  const rankPrefix = clean(visitor.rankPrefix)
+  const lastName = clean(visitor.lastName)
+  const firstName = clean(visitor.firstName)
+
+  if (rankPrefix && lastName) {
+    const initials = extractDisplayInitials(visitor)
+    return `${rankPrefix} ${lastName}${initials ? `, ${initials}` : ''}`
+  }
+
+  if (lastName && firstName) return `${lastName}, ${firstName}`
+  if (lastName) return lastName
+
+  return visitorDisplayName(visitor)
+}
+
 function extractVisitReasonField(visitor: VisitorResponse, fieldName: string): string | undefined {
   const visitReason = clean(visitor.visitReason)
   if (!visitReason) return undefined
@@ -101,10 +125,10 @@ export function getPublicVisitorContextLine(visitor: VisitorResponse): string | 
 
 export function getPublicVisitorTitle(visitor: VisitorResponse): string {
   if (visitor.visitType === 'contractor') {
-    return clean(visitor.organization) ?? visitorDisplayName(visitor)
+    return clean(visitor.organization) ?? visitorPublicName(visitor)
   }
 
-  return visitorDisplayName(visitor)
+  return visitorPublicName(visitor)
 }
 
 export function buildVisitorEventTabs(activeVisitors: VisitorResponse[]): VisitorEventTabSummary[] {
@@ -289,7 +313,16 @@ export function buildVisitorSignoutGrouping(
     }
   }
 
-  const groupsWithoutCodes = Array.from(groupedMap.entries())
+  const groupEntries: Array<[string, VisitorResponse[]]> = []
+  for (const [groupId, members] of groupedMap.entries()) {
+    if (members.length <= 1) {
+      ungroupedVisitors.push(...members)
+    } else {
+      groupEntries.push([groupId, members])
+    }
+  }
+
+  const groupsWithoutCodes = groupEntries
     .map(([groupId, members]) => {
       const sortedMembers = [...members].sort((left, right) =>
         left.checkInTime.localeCompare(right.checkInTime)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.3.16",
+  "version": "3.3.17",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.3.16",
+  "version": "3.3.17",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.3.16",
+  "version": "3.3.17",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.3.16",
+  "version": "3.3.17",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary
- Improves kiosk visitor sign-out clarity, density, and group expansion behavior.
- Removes repeated visitor detail text from dashboard visitor cards.
- Allows any authenticated Sentinel user to run Repair Host Hotspot.
- Adds a daily 06:00 host hotspot repair scheduler that skips duplicates when repair is already queued or running.
- Bumps Sentinel workspace packages to 3.3.17.

## Why it matters
This patch makes the public kiosk easier for visitors to understand, keeps dashboard cards cleaner for operators, and makes hotspot recovery both more accessible and more automatic before daily use.

## What changed
### User-facing
- Kiosk one-person groups now show as individual visitors instead of empty expandable groups.
- Visitor cards are more compact so more active visitors fit in the kiosk visitor rail.
- Expanded groups scroll into view so visitors can see the group header and individual sign-out choices.
- Duplicate full-group sign-out buttons were removed.

### Admin and operator-facing
- Dashboard visitor cards avoid repeating information already shown in the subtitle.
- Repair Host Hotspot is available to every signed-in user from the navbar and Updates page.
- The kiosk time and lead panels are easier to notice while keeping the header restrained.

### Backend and scheduling
- Host hotspot repair now accepts authenticated member requests instead of admin-only requests.
- A backend scheduler queues host hotspot repair daily at 06:00.
- Scheduled repair requests are marked with the backend-scheduler source and skip duplicate queueing if repair is already queued or running.

## Upgrade and migration
- No database migration is required.
- No manual configuration is required for the default 06:00 schedule.
- The backend service must restart through the normal update process for the scheduler job to start.

## Risk and rollback
The main operational risk is that a scheduled hotspot repair could briefly affect hosted hotspot availability around 06:00. The job avoids duplicate requests when repair is already queued or running. Rollback is safe by reverting to the previous release because this patch does not include schema changes.

## Testing performed
- pnpm version:check
- pnpm --filter frontend-admin exec vitest run src/lib/dashboard-visitor-card-details.test.ts src/lib/visitor-signout-grouping.test.ts src/components/layout/app-navbar.logic.test.ts
- pnpm --filter frontend-admin exec tsc --noEmit
- pnpm --filter @sentinel/backend typecheck
- pnpm --filter @sentinel/backend lint
- pnpm --filter frontend-admin lint

## Changelog candidates
- Improved kiosk visitor sign-out cards and group expansion behavior.
- Dashboard visitor cards no longer repeat subtitle details in the detail text.
- Repair Host Hotspot can now be run by any signed-in Sentinel user.
- Host hotspot repair now queues automatically each day at 06:00 and skips duplicate repair requests.
