### PR TITLE
fix(kiosk): refresh event option counts after visitor checkout

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.3.18",
+  "version": "3.3.19",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.3.18",
+  "version": "3.3.19",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/components/events/event-form-modal.tsx
+++ b/apps/frontend-admin/src/components/events/event-form-modal.tsx
@@ -13,6 +13,10 @@ import {
 import { Checkbox } from '@/components/ui/checkbox'
 import { useCreateUnitEvent, useUpdateUnitEvent, useEventTypes } from '@/hooks/use-events'
 import { Plus, Trash2 } from 'lucide-react'
+import {
+  allowsGeneralEventVisitorOption,
+  buildUnitEventMetadataWithGeneralVisitorOption,
+} from '@/lib/unit-event-visitor-options'
 import type {
   UnitEventResponse,
   CreateUnitEventInput,
@@ -179,6 +183,7 @@ export function EventFormModal({
   const [organizer, setOrganizer] = useState('')
   const [requiresDutyWatch, setRequiresDutyWatch] = useState(false)
   const [enableVisitorOptions, setEnableVisitorOptions] = useState(false)
+  const [allowGeneralEventVisitorOption, setAllowGeneralEventVisitorOption] = useState(false)
   const [visitorOptions, setVisitorOptions] = useState<VisitorOptionDraft[]>([emptyVisitorOption()])
   const [notes, setNotes] = useState('')
   const [metadata, setMetadata] = useState('')
@@ -215,6 +220,7 @@ export function EventFormModal({
       setOrganizer(event.organizer ?? '')
       setRequiresDutyWatch(event.requiresDutyWatch)
       setEnableVisitorOptions(event.visitorOptions.length > 0)
+      setAllowGeneralEventVisitorOption(allowsGeneralEventVisitorOption(event.metadata))
       setVisitorOptions(
         event.visitorOptions.length > 0
           ? event.visitorOptions.map((option) => ({
@@ -240,6 +246,7 @@ export function EventFormModal({
       setOrganizer('')
       setRequiresDutyWatch(false)
       setEnableVisitorOptions(false)
+      setAllowGeneralEventVisitorOption(false)
       setVisitorOptions([emptyVisitorOption()])
       setNotes('')
       setMetadata('')
@@ -321,7 +328,10 @@ export function EventFormModal({
       description: description.trim() || null,
       organizer: organizer.trim() || null,
       requiresDutyWatch,
-      metadata: parsedMetadata,
+      metadata: buildUnitEventMetadataWithGeneralVisitorOption(
+        parsedMetadata,
+        enableVisitorOptions && allowGeneralEventVisitorOption
+      ),
       notes: notes.trim() || null,
       visitorOptions: buildVisitorOptionsPayload(),
     }
@@ -700,6 +710,9 @@ export function EventFormModal({
                         if (nextEnabled && visitorOptions.length === 0) {
                           setVisitorOptions([emptyVisitorOption()])
                         }
+                        if (!nextEnabled) {
+                          setAllowGeneralEventVisitorOption(false)
+                        }
                         clearFieldError('visitorOptions')
                         setSubmitError(null)
                       }}
@@ -783,6 +796,30 @@ export function EventFormModal({
                           {formErrors.visitorOptions}
                         </p>
                       )}
+
+                      <label
+                        htmlFor="allow-general-event-visitor-option"
+                        className="flex cursor-pointer items-start gap-[var(--space-2)] rounded-md border border-base-300 bg-base-200 p-[var(--space-3)]"
+                      >
+                        <Checkbox
+                          id="allow-general-event-visitor-option"
+                          checked={allowGeneralEventVisitorOption}
+                          onCheckedChange={(checked) => {
+                            setAllowGeneralEventVisitorOption(checked === true)
+                            setSubmitError(null)
+                          }}
+                          disabled={isSubmitting}
+                        />
+                        <span className="space-y-1">
+                          <span className="text-sm font-medium">
+                            Also allow General event visitor
+                          </span>
+                          <span className="block text-xs text-base-content/60">
+                            Shows a no-option choice on the kiosk alongside the custom visitor
+                            options.
+                          </span>
+                        </span>
+                      </label>
 
                       <button
                         type="button"

--- a/apps/frontend-admin/src/components/kiosk/visitor-self-signin-flow.tsx
+++ b/apps/frontend-admin/src/components/kiosk/visitor-self-signin-flow.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/lib/visitor-self-signin'
 import { useCreateVisitor, useCreateVisitorGroup } from '@/hooks/use-visitors'
 import { formatUnitEventDateRange } from '@/lib/unit-event-dates'
+import { allowsGeneralEventVisitorOption } from '@/lib/unit-event-visitor-options'
 import {
   TouchScreenKeyboard,
   type TouchKeyboardMode,
@@ -65,6 +66,7 @@ interface EventOption {
   id: string
   title: string
   eventDateLabel: string
+  allowGeneralEventVisitorOption: boolean
   visitorOptions: Array<{
     id: string
     title: string
@@ -234,6 +236,7 @@ export function VisitorSelfSigninFlow({
   const eventListQuery = useQuery({
     queryKey: ['kiosk-unit-events'],
     enabled: requiresEventSelection,
+    refetchOnMount: 'always',
     queryFn: async (): Promise<EventOption[]> => {
       const response = await apiClient.unitEvents.listUnitEvents({
         query: {
@@ -250,6 +253,7 @@ export function VisitorSelfSigninFlow({
         id: event.id,
         title: event.title,
         eventDateLabel: formatUnitEventDateRange(event, 'MMM d, yyyy'),
+        allowGeneralEventVisitorOption: allowsGeneralEventVisitorOption(event.metadata),
         visitorOptions: event.visitorOptions.map((option) => ({
           id: option.id,
           title: option.title,
@@ -276,6 +280,7 @@ export function VisitorSelfSigninFlow({
   const selectedEventDetailsQuery = useQuery({
     queryKey: ['kiosk-unit-event', selectedEvent?.id],
     enabled: requiresEventSelection && Boolean(selectedEvent?.id),
+    refetchOnMount: 'always',
     queryFn: async (): Promise<EventOption> => {
       if (!selectedEvent?.id) {
         throw new Error('Select an event before loading event options')
@@ -293,6 +298,7 @@ export function VisitorSelfSigninFlow({
         id: response.body.id,
         title: response.body.title,
         eventDateLabel: formatUnitEventDateRange(response.body, 'MMM d, yyyy'),
+        allowGeneralEventVisitorOption: allowsGeneralEventVisitorOption(response.body.metadata),
         visitorOptions: response.body.visitorOptions.map((option) => ({
           id: option.id,
           title: option.title,
@@ -303,8 +309,16 @@ export function VisitorSelfSigninFlow({
     },
   })
 
-  const selectedEventForDisplay = selectedEventDetailsQuery.data ?? selectedEvent
+  const selectedEventFromList = eventListQuery.data?.find((event) => event.id === selectedEvent?.id)
+  const selectedEventForDisplay =
+    selectedEventDetailsQuery.data ?? selectedEventFromList ?? selectedEvent
   const selectedEventVisitorOptions = selectedEventForDisplay?.visitorOptions ?? []
+  const showGeneralEventVisitorOption =
+    selectedEventForDisplay?.allowGeneralEventVisitorOption === true
+  const requiresEventOptionSelection =
+    requiresEventSelection &&
+    selectedEventVisitorOptions.length > 0 &&
+    !showGeneralEventVisitorOption
 
   const focusKeyboardField = (name: KeyboardFieldName, nextValueLength?: number) => {
     const fieldElement = fieldRefs.current[name]
@@ -556,9 +570,23 @@ export function VisitorSelfSigninFlow({
     }
   }
 
+  const clearCurrentMemberFields = () => {
+    setValue('rankPrefix', '')
+    setValue('initials', '')
+    setValue('firstName', '')
+    setValue('lastName', '')
+    setValue('unit', '')
+    clearErrors(['rankPrefix', 'initials', 'firstName', 'lastName', 'unit'])
+  }
+
   const handleBranchSelect = (value: SelfServiceVisitorBranch) => {
+    const branchChanged = branch !== value
     setValue('branch', value, { shouldValidate: true })
     clearErrors('branch')
+
+    if (branchChanged) {
+      clearCurrentMemberFields()
+    }
 
     const isOnRoutingStep = routingStep !== null && step === routingStep
     if (isOnRoutingStep) {
@@ -721,6 +749,9 @@ export function VisitorSelfSigninFlow({
       if (requiresEventSelection) {
         fields.push('eventId')
       }
+      if (requiresEventOptionSelection) {
+        fields.push('unitEventVisitorOptionId')
+      }
       const valid = fields.length > 0 ? await trigger(fields) : true
       if (valid) {
         setStep((routingStep ?? personalInfoStep) as FlowStep)
@@ -775,6 +806,7 @@ export function VisitorSelfSigninFlow({
   }): ReasonFirstGroupMemberInput => {
     if (followsMilitaryPath) {
       return {
+        branch: reason && reasonRequiresBranch(reason) ? 'military' : undefined,
         rankPrefix: values.rankPrefix,
         initials: values.initials,
         lastName: values.lastName,
@@ -783,6 +815,7 @@ export function VisitorSelfSigninFlow({
     }
 
     return {
+      branch: reason && reasonRequiresBranch(reason) ? 'civilian' : undefined,
       firstName: values.firstName,
       lastName: values.lastName,
     }
@@ -797,8 +830,8 @@ export function VisitorSelfSigninFlow({
     if (!hasPendingMemberInput) {
       setSubmitError(
         followsMilitaryPath
-          ? 'Enter rank, initials, last name, and unit before adding another member'
-          : 'Enter first and last name before adding another member'
+          ? 'Enter rank, initials, last name, and unit before adding another visitor'
+          : 'Enter first and last name before adding another visitor'
       )
       return
     }
@@ -818,12 +851,7 @@ export function VisitorSelfSigninFlow({
     }
 
     setGroupMembers((current) => [...current, buildCurrentMemberFromValues(currentValues)])
-    setValue('rankPrefix', '')
-    setValue('initials', '')
-    setValue('firstName', '')
-    setValue('lastName', '')
-    setValue('unit', '')
-    clearErrors(['rankPrefix', 'initials', 'firstName', 'lastName', 'unit'])
+    clearCurrentMemberFields()
     setSubmitError(null)
   }
 
@@ -895,11 +923,12 @@ export function VisitorSelfSigninFlow({
       const selectedEventOptionTitle = selectedEventForDisplay?.visitorOptions.find(
         (option) => option.id === values.unitEventVisitorOptionId
       )?.title
+      const submissionBranch = (membersForSubmission[0]?.branch ?? values.branch) || undefined
 
       const commonPayloadContext = {
         kioskId,
         reason: values.reason,
-        branch: values.branch || undefined,
+        branch: submissionBranch,
         organization: values.organization,
         workDescription: values.workDescription,
         hostMemberId: values.hostMemberId,
@@ -1049,7 +1078,10 @@ export function VisitorSelfSigninFlow({
     validate: (value) =>
       !requiresEventSelection || Boolean(value) || 'Select an event before continuing',
   })
-  const eventOptionRegistration = register('unitEventVisitorOptionId')
+  const eventOptionRegistration = register('unitEventVisitorOptionId', {
+    validate: (value) =>
+      !requiresEventOptionSelection || Boolean(value) || 'Select an event option before continuing',
+  })
 
   const rankPrefixRegistration = register('rankPrefix', {
     validate: (value) =>
@@ -1110,9 +1142,6 @@ export function VisitorSelfSigninFlow({
   const isSubmitting = createVisitor.isPending || createVisitorGroup.isPending
   const reviewReasonLabel =
     SELF_SERVICE_REASON_OPTIONS.find((option) => option.value === reviewReason)?.label ?? 'Other'
-  const reviewBranchLabel = branch
-    ? SELF_SERVICE_BRANCH_OPTIONS.find((option) => option.value === branch)?.label
-    : undefined
   const currentMemberForReview = hasCurrentMemberForReview
     ? buildCurrentMemberFromValues({
         rankPrefix,
@@ -1125,6 +1154,18 @@ export function VisitorSelfSigninFlow({
   const reviewMembers = currentMemberForReview
     ? [...groupMembers, currentMemberForReview]
     : groupMembers
+
+  const getMemberBranchLabel = (member: ReasonFirstGroupMemberInput): string | undefined => {
+    if (!member.branch) return undefined
+    return SELF_SERVICE_BRANCH_OPTIONS.find((option) => option.value === member.branch)?.label
+  }
+  const reviewBranchValues = reviewMembers
+    .map((member) => member.branch)
+    .filter((value): value is SelfServiceVisitorBranch => Boolean(value))
+  const reviewBranchLabel =
+    reviewBranchValues.length > 0 && new Set(reviewBranchValues).size === 1
+      ? SELF_SERVICE_BRANCH_OPTIONS.find((option) => option.value === reviewBranchValues[0])?.label
+      : undefined
 
   const formatReviewMember = (member: ReasonFirstGroupMemberInput): string => {
     if (member.rankPrefix || member.initials || member.unit) {
@@ -1393,12 +1434,10 @@ export function VisitorSelfSigninFlow({
                                 className="rounded-box border border-base-300 bg-base-100"
                                 style={{ padding: 'var(--space-3)' }}
                               >
-                                <p className="text-sm font-semibold">
-                                  Choose an option if it applies
-                                </p>
+                                <p className="text-sm font-semibold">Choose an event option</p>
                                 <p className="text-xs text-base-content/70">
-                                  You can continue without an option. Full options are only blocked
-                                  for that choice.
+                                  Select the option that matches your visit. Full options are
+                                  blocked for that choice.
                                 </p>
                                 {selectedEventDetailsQuery.isLoading && (
                                   <div
@@ -1417,28 +1456,30 @@ export function VisitorSelfSigninFlow({
                                 )}
                                 {selectedEventVisitorOptions.length > 0 && (
                                   <div className="mt-2 grid grid-cols-1 gap-2">
-                                    <button
-                                      type="button"
-                                      className={cn(
-                                        'btn btn-outline btn-md h-auto justify-between border-base-300 bg-base-100 text-left text-base-content hover:border-primary hover:bg-base-200',
-                                        !unitEventVisitorOptionId && 'border-primary bg-base-200'
-                                      )}
-                                      style={{
-                                        minHeight: '3rem',
-                                        padding: 'var(--space-2) var(--space-3)',
-                                      }}
-                                      onClick={() => {
-                                        setValue('unitEventVisitorOptionId', '', {
-                                          shouldValidate: true,
-                                        })
-                                        clearErrors('unitEventVisitorOptionId')
-                                      }}
-                                    >
-                                      <span className="truncate">General event visitor</span>
-                                      <span className="text-sm font-normal text-base-content/70">
-                                        No option
-                                      </span>
-                                    </button>
+                                    {showGeneralEventVisitorOption && (
+                                      <button
+                                        type="button"
+                                        className={cn(
+                                          'btn btn-outline btn-md h-auto justify-between border-base-300 bg-base-100 text-left text-base-content hover:border-primary hover:bg-base-200',
+                                          !unitEventVisitorOptionId && 'border-primary bg-base-200'
+                                        )}
+                                        style={{
+                                          minHeight: '3rem',
+                                          padding: 'var(--space-2) var(--space-3)',
+                                        }}
+                                        onClick={() => {
+                                          setValue('unitEventVisitorOptionId', '', {
+                                            shouldValidate: true,
+                                          })
+                                          clearErrors('unitEventVisitorOptionId')
+                                        }}
+                                      >
+                                        <span className="truncate">General event visitor</span>
+                                        <span className="text-sm font-normal text-base-content/70">
+                                          No option
+                                        </span>
+                                      </button>
+                                    )}
                                     {selectedEventVisitorOptions.map((option) => {
                                       const remaining =
                                         option.maxSelections === null
@@ -1692,6 +1733,37 @@ export function VisitorSelfSigninFlow({
 
             {step === personalInfoStep && (
               <div className="flex flex-col" style={{ gap: 'var(--space-4)' }}>
+                {requiresBranch && (
+                  <div
+                    className="rounded-box border border-base-300 bg-base-200"
+                    style={{ padding: 'var(--space-3)' }}
+                  >
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div>
+                        <p className="font-semibold text-base-content">Current visitor type</p>
+                        <p className="text-sm text-base-content/70">
+                          Choose the type for the visitor you are entering now.
+                        </p>
+                      </div>
+                      <div className="join">
+                        {SELF_SERVICE_BRANCH_OPTIONS.map((option) => (
+                          <button
+                            key={option.value}
+                            type="button"
+                            className={cn(
+                              'btn join-item btn-sm',
+                              branch === option.value ? 'btn-primary' : 'btn-outline'
+                            )}
+                            onClick={() => handleBranchSelect(option.value)}
+                          >
+                            {option.label}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                )}
+
                 <div className="grid grid-cols-1 gap-2 lg:grid-cols-2">
                   {followsMilitaryPath && (
                     <>
@@ -1869,14 +1941,14 @@ export function VisitorSelfSigninFlow({
                   style={{ padding: 'var(--space-3)' }}
                 >
                   <div className="flex items-center justify-between gap-2">
-                    <p className="font-semibold">Group members added: {groupMembers.length}</p>
+                    <p className="font-semibold">Visitors added: {groupMembers.length}</p>
                     <button
                       type="button"
                       className="btn btn-secondary btn-sm"
                       disabled={!hasPendingMemberInput}
                       onClick={() => void handleAddCurrentMember()}
                     >
-                      Add member
+                      Add visitor
                     </button>
                   </div>
 
@@ -1888,6 +1960,9 @@ export function VisitorSelfSigninFlow({
                           className="flex items-center justify-between rounded-box border border-base-300 bg-base-100 px-3 py-2"
                         >
                           <span className="text-sm">
+                            {getMemberBranchLabel(member)
+                              ? `${getMemberBranchLabel(member)} - `
+                              : ''}
                             {member.rankPrefix ? `${member.rankPrefix} ` : ''}
                             {member.firstName ?? member.initials ?? 'Visitor'} {member.lastName}
                             {member.unit ? ` (${member.unit})` : ''}
@@ -1905,7 +1980,7 @@ export function VisitorSelfSigninFlow({
                   ) : (
                     <p className="mt-2 text-sm text-base-content/70">
                       Add each visitor in the group. The current form fields are for the next
-                      member.
+                      visitor.
                     </p>
                   )}
                 </div>
@@ -2065,6 +2140,11 @@ export function VisitorSelfSigninFlow({
                           <p className="font-semibold text-base-content">
                             {formatReviewMember(member) || `Visitor ${index + 1}`}
                           </p>
+                          {getMemberBranchLabel(member) && (
+                            <p className="mt-1 text-sm text-base-content/70">
+                              {getMemberBranchLabel(member)}
+                            </p>
+                          )}
                         </div>
                       ))}
                     </div>

--- a/apps/frontend-admin/src/components/visitors/visitor-signin-modal.tsx
+++ b/apps/frontend-admin/src/components/visitors/visitor-signin-modal.tsx
@@ -7,6 +7,7 @@ import { useMembers } from '@/hooks/use-members'
 import { useUnitEvents } from '@/hooks/use-events'
 import { useAuthStore } from '@/store/auth-store'
 import { cn } from '@/lib/utils'
+import { allowsGeneralEventVisitorOption } from '@/lib/unit-event-visitor-options'
 import { Search, X } from 'lucide-react'
 import type { CreateVisitorInput } from '@sentinel/contracts'
 
@@ -96,6 +97,7 @@ export function VisitorSigninModal({ open, onOpenChange }: VisitorSigninModalPro
     [eventsData?.data, selectedEventId]
   )
   const selectedEventVisitorOptions = selectedEvent?.visitorOptions ?? []
+  const showGeneralEventVisitorOption = allowsGeneralEventVisitorOption(selectedEvent?.metadata)
 
   // Sync open prop with dialog element
   useEffect(() => {
@@ -129,6 +131,14 @@ export function VisitorSigninModal({ open, onOpenChange }: VisitorSigninModalPro
   const onSubmit = async (data: FormData) => {
     setSubmitError(null)
     try {
+      if (
+        selectedEventVisitorOptions.length > 0 &&
+        !showGeneralEventVisitorOption &&
+        !data.unitEventVisitorOptionId
+      ) {
+        throw new Error('Select an event option before signing in this visitor')
+      }
+
       const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
       const visitorData: CreateVisitorInput = {
         rankPrefix: data.rankPrefix || undefined,
@@ -358,23 +368,24 @@ export function VisitorSigninModal({ open, onOpenChange }: VisitorSigninModalPro
                   <div>
                     <p className="text-sm font-semibold text-base-content">Event option</p>
                     <p className="text-xs text-base-content/65">
-                      Select one if it applies. Visitors can still sign in without choosing an
-                      option.
+                      Select the option that matches this visit.
                     </p>
                   </div>
                   <div className="mt-(--space-2) grid gap-(--space-2)">
-                    <button
-                      type="button"
-                      className={cn(
-                        'btn btn-outline h-auto justify-between border-base-300 bg-base-100 px-(--space-3) py-(--space-2) text-left',
-                        !selectedEventOptionId && 'border-primary bg-primary-fadded'
-                      )}
-                      onClick={() => setValue('unitEventVisitorOptionId', '')}
-                      disabled={isSubmitting}
-                    >
-                      <span className="truncate">General event visitor</span>
-                      <span className="text-xs font-normal text-base-content/65">No option</span>
-                    </button>
+                    {showGeneralEventVisitorOption && (
+                      <button
+                        type="button"
+                        className={cn(
+                          'btn btn-outline h-auto justify-between border-base-300 bg-base-100 px-(--space-3) py-(--space-2) text-left',
+                          !selectedEventOptionId && 'border-primary bg-primary-fadded'
+                        )}
+                        onClick={() => setValue('unitEventVisitorOptionId', '')}
+                        disabled={isSubmitting}
+                      >
+                        <span className="truncate">General event visitor</span>
+                        <span className="text-xs font-normal text-base-content/65">No option</span>
+                      </button>
+                    )}
 
                     {selectedEventVisitorOptions.map((option) => {
                       const remaining =

--- a/apps/frontend-admin/src/hooks/use-visitors.test.ts
+++ b/apps/frontend-admin/src/hooks/use-visitors.test.ts
@@ -1,15 +1,21 @@
 import { QueryClient } from '@tanstack/react-query'
 import { describe, expect, it, vi } from 'vitest'
-import { invalidateVisitorEventAvailabilityQueries } from '../lib/visitor-event-availability-invalidation'
+import { refreshVisitorEventAvailabilityQueries } from '../lib/visitor-event-availability-invalidation'
 
-describe('invalidateVisitorEventAvailabilityQueries', () => {
-  it('refreshes kiosk event option capacity after visitor sign-ins and sign-outs', () => {
+describe('refreshVisitorEventAvailabilityQueries', () => {
+  it('refreshes active and inactive kiosk event option capacity after visitor changes', async () => {
     const queryClient = new QueryClient()
     const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
 
-    invalidateVisitorEventAvailabilityQueries(queryClient)
+    await refreshVisitorEventAvailabilityQueries(queryClient)
 
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['kiosk-unit-events'] })
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['kiosk-unit-event'] })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['kiosk-unit-events'],
+      refetchType: 'all',
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['kiosk-unit-event'],
+      refetchType: 'all',
+    })
   })
 })

--- a/apps/frontend-admin/src/hooks/use-visitors.ts
+++ b/apps/frontend-admin/src/hooks/use-visitors.ts
@@ -3,7 +3,10 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { apiClient } from '@/lib/api-client'
 import { invalidateDashboardQueries } from '@/lib/dashboard-query-invalidation'
-import { invalidateVisitorEventAvailabilityQueries } from '@/lib/visitor-event-availability-invalidation'
+import {
+  invalidateVisitorEventAvailabilityQueries,
+  refreshVisitorEventAvailabilityQueries,
+} from '@/lib/visitor-event-availability-invalidation'
 import type {
   CreateVisitorInput,
   CreateVisitorGroupInput,
@@ -37,10 +40,10 @@ export function useCreateVisitor() {
       }
       return response.body
     },
-    onSuccess: () => {
+    onSuccess: async () => {
       queryClient.invalidateQueries({ queryKey: ['active-visitors'] })
       queryClient.invalidateQueries({ queryKey: ['present-people'] })
-      invalidateVisitorEventAvailabilityQueries(queryClient)
+      await refreshVisitorEventAvailabilityQueries(queryClient)
       void invalidateDashboardQueries(queryClient)
     },
   })
@@ -62,10 +65,10 @@ export function useCreateVisitorGroup() {
       }
       return response.body
     },
-    onSuccess: () => {
+    onSuccess: async () => {
       queryClient.invalidateQueries({ queryKey: ['active-visitors'] })
       queryClient.invalidateQueries({ queryKey: ['present-people'] })
-      invalidateVisitorEventAvailabilityQueries(queryClient)
+      await refreshVisitorEventAvailabilityQueries(queryClient)
       void invalidateDashboardQueries(queryClient)
     },
   })
@@ -84,10 +87,10 @@ export function useCheckoutVisitor() {
       }
       return response.body
     },
-    onSuccess: () => {
+    onSuccess: async () => {
       queryClient.invalidateQueries({ queryKey: ['active-visitors'] })
       queryClient.invalidateQueries({ queryKey: ['present-people'] })
-      invalidateVisitorEventAvailabilityQueries(queryClient)
+      await refreshVisitorEventAvailabilityQueries(queryClient)
       void invalidateDashboardQueries(queryClient)
     },
   })
@@ -108,10 +111,10 @@ export function useCheckoutVisitorGroup() {
       }
       return response.body
     },
-    onSuccess: () => {
+    onSuccess: async () => {
       queryClient.invalidateQueries({ queryKey: ['active-visitors'] })
       queryClient.invalidateQueries({ queryKey: ['present-people'] })
-      invalidateVisitorEventAvailabilityQueries(queryClient)
+      await refreshVisitorEventAvailabilityQueries(queryClient)
       void invalidateDashboardQueries(queryClient)
     },
   })

--- a/apps/frontend-admin/src/lib/unit-event-visitor-options.test.ts
+++ b/apps/frontend-admin/src/lib/unit-event-visitor-options.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import {
+  allowsGeneralEventVisitorOption,
+  buildUnitEventMetadataWithGeneralVisitorOption,
+} from './unit-event-visitor-options'
+
+describe('allowsGeneralEventVisitorOption', () => {
+  it('requires the event metadata flag to show the General event visitor option', () => {
+    expect(allowsGeneralEventVisitorOption(null)).toBe(false)
+    expect(allowsGeneralEventVisitorOption({})).toBe(false)
+    expect(allowsGeneralEventVisitorOption({ allowGeneralEventVisitorOption: false })).toBe(false)
+    expect(allowsGeneralEventVisitorOption({ allowGeneralEventVisitorOption: true })).toBe(true)
+  })
+})
+
+describe('buildUnitEventMetadataWithGeneralVisitorOption', () => {
+  it('stores the setting without removing unrelated metadata', () => {
+    expect(buildUnitEventMetadataWithGeneralVisitorOption({ dress: 'No. 3B' }, true)).toEqual({
+      dress: 'No. 3B',
+      allowGeneralEventVisitorOption: true,
+    })
+  })
+
+  it('removes the setting when disabled and returns null for empty metadata', () => {
+    expect(
+      buildUnitEventMetadataWithGeneralVisitorOption(
+        { allowGeneralEventVisitorOption: true },
+        false
+      )
+    ).toBeNull()
+  })
+})

--- a/apps/frontend-admin/src/lib/unit-event-visitor-options.ts
+++ b/apps/frontend-admin/src/lib/unit-event-visitor-options.ts
@@ -1,0 +1,24 @@
+const ALLOW_GENERAL_EVENT_VISITOR_OPTION_KEY = 'allowGeneralEventVisitorOption'
+
+export function allowsGeneralEventVisitorOption(metadata: unknown): boolean {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return false
+  }
+
+  return (metadata as Record<string, unknown>)[ALLOW_GENERAL_EVENT_VISITOR_OPTION_KEY] === true
+}
+
+export function buildUnitEventMetadataWithGeneralVisitorOption(
+  metadata: Record<string, unknown> | null,
+  allowGeneralEventVisitorOption: boolean
+): Record<string, unknown> | null {
+  const nextMetadata = { ...(metadata ?? {}) }
+
+  if (allowGeneralEventVisitorOption) {
+    nextMetadata[ALLOW_GENERAL_EVENT_VISITOR_OPTION_KEY] = true
+  } else {
+    delete nextMetadata[ALLOW_GENERAL_EVENT_VISITOR_OPTION_KEY]
+  }
+
+  return Object.keys(nextMetadata).length > 0 ? nextMetadata : null
+}

--- a/apps/frontend-admin/src/lib/visitor-event-availability-invalidation.ts
+++ b/apps/frontend-admin/src/lib/visitor-event-availability-invalidation.ts
@@ -3,7 +3,21 @@ import type { QueryClient } from '@tanstack/react-query'
 const kioskUnitEventsQueryKey = ['kiosk-unit-events'] as const
 const kioskUnitEventQueryKey = ['kiosk-unit-event'] as const
 
+export async function refreshVisitorEventAvailabilityQueries(
+  queryClient: QueryClient
+): Promise<void> {
+  await Promise.all([
+    queryClient.invalidateQueries({
+      queryKey: kioskUnitEventsQueryKey,
+      refetchType: 'all',
+    }),
+    queryClient.invalidateQueries({
+      queryKey: kioskUnitEventQueryKey,
+      refetchType: 'all',
+    }),
+  ])
+}
+
 export function invalidateVisitorEventAvailabilityQueries(queryClient: QueryClient): void {
-  void queryClient.invalidateQueries({ queryKey: kioskUnitEventsQueryKey })
-  void queryClient.invalidateQueries({ queryKey: kioskUnitEventQueryKey })
+  void refreshVisitorEventAvailabilityQueries(queryClient)
 }

--- a/apps/frontend-admin/src/lib/visitor-self-signin.test.ts
+++ b/apps/frontend-admin/src/lib/visitor-self-signin.test.ts
@@ -209,6 +209,34 @@ describe('buildReasonFirstVisitorGroupPayload', () => {
     expect(payload.unitEventVisitorOptionId).toBe('44444444-4444-4444-4444-444444444444')
     expect(payload.purposeDetails).toContain('Option: Gallery Attendee')
   })
+
+  it('supports military and civilian visitors in the same group', () => {
+    const payload = buildReasonFirstVisitorGroupPayload({
+      kioskId: 'DASHBOARD_KIOSK',
+      reason: 'event',
+      eventId: '22222222-2222-2222-2222-222222222222',
+      eventTitle: 'Standing Court Martial',
+      members: [
+        { branch: 'civilian', firstName: 'Alex', lastName: 'Taylor' },
+        {
+          branch: 'military',
+          rankPrefix: 'PO2',
+          initials: 'M.J.',
+          lastName: 'Sauk',
+          unit: 'HMCS Example',
+        },
+      ],
+    })
+
+    expect(payload.members.map((member) => member.visitType)).toEqual(['guest', 'military'])
+    expect(payload.members[1]).toMatchObject({
+      firstName: 'M.J.',
+      lastName: 'Sauk',
+      rankPrefix: 'PO2',
+      unit: 'HMCS Example',
+    })
+    expect(payload.visitReason).not.toContain('Category:')
+  })
 })
 
 describe('resolveVisitorSelfSigninSubmissionMode', () => {

--- a/apps/frontend-admin/src/lib/visitor-self-signin.ts
+++ b/apps/frontend-admin/src/lib/visitor-self-signin.ts
@@ -265,6 +265,7 @@ export interface BuildReasonFirstVisitorPayloadInput {
 }
 
 export interface ReasonFirstGroupMemberInput {
+  branch?: SelfServiceVisitorBranch
   firstName?: string
   lastName?: string
   initials?: string
@@ -420,16 +421,22 @@ export function buildReasonFirstVisitorGroupPayload(
     throw new Error('At least one visitor is required')
   }
 
-  const visitType = resolveVisitType(input.reason, input.branch)
   const visitPurpose = resolveVisitPurpose(input.reason)
 
-  if (reasonRequiresBranch(input.reason) && !input.branch) {
+  if (
+    reasonRequiresBranch(input.reason) &&
+    !input.branch &&
+    input.members.some((member) => !member.branch)
+  ) {
     throw new Error('Select Military or Civilian to continue')
   }
 
-  const isMilitaryIdentity = input.reason !== 'recruitment' && input.branch === 'military'
   const organization = trimValue(input.organization)
   const workDescription = trimValue(input.workDescription)
+  const memberBranches = input.members
+    .map((member) => member.branch ?? input.branch)
+    .filter((branch): branch is SelfServiceVisitorBranch => Boolean(branch))
+  const sharedSummaryBranch = new Set(memberBranches).size === 1 ? memberBranches[0] : undefined
   const purposeDetailsForEvent =
     reasonRequiresEventSelection(input.reason) && trimValue(input.eventTitle)
       ? trimValue(input.eventDateLabel)
@@ -447,7 +454,7 @@ export function buildReasonFirstVisitorGroupPayload(
 
   const sharedVisitReason = buildReasonFirstVisitSummary({
     reason: input.reason,
-    branch: input.branch,
+    branch: sharedSummaryBranch,
     organization: input.organization,
     workDescription: input.workDescription,
     eventTitle: input.eventTitle,
@@ -457,6 +464,9 @@ export function buildReasonFirstVisitorGroupPayload(
   })
 
   const members = input.members.map((member) => {
+    const memberBranch = member.branch ?? input.branch
+    const memberVisitType = resolveVisitType(input.reason, memberBranch)
+    const isMilitaryIdentity = input.reason !== 'recruitment' && memberBranch === 'military'
     const rankPrefix = trimValue(member.rankPrefix)
     const unit = trimValue(member.unit)
     const firstName = isMilitaryIdentity
@@ -479,7 +489,7 @@ export function buildReasonFirstVisitorGroupPayload(
       name: [rankPrefix, firstName, lastName].filter(Boolean).join(' '),
       rankPrefix,
       unit,
-      visitType,
+      visitType: memberVisitType,
     }
 
     if (input.reason === 'recruitment') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.3.18",
+  "version": "3.3.19",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.3.18",
+  "version": "3.3.19",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.3.18",
+  "version": "3.3.19",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.3.18",
+  "version": "3.3.19",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Refreshes kiosk event option availability after visitor sign-in and sign-out so remaining counts stay current without a browser refresh.
- Lets kiosk visitor groups include both Military and Civilian visitors, with the correct fields and visit type for each added person.
- Adds an event setting that controls whether the kiosk shows the no-option “General event visitor” choice alongside custom event options.
- Prepares Sentinel `v3.3.19` as the next patch release.

## Why this change was needed

Event visitor option counts could remain stale after checkout until the kiosk page was manually refreshed. Visitor group sign-in also treated added people as one shared visitor type, which made mixed Military/Civilian groups awkward. Events with custom options still showed “General event visitor” even when the event was meant to require one of the configured options.

## What changed

### User-facing

- Kiosk visitor sign-in now pulls updated event option availability after visitor changes.
- Kiosk group sign-in now lets each added visitor be Military or Civilian.
- Kiosk event option selection now hides “General event visitor” unless the event explicitly allows it.

### Admin/operator-facing

- Event setup now includes “Also allow General event visitor” under visitor options.
- Dashboard manual visitor sign-in follows the same event option rule as the kiosk.

### Backend/API

- No backend route changes.

### Database

- No database migration is required. The new event setting is stored in existing event metadata.

### Deployment/update

- Workspace package versions were bumped to `3.3.19`.

### Tests

- Added coverage for event metadata option handling.
- Added coverage for mixed Military/Civilian visitor group payloads.
- Updated visitor query invalidation coverage for active and inactive kiosk event availability queries.

## User impact

Visitors should see current event option availability after someone signs out, can add mixed visitor types in a group, and only see “General event visitor” when the event allows that fallback.

## Operator impact

Event organizers can decide whether custom event options are mandatory or whether a general visitor choice should still be available. No manual data repair is required.

## Upgrade or migration notes

No upgrade action required beyond installing the patch release. No database migration or configuration change is required.

## Risk and rollback notes

Main risk is event option selection behavior for events that previously relied on the implicit “General event visitor” choice. Existing events with custom options will now require a configured option unless the new event setting is enabled. Rollback is safe and does not require data migration.

## Testing performed

- `pnpm --filter frontend-admin exec vitest run src/hooks/use-visitors.test.ts src/lib/visitor-self-signin.test.ts src/lib/unit-event-visitor-options.test.ts`
- `pnpm --filter frontend-admin exec tsc --noEmit`
- `pnpm --filter frontend-admin lint`
- `pnpm version:check`
- `git diff --check`

## Changelog candidates

- Fixed stale kiosk event option availability after visitor sign-out. This keeps remaining event option counts current without requiring a browser refresh.
- Changed kiosk group sign-in so each added visitor can be Military or Civilian. This supports mixed visitor groups with the correct sign-in fields.
- Changed event option selection so “General event visitor” only appears when the event explicitly allows it. This lets events require visitors to select one of the configured options.
