### PR TITLE
Release v3.3.18

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.3.17",
+  "version": "3.3.18",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/repositories/unit-event-repository.test.ts
+++ b/apps/backend/src/repositories/unit-event-repository.test.ts
@@ -1,0 +1,44 @@
+import type { PrismaClientInstance } from '@sentinel/database'
+import { describe, expect, it, vi } from 'vitest'
+import { UnitEventRepository } from './unit-event-repository.js'
+
+interface UnitEventRepositoryPrismaMock {
+  unitEvent: {
+    findMany: ReturnType<typeof vi.fn>
+    count: ReturnType<typeof vi.fn>
+  }
+}
+
+describe('UnitEventRepository visitor option counts', () => {
+  it('loads selectedCount from active visitors only', async () => {
+    const prismaMock: UnitEventRepositoryPrismaMock = {
+      unitEvent: {
+        findMany: vi.fn().mockResolvedValue([]),
+        count: vi.fn().mockResolvedValue(0),
+      },
+    }
+    const repository = new UnitEventRepository(prismaMock as unknown as PrismaClientInstance)
+
+    await repository.findEvents({ status: 'scheduled' })
+
+    expect(prismaMock.unitEvent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        include: expect.objectContaining({
+          visitorOptions: expect.objectContaining({
+            include: {
+              _count: {
+                select: {
+                  visitors: {
+                    where: {
+                      checkOutTime: null,
+                    },
+                  },
+                },
+              },
+            },
+          }),
+        }),
+      })
+    )
+  })
+})

--- a/apps/backend/src/repositories/unit-event-repository.ts
+++ b/apps/backend/src/repositories/unit-event-repository.ts
@@ -257,7 +257,13 @@ const visitorOptionsInclude = {
   orderBy: { displayOrder: 'asc' as const },
   include: {
     _count: {
-      select: { visitors: true },
+      select: {
+        visitors: {
+          where: {
+            checkOutTime: null,
+          },
+        },
+      },
     },
   },
 }

--- a/apps/backend/src/repositories/visitor-repository.test.ts
+++ b/apps/backend/src/repositories/visitor-repository.test.ts
@@ -1,0 +1,189 @@
+import type { PrismaClientInstance } from '@sentinel/database'
+import { describe, expect, it, vi } from 'vitest'
+import { VisitorRepository } from './visitor-repository.js'
+
+interface VisitorCountArgs {
+  where?: {
+    unitEventVisitorOptionId?: string
+    checkOutTime?: Date | null
+  }
+}
+
+interface VisitorRepositoryPrismaMock {
+  $transaction: ReturnType<typeof vi.fn>
+  unitEvent: {
+    findUnique: ReturnType<typeof vi.fn>
+  }
+  event: {
+    findUnique: ReturnType<typeof vi.fn>
+  }
+  unitEventVisitorOption: {
+    findUnique: ReturnType<typeof vi.fn>
+  }
+  visitor: {
+    count: ReturnType<typeof vi.fn>
+    create: ReturnType<typeof vi.fn>
+    findMany: ReturnType<typeof vi.fn>
+    update: ReturnType<typeof vi.fn>
+    findUniqueOrThrow: ReturnType<typeof vi.fn>
+  }
+}
+
+function createPrismaMock(): VisitorRepositoryPrismaMock {
+  const prismaMock: VisitorRepositoryPrismaMock = {
+    $transaction: vi.fn(),
+    unitEvent: {
+      findUnique: vi.fn(),
+    },
+    event: {
+      findUnique: vi.fn(),
+    },
+    unitEventVisitorOption: {
+      findUnique: vi.fn(),
+    },
+    visitor: {
+      count: vi.fn(),
+      create: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+      findUniqueOrThrow: vi.fn(),
+    },
+  }
+
+  prismaMock.$transaction.mockImplementation(
+    async (callback: (tx: VisitorRepositoryPrismaMock) => Promise<unknown>) => callback(prismaMock)
+  )
+
+  return prismaMock
+}
+
+describe('VisitorRepository event option capacity', () => {
+  it('ignores checked-out visitors when deciding if a limited event option has room', async () => {
+    const eventId = '11111111-1111-1111-1111-111111111111'
+    const optionId = '22222222-2222-2222-2222-222222222222'
+    const checkInTime = new Date('2026-05-21T13:00:00.000Z')
+    const createdAt = new Date('2026-05-21T13:00:01.000Z')
+    const prismaMock = createPrismaMock()
+
+    prismaMock.unitEvent.findUnique.mockResolvedValue({ id: eventId })
+    prismaMock.unitEventVisitorOption.findUnique.mockResolvedValue({
+      id: optionId,
+      eventId,
+      title: 'Gallery Attendee',
+      maxSelections: 27,
+    })
+    prismaMock.visitor.count.mockImplementation(async (args: VisitorCountArgs) =>
+      args.where?.checkOutTime === null ? 0 : 27
+    )
+    prismaMock.visitor.create.mockResolvedValue({
+      id: 'visitor-1',
+      name: 'Guest, Jane',
+      rankPrefix: null,
+      firstName: 'Jane',
+      lastName: 'Guest',
+      displayName: null,
+      organization: null,
+      unit: null,
+      mobilePhone: null,
+      licensePlate: null,
+      visitType: 'event',
+      visitTypeId: null,
+      eventId: null,
+      unitEventId: eventId,
+      unitEventVisitorOptionId: optionId,
+      hostMemberId: null,
+      visitReason: 'Event',
+      visitPurpose: null,
+      purposeDetails: null,
+      recruitmentStep: null,
+      checkInTime,
+      checkOutTime: null,
+      temporaryBadgeId: null,
+      kioskId: 'kiosk-1',
+      adminNotes: null,
+      checkInMethod: 'kiosk_self_service',
+      createdByAdmin: null,
+      visitorGroupId: null,
+      createdAt,
+    })
+    prismaMock.visitor.findMany.mockResolvedValue([
+      {
+        id: 'visitor-1',
+        name: 'Guest, Jane',
+        rankPrefix: null,
+        firstName: 'Jane',
+        lastName: 'Guest',
+      },
+    ])
+    prismaMock.visitor.update.mockResolvedValue({})
+    prismaMock.visitor.findUniqueOrThrow.mockResolvedValue({
+      id: 'visitor-1',
+      name: 'Guest, Jane',
+      rankPrefix: null,
+      firstName: 'Jane',
+      lastName: 'Guest',
+      displayName: 'Guest, J.',
+      organization: null,
+      unit: null,
+      mobilePhone: null,
+      licensePlate: null,
+      visitType: 'event',
+      visitTypeId: null,
+      eventId: null,
+      unitEventId: eventId,
+      unitEventVisitorOptionId: optionId,
+      hostMemberId: null,
+      visitReason: 'Event',
+      visitPurpose: null,
+      purposeDetails: null,
+      recruitmentStep: null,
+      checkInTime,
+      checkOutTime: null,
+      temporaryBadgeId: null,
+      kioskId: 'kiosk-1',
+      adminNotes: null,
+      checkInMethod: 'kiosk_self_service',
+      createdByAdmin: null,
+      visitorGroupId: null,
+      createdAt,
+      event: null,
+      unitEvent: { title: 'Standing Court Martial' },
+      unitEventVisitorOption: {
+        id: optionId,
+        eventId,
+        title: 'Gallery Attendee',
+        maxSelections: 27,
+        displayOrder: 0,
+        createdAt,
+        updatedAt: createdAt,
+      },
+      hostMember: null,
+      badge: null,
+    })
+
+    const repository = new VisitorRepository(prismaMock as unknown as PrismaClientInstance)
+
+    await expect(
+      repository.create({
+        firstName: 'Jane',
+        lastName: 'Guest',
+        visitType: 'event',
+        visitReason: 'Event',
+        unitEventId: eventId,
+        unitEventVisitorOptionId: optionId,
+        kioskId: 'kiosk-1',
+        checkInMethod: 'kiosk_self_service',
+      })
+    ).resolves.toMatchObject({
+      id: 'visitor-1',
+      unitEventVisitorOptionId: optionId,
+    })
+
+    expect(prismaMock.visitor.count).toHaveBeenCalledWith({
+      where: {
+        unitEventVisitorOptionId: optionId,
+        checkOutTime: null,
+      },
+    })
+  })
+})

--- a/apps/backend/src/repositories/visitor-repository.ts
+++ b/apps/backend/src/repositories/visitor-repository.ts
@@ -222,7 +222,10 @@ export class VisitorRepository {
 
     if (option.maxSelections !== null) {
       const selectedCount = await tx.visitor.count({
-        where: { unitEventVisitorOptionId: option.id },
+        where: {
+          unitEventVisitorOptionId: option.id,
+          checkOutTime: null,
+        },
       })
       if (selectedCount + visitorCount > option.maxSelections) {
         throw new VisitorEventOptionError(

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.3.17",
+  "version": "3.3.18",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/hooks/use-visitors.test.ts
+++ b/apps/frontend-admin/src/hooks/use-visitors.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { invalidateVisitorEventAvailabilityQueries } from '../lib/visitor-event-availability-invalidation'
 
 describe('invalidateVisitorEventAvailabilityQueries', () => {
-  it('refreshes kiosk event option capacity after visitor sign-ins', () => {
+  it('refreshes kiosk event option capacity after visitor sign-ins and sign-outs', () => {
     const queryClient = new QueryClient()
     const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
 

--- a/apps/frontend-admin/src/hooks/use-visitors.ts
+++ b/apps/frontend-admin/src/hooks/use-visitors.ts
@@ -87,6 +87,7 @@ export function useCheckoutVisitor() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['active-visitors'] })
       queryClient.invalidateQueries({ queryKey: ['present-people'] })
+      invalidateVisitorEventAvailabilityQueries(queryClient)
       void invalidateDashboardQueries(queryClient)
     },
   })
@@ -110,6 +111,7 @@ export function useCheckoutVisitorGroup() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['active-visitors'] })
       queryClient.invalidateQueries({ queryKey: ['present-people'] })
+      invalidateVisitorEventAvailabilityQueries(queryClient)
       void invalidateDashboardQueries(queryClient)
     },
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.3.17",
+  "version": "3.3.18",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.3.17",
+  "version": "3.3.18",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.3.17",
+  "version": "3.3.18",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.3.17",
+  "version": "3.3.18",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary
- Fixes limited Event Option availability so checked-out visitors no longer consume capacity.
- Refreshes kiosk event availability after individual visitor and visitor group sign-outs.
- Adds regression coverage for active-only event option counts and kiosk availability query invalidation.
- Bumps Sentinel workspace packages to 3.3.18.

## Why this change was needed
Event Options with maximum counts were counting historical visitors instead of only visitors who are still signed in. This caused options such as Gallery Attendee to show fewer available spots even after all visitors had checked out.

## What changed
### User-facing
- Kiosk Event Option availability now returns to the correct count after visitors sign out.
- Individual and group visitor sign-outs trigger an immediate refresh of kiosk event availability data.

### Admin/operator-facing
- Event capacity shown on the kiosk should now match the current active visitor count without requiring an operator to recreate the event or manually reset data.

### Backend/API
- Limited event option enforcement now counts only visitors with no checkout time.
- Unit event visitor option selected counts now use active visitors only.

### Database
- No schema change.
- Existing historical visitor records remain unchanged.

### Deployment/update
- Standard patch update only.
- Backend and frontend services should restart through the normal update process.

### Tests
- Added focused repository coverage for active-only event option capacity counts.
- Updated kiosk availability invalidation coverage for sign-ins and sign-outs.

## User impact
Visitors and kiosk users will see available Event Option counts recover as people leave. For example, if an option allows 27 Gallery Attendees and everyone checks out, the kiosk should show 27 available again.

## Operator impact
Operators should no longer need to manually intervene when Event Option capacity appears stuck after visitor checkout.

## Upgrade or migration notes
No database migration is required. No configuration change is required. Deploy the patch through the normal Sentinel update process.

## Risk and rollback notes
The main risk is that event option counts now intentionally ignore checked-out visitors, so reports that need historical totals must continue using reporting data rather than kiosk availability. Rollback to v3.3.17 is safe because there are no schema changes.

## Testing performed
- pnpm version:check
- cd apps/backend && ../frontend-admin/node_modules/.bin/vitest run src/repositories/visitor-repository.test.ts src/repositories/unit-event-repository.test.ts
- pnpm --filter frontend-admin exec vitest run src/hooks/use-visitors.test.ts
- pnpm --filter @sentinel/backend typecheck
- pnpm --filter frontend-admin exec tsc --noEmit
- pnpm --filter @sentinel/backend lint
- pnpm --filter frontend-admin lint

## Changelog candidates
- Fixed limited Event Option availability so checked-out visitors no longer reduce available kiosk capacity.
- Refreshed kiosk event availability immediately after individual or group visitor sign-out.
- Added regression coverage for active-only Event Option counts.
