### PR TITLE
Release v3.3.20

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.3.19",
+  "version": "3.3.20",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/routes/system-status.ts
+++ b/apps/backend/src/routes/system-status.ts
@@ -3,9 +3,12 @@ import type { SystemStatusResponse } from '@sentinel/contracts'
 import { systemStatusContract } from '@sentinel/contracts'
 import { getPrismaClient } from '../lib/database.js'
 import { SystemStatusService } from '../services/system-status-service.js'
+import { broadcastSystemRefreshRequired } from '../websocket/broadcast.js'
 
 const s = initServer()
 const systemStatusService = new SystemStatusService(getPrismaClient())
+const automatedHotspotRecoverySources = new Set(['host-hotspot-monitor', 'backend-scheduler'])
+const broadcastedRecoveredRequests = new Set<string>()
 
 function toKioskSafeSystemStatus(status: SystemStatusResponse): SystemStatusResponse {
   return {
@@ -30,6 +33,35 @@ function toKioskSafeSystemStatus(status: SystemStatusResponse): SystemStatusResp
   }
 }
 
+function maybeBroadcastRecoveredHotspot(status: SystemStatusResponse): void {
+  const recoveryStatus = status.network.hostHotspotRecovery
+  const requestId = recoveryStatus?.requestId
+  const source = recoveryStatus?.source
+
+  if (
+    !recoveryStatus ||
+    recoveryStatus.state !== 'completed' ||
+    status.network.issueCode !== 'none' ||
+    !source ||
+    !automatedHotspotRecoverySources.has(source)
+  ) {
+    return
+  }
+
+  const broadcastKey = requestId ?? `${source}:${recoveryStatus.updatedAt}`
+  if (broadcastedRecoveredRequests.has(broadcastKey)) {
+    return
+  }
+
+  broadcastedRecoveredRequests.add(broadcastKey)
+  broadcastSystemRefreshRequired({
+    reason: 'host_hotspot_recovered',
+    requestId: requestId ?? null,
+    message: 'Sentinel hotspot recovery completed. Refreshing connected pages.',
+    timestamp: new Date().toISOString(),
+  })
+}
+
 export const systemStatusRouter = s.router(systemStatusContract, {
   getSystemStatus: async ({ req }) => {
     if (!req.member && !req.apiKey) {
@@ -44,6 +76,7 @@ export const systemStatusRouter = s.router(systemStatusContract, {
 
     try {
       const status = await systemStatusService.getSystemStatus()
+      maybeBroadcastRecoveredHotspot(status)
 
       return {
         status: 200 as const,

--- a/apps/backend/src/services/host-hotspot-recovery-service.test.ts
+++ b/apps/backend/src/services/host-hotspot-recovery-service.test.ts
@@ -1,10 +1,11 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   DEFAULT_HOST_HOTSPOT_RECOVERY_REQUEST_DIR,
   DEFAULT_HOST_HOTSPOT_RECOVERY_STATUS_FILE,
+  DEFAULT_HOST_HOTSPOT_RECOVERY_HISTORY_FILE,
   HostHotspotRecoveryQueueError,
   HostHotspotRecoveryService,
 } from './host-hotspot-recovery-service.js'
@@ -16,6 +17,9 @@ describe('HostHotspotRecoveryService', () => {
     )
     expect(DEFAULT_HOST_HOTSPOT_RECOVERY_STATUS_FILE).toBe(
       '/opt/sentinel/deploy/runtime/hotspot-recovery/status.json'
+    )
+    expect(DEFAULT_HOST_HOTSPOT_RECOVERY_HISTORY_FILE).toBe(
+      '/opt/sentinel/deploy/runtime/hotspot-recovery/history.jsonl'
     )
   })
 
@@ -41,10 +45,35 @@ describe('HostHotspotRecoveryService', () => {
       state: 'queued',
       stage: 'request_queued',
       requestId: queued.requestId,
+      source: 'frontend-admin',
       message: 'Host hotspot repair request queued. Waiting for the host processor to start.',
+      estimatedDurationSeconds: 45,
     })
     expect(status?.updatedAt).toBeTruthy()
     expect(payload.source).toBe('frontend-admin')
+
+    await rm(rootDir, { recursive: true, force: true })
+  })
+
+  it('uses recent completed recovery history for duration estimates', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'sentinel-hotspot-recovery-'))
+    const requestDir = join(rootDir, 'requests')
+    const statusFile = join(rootDir, 'status.json')
+    const historyFile = join(rootDir, 'history.jsonl')
+    const service = new HostHotspotRecoveryService(requestDir, statusFile, historyFile)
+
+    await writeFile(
+      historyFile,
+      [
+        JSON.stringify({ state: 'completed', durationSeconds: 35 }),
+        JSON.stringify({ state: 'failed', durationSeconds: 90 }),
+        JSON.stringify({ state: 'completed', durationSeconds: 42 }),
+        JSON.stringify({ state: 'completed', durationSeconds: 55 }),
+      ].join('\n'),
+      'utf-8'
+    )
+
+    expect(await service.readEstimatedDurationSeconds()).toBe(42)
 
     await rm(rootDir, { recursive: true, force: true })
   })

--- a/apps/backend/src/services/host-hotspot-recovery-service.ts
+++ b/apps/backend/src/services/host-hotspot-recovery-service.ts
@@ -7,7 +7,10 @@ export const DEFAULT_HOST_HOTSPOT_RECOVERY_REQUEST_DIR =
   '/opt/sentinel/deploy/runtime/hotspot-recovery/requests'
 export const DEFAULT_HOST_HOTSPOT_RECOVERY_STATUS_FILE =
   '/opt/sentinel/deploy/runtime/hotspot-recovery/status.json'
+export const DEFAULT_HOST_HOTSPOT_RECOVERY_HISTORY_FILE =
+  '/opt/sentinel/deploy/runtime/hotspot-recovery/history.jsonl'
 const HOST_HOTSPOT_RECOVERY_STATUS_STALE_SECONDS = 600
+const DEFAULT_HOST_HOTSPOT_RECOVERY_ESTIMATE_SECONDS = 45
 
 export interface QueueHostHotspotRecoveryInput {
   requestedByMemberId: string
@@ -21,8 +24,9 @@ export interface QueueHostHotspotRecoveryInput {
 export class HostHotspotRecoveryService {
   private readonly requestDir: string
   private readonly statusFilePath: string
+  private readonly historyFilePath: string
 
-  constructor(requestDir?: string, statusFilePath?: string) {
+  constructor(requestDir?: string, statusFilePath?: string, historyFilePath?: string) {
     requestDir =
       requestDir ??
       process.env.HOST_HOTSPOT_RECOVERY_REQUEST_DIR ??
@@ -32,6 +36,10 @@ export class HostHotspotRecoveryService {
       statusFilePath ??
       process.env.HOST_HOTSPOT_RECOVERY_STATUS_FILE ??
       resolveDefaultStatusFilePath(requestDir)
+    this.historyFilePath =
+      historyFilePath ??
+      process.env.HOST_HOTSPOT_RECOVERY_HISTORY_FILE ??
+      resolveDefaultHistoryFilePath(requestDir)
   }
 
   async queueRecoveryRequest(input: QueueHostHotspotRecoveryInput): Promise<{
@@ -64,6 +72,7 @@ export class HostHotspotRecoveryService {
       message: 'Host hotspot repair request queued. Waiting for the host processor to start.',
       requestId,
       requestedAt: payload.requestedAt,
+      source: payload.source,
     })
 
     return {
@@ -80,9 +89,32 @@ export class HostHotspotRecoveryService {
         return null
       }
 
-      return status
+      return {
+        ...status,
+        estimatedDurationSeconds: await this.readEstimatedDurationSeconds(),
+      }
     } catch {
       return null
+    }
+  }
+
+  async readEstimatedDurationSeconds(): Promise<number> {
+    try {
+      const raw = await readFile(this.historyFilePath, 'utf-8')
+      const durations = raw
+        .split('\n')
+        .map((line) => parseRecoveryHistoryDuration(line))
+        .filter((duration): duration is number => duration !== null)
+        .slice(-10)
+
+      if (durations.length === 0) {
+        return DEFAULT_HOST_HOTSPOT_RECOVERY_ESTIMATE_SECONDS
+      }
+
+      const sorted = [...durations].sort((a, b) => a - b)
+      return sorted[Math.floor(sorted.length / 2)] ?? DEFAULT_HOST_HOTSPOT_RECOVERY_ESTIMATE_SECONDS
+    } catch {
+      return DEFAULT_HOST_HOTSPOT_RECOVERY_ESTIMATE_SECONDS
     }
   }
 
@@ -92,12 +124,14 @@ export class HostHotspotRecoveryService {
     message: string
     requestId: string
     requestedAt: string
+    source: string
   }): Promise<void> {
     const status: HostHotspotRecoveryStatus = {
       state: input.state,
       stage: input.stage,
       message: input.message,
       requestId: input.requestId,
+      source: input.source,
       connectionName: null,
       hotspotSsid: null,
       hotspotDevice: null,
@@ -107,6 +141,8 @@ export class HostHotspotRecoveryService {
       startedAt: input.requestedAt,
       updatedAt: new Date().toISOString(),
       completedAt: null,
+      durationSeconds: null,
+      estimatedDurationSeconds: await this.readEstimatedDurationSeconds(),
     }
 
     try {
@@ -150,6 +186,12 @@ function resolveDefaultStatusFilePath(requestDir: string): string {
     : join(requestDir, 'status.json')
 }
 
+function resolveDefaultHistoryFilePath(requestDir: string): string {
+  return basename(requestDir) === 'requests'
+    ? join(dirname(requestDir), 'history.jsonl')
+    : join(requestDir, 'history.jsonl')
+}
+
 function parseHostHotspotRecoveryStatus(payload: unknown): HostHotspotRecoveryStatus | null {
   if (!isRecord(payload)) {
     return null
@@ -169,6 +211,7 @@ function parseHostHotspotRecoveryStatus(payload: unknown): HostHotspotRecoverySt
     stage,
     message,
     requestId: normalizeNullableString(payload.requestId),
+    source: normalizeNullableString(payload.source),
     connectionName: normalizeNullableString(payload.connectionName),
     hotspotSsid: normalizeNullableString(payload.hotspotSsid),
     hotspotDevice: normalizeNullableString(payload.hotspotDevice),
@@ -178,6 +221,26 @@ function parseHostHotspotRecoveryStatus(payload: unknown): HostHotspotRecoverySt
     startedAt: normalizeTimestampString(payload.startedAt),
     updatedAt,
     completedAt: normalizeTimestampString(payload.completedAt),
+    durationSeconds: normalizeNullableNumber(payload.durationSeconds),
+    estimatedDurationSeconds: normalizeNullableNumber(payload.estimatedDurationSeconds),
+  }
+}
+
+function parseRecoveryHistoryDuration(line: string): number | null {
+  if (line.trim().length === 0) {
+    return null
+  }
+
+  try {
+    const payload = JSON.parse(line) as unknown
+    if (!isRecord(payload) || payload.state !== 'completed') {
+      return null
+    }
+
+    const duration = normalizeNullableNumber(payload.durationSeconds)
+    return duration !== null && duration > 0 && duration <= 300 ? Math.round(duration) : null
+  } catch {
+    return null
   }
 }
 
@@ -219,6 +282,19 @@ function normalizeNullableBoolean(value: unknown): boolean | null {
 
 function normalizeNullableString(value: unknown): string | null {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
+function normalizeNullableNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return null
+  }
+
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
 }
 
 function normalizeTimestampString(value: unknown): string | null {

--- a/apps/backend/src/websocket/broadcast.ts
+++ b/apps/backend/src/websocket/broadcast.ts
@@ -31,6 +31,28 @@ export function broadcastLogEntry(entry: LogEntry) {
 }
 
 /**
+ * Tell connected clients to refresh after host-side recovery changes.
+ */
+export function broadcastSystemRefreshRequired(payload: {
+  reason: 'host_hotspot_recovered'
+  requestId: string | null
+  message: string
+  timestamp: string
+}) {
+  if (!io) {
+    logger.warn('Cannot broadcast system refresh request: Socket.IO not initialized')
+    return
+  }
+
+  io.emit('system:refresh-required', payload)
+
+  logger.info('Broadcasted system refresh request', {
+    reason: payload.reason,
+    requestId: payload.requestId,
+  })
+}
+
+/**
  * Broadcast presence statistics update
  */
 export function broadcastPresenceUpdate(stats: {

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.3.19",
+  "version": "3.3.20",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/app/layout.tsx
+++ b/apps/frontend-admin/src/app/layout.tsx
@@ -10,6 +10,7 @@ import { queryClient } from '@/lib/query-client'
 import { AppNavbar } from '@/components/layout/app-navbar'
 import { AppSidebar } from '@/components/layout/app-sidebar'
 import { AuthHydrator } from '@/components/auth/auth-hydrator'
+import { AutomatedHotspotRecoveryNotice } from '@/components/network/automated-hotspot-recovery-notice'
 import './globals.css'
 
 const DRAWER_ID = 'app-drawer'
@@ -56,6 +57,7 @@ export default function RootLayout({
               </div>
             </div>
           )}
+          {!isBareRoute && <AutomatedHotspotRecoveryNotice />}
           <Toaster
             position="top-right"
             expand={false}

--- a/apps/frontend-admin/src/components/network/automated-hotspot-recovery-notice.logic.test.ts
+++ b/apps/frontend-admin/src/components/network/automated-hotspot-recovery-notice.logic.test.ts
@@ -1,0 +1,129 @@
+import type { HostHotspotRecoveryStatus, SystemStatusResponse } from '@sentinel/contracts'
+import { describe, expect, it } from 'vitest'
+import {
+  formatRecoveryTime,
+  getRecoveryElapsedSeconds,
+  getRecoveryEstimateSeconds,
+  getRecoveryProgressPercent,
+  getRecoveryRemainingSeconds,
+  isAutomatedHotspotRecoveryActive,
+  isAutomatedHotspotRecoveryComplete,
+} from './automated-hotspot-recovery-notice.logic'
+
+function createRecoveryStatus(
+  overrides?: Partial<HostHotspotRecoveryStatus>
+): HostHotspotRecoveryStatus {
+  return {
+    state: 'running',
+    stage: 'resetting_usb',
+    message: 'Automated repair is running.',
+    requestId: 'request-1',
+    source: 'host-hotspot-monitor',
+    connectionName: null,
+    hotspotSsid: 'Stone Frigate',
+    hotspotDevice: 'wlan-ap',
+    scanDevice: 'wlan-scan',
+    usbDevice: '1-4',
+    hardwareResetApplied: false,
+    startedAt: '2026-05-22T12:00:00.000Z',
+    updatedAt: '2026-05-22T12:00:10.000Z',
+    completedAt: null,
+    durationSeconds: null,
+    estimatedDurationSeconds: 40,
+    ...overrides,
+  }
+}
+
+function createSystemStatus(
+  recoveryStatus: HostHotspotRecoveryStatus | null,
+  issueCode: SystemStatusResponse['network']['issueCode'] = 'hotspot_not_visible'
+): SystemStatusResponse {
+  return {
+    overall: { status: issueCode === 'none' ? 'healthy' : 'warning', label: 'Network attention' },
+    backend: {
+      status: 'healthy',
+      environment: 'test',
+      version: 'v0.0.0',
+      uptimeSeconds: 10,
+      serviceTimestamp: '2026-05-22T12:00:00.000Z',
+    },
+    database: { healthy: true, address: 'postgres' },
+    network: {
+      status: issueCode === 'none' ? 'healthy' : 'warning',
+      telemetryAvailable: true,
+      telemetryAgeSeconds: 1,
+      message: 'Network status',
+      issueCode,
+      wifiConnected: true,
+      currentSsid: 'GC Public',
+      hostIpAddress: '10.42.0.1',
+      hotspotProfilePresent: true,
+      hotspotAdapterApproved: true,
+      scanAdapterPresent: true,
+      hotspotDevice: 'wlan-ap',
+      hotspotSsid: 'Stone Frigate',
+      hotspotScanDevice: 'wlan-scan',
+      hotspotSsidVisibleFromLaptop: issueCode === 'none',
+      hotspotAdapterBusy: false,
+      internetWifiConnection: null,
+      internetWifiSsid: null,
+      approvedSsids: ['GC Public'],
+      approvedSsid: true,
+      internetReachable: true,
+      remoteTarget: null,
+      remoteReachable: null,
+      portalRecoveryLikely: null,
+      hostHotspotRecovery: recoveryStatus,
+      generatedAt: '2026-05-22T12:00:10.000Z',
+    },
+    remoteSystems: {
+      status: 'healthy',
+      activeCount: 0,
+      staleThresholdSeconds: 90,
+      overflowCount: 0,
+      sessions: [],
+    },
+    lastCheckedAt: '2026-05-22T12:00:10.000Z',
+  }
+}
+
+describe('automated hotspot recovery notice logic', () => {
+  it('identifies active automated hotspot recovery', () => {
+    expect(isAutomatedHotspotRecoveryActive(createSystemStatus(createRecoveryStatus()))).toBe(true)
+    expect(
+      isAutomatedHotspotRecoveryActive(
+        createSystemStatus(createRecoveryStatus({ source: 'frontend-admin' }))
+      )
+    ).toBe(false)
+  })
+
+  it('identifies completed automated recovery once network status is healthy', () => {
+    expect(
+      isAutomatedHotspotRecoveryComplete(
+        createSystemStatus(
+          createRecoveryStatus({
+            state: 'completed',
+            stage: 'completed',
+            completedAt: '2026-05-22T12:00:35.000Z',
+          }),
+          'none'
+        )
+      )
+    ).toBe(true)
+  })
+
+  it('uses historical estimates and elapsed time for remaining time', () => {
+    const recoveryStatus = createRecoveryStatus({ estimatedDurationSeconds: 40 })
+    const nowMs = new Date('2026-05-22T12:00:15.000Z').getTime()
+
+    expect(getRecoveryEstimateSeconds(recoveryStatus)).toBe(40)
+    expect(getRecoveryElapsedSeconds(recoveryStatus, nowMs)).toBe(15)
+    expect(getRecoveryRemainingSeconds(recoveryStatus, nowMs)).toBe(25)
+    expect(getRecoveryProgressPercent(recoveryStatus, nowMs)).toBe(38)
+  })
+
+  it('formats short and minute-level durations', () => {
+    expect(formatRecoveryTime(42)).toBe('42s')
+    expect(formatRecoveryTime(75)).toBe('1m 15s')
+  })
+})

--- a/apps/frontend-admin/src/components/network/automated-hotspot-recovery-notice.logic.ts
+++ b/apps/frontend-admin/src/components/network/automated-hotspot-recovery-notice.logic.ts
@@ -1,0 +1,109 @@
+import type { HostHotspotRecoveryStatus, SystemStatusResponse } from '@sentinel/contracts'
+
+const AUTOMATED_RECOVERY_SOURCES = new Set(['host-hotspot-monitor', 'backend-scheduler'])
+const DEFAULT_ESTIMATED_RECOVERY_SECONDS = 45
+
+export function isAutomatedHotspotRecovery(
+  recoveryStatus: HostHotspotRecoveryStatus | null | undefined
+): boolean {
+  const source = recoveryStatus?.source
+  return typeof source === 'string' && AUTOMATED_RECOVERY_SOURCES.has(source)
+}
+
+export function isAutomatedHotspotRecoveryActive(
+  systemStatus: SystemStatusResponse | null | undefined
+): boolean {
+  const recoveryStatus = systemStatus?.network.hostHotspotRecovery
+  return (
+    isAutomatedHotspotRecovery(recoveryStatus) &&
+    (recoveryStatus?.state === 'queued' || recoveryStatus?.state === 'running')
+  )
+}
+
+export function isAutomatedHotspotRecoveryComplete(
+  systemStatus: SystemStatusResponse | null | undefined
+): boolean {
+  const recoveryStatus = systemStatus?.network.hostHotspotRecovery
+  return (
+    isAutomatedHotspotRecovery(recoveryStatus) &&
+    recoveryStatus?.state === 'completed' &&
+    systemStatus?.network.issueCode === 'none'
+  )
+}
+
+export function getRecoveryEstimateSeconds(
+  recoveryStatus: HostHotspotRecoveryStatus | null | undefined
+): number {
+  const estimate = recoveryStatus?.estimatedDurationSeconds
+  return typeof estimate === 'number' && Number.isFinite(estimate) && estimate > 0
+    ? Math.round(estimate)
+    : DEFAULT_ESTIMATED_RECOVERY_SECONDS
+}
+
+export function getRecoveryElapsedSeconds(
+  recoveryStatus: HostHotspotRecoveryStatus | null | undefined,
+  nowMs = Date.now()
+): number {
+  const startedAt = recoveryStatus?.startedAt
+  if (!startedAt) {
+    return 0
+  }
+
+  const startedAtMs = new Date(startedAt).getTime()
+  if (Number.isNaN(startedAtMs)) {
+    return 0
+  }
+
+  return Math.max(0, Math.round((nowMs - startedAtMs) / 1_000))
+}
+
+export function getRecoveryRemainingSeconds(
+  recoveryStatus: HostHotspotRecoveryStatus | null | undefined,
+  nowMs = Date.now()
+): number {
+  return Math.max(
+    0,
+    getRecoveryEstimateSeconds(recoveryStatus) - getRecoveryElapsedSeconds(recoveryStatus, nowMs)
+  )
+}
+
+export function getRecoveryProgressPercent(
+  recoveryStatus: HostHotspotRecoveryStatus | null | undefined,
+  nowMs = Date.now()
+): number {
+  if (recoveryStatus?.state === 'completed') {
+    return 100
+  }
+
+  if (recoveryStatus?.state === 'failed') {
+    return 100
+  }
+
+  const estimate = getRecoveryEstimateSeconds(recoveryStatus)
+  const elapsed = getRecoveryElapsedSeconds(recoveryStatus, nowMs)
+  const calculated = Math.round((elapsed / estimate) * 100)
+  return Math.min(95, Math.max(10, calculated))
+}
+
+export function formatRecoveryTime(seconds: number): string {
+  const normalized = Math.max(0, Math.round(seconds))
+  if (normalized < 60) {
+    return `${normalized}s`
+  }
+
+  const minutes = Math.floor(normalized / 60)
+  const remainder = normalized % 60
+  return remainder === 0 ? `${minutes}m` : `${minutes}m ${remainder}s`
+}
+
+export function getRecoveryRequestKey(
+  recoveryStatus: HostHotspotRecoveryStatus | null | undefined
+): string | null {
+  if (!recoveryStatus) {
+    return null
+  }
+
+  return (
+    recoveryStatus.requestId ?? `${recoveryStatus.source ?? 'unknown'}:${recoveryStatus.updatedAt}`
+  )
+}

--- a/apps/frontend-admin/src/components/network/automated-hotspot-recovery-notice.tsx
+++ b/apps/frontend-admin/src/components/network/automated-hotspot-recovery-notice.tsx
@@ -1,0 +1,310 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import type { HostHotspotRecoveryStatus } from '@sentinel/contracts'
+import { CheckCircle2, Clock3, RotateCcw, WifiOff } from 'lucide-react'
+import { AppBadge } from '@/components/ui/AppBadge'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { LoadingSpinner } from '@/components/ui/loading-spinner'
+import { useSystemStatus } from '@/hooks/use-system-status'
+import { websocketManager } from '@/lib/websocket'
+import { cn } from '@/lib/utils'
+import { useAuthStore } from '@/store/auth-store'
+import {
+  formatRecoveryTime,
+  getRecoveryEstimateSeconds,
+  getRecoveryProgressPercent,
+  getRecoveryRemainingSeconds,
+  getRecoveryRequestKey,
+  isAutomatedHotspotRecoveryActive,
+  isAutomatedHotspotRecoveryComplete,
+} from './automated-hotspot-recovery-notice.logic'
+
+const REFRESH_EVENT_DELAY_MS = 2_000
+const REFRESH_STORAGE_PREFIX = 'sentinel-hotspot-refresh:'
+
+type SystemRefreshPayload = {
+  reason: 'host_hotspot_recovered'
+  requestId: string | null
+  message: string
+  timestamp: string
+}
+
+function isSystemRefreshPayload(value: unknown): value is SystemRefreshPayload {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const payload = value as Record<string, unknown>
+  return (
+    payload.reason === 'host_hotspot_recovered' &&
+    (typeof payload.requestId === 'string' || payload.requestId === null) &&
+    typeof payload.message === 'string' &&
+    typeof payload.timestamp === 'string'
+  )
+}
+
+function hasRefreshRun(key: string): boolean {
+  if (typeof window === 'undefined') {
+    return false
+  }
+
+  try {
+    return window.sessionStorage.getItem(`${REFRESH_STORAGE_PREFIX}${key}`) === 'done'
+  } catch {
+    return false
+  }
+}
+
+function markRefreshRun(key: string): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    window.sessionStorage.setItem(`${REFRESH_STORAGE_PREFIX}${key}`, 'done')
+  } catch {
+    // Best effort only. Reload protection is nice to have, not required for recovery.
+  }
+}
+
+export function AutomatedHotspotRecoveryNotice() {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
+  const queryClient = useQueryClient()
+  const [nowMs, setNowMs] = useState(() => Date.now())
+  const [refreshPayload, setRefreshPayload] = useState<SystemRefreshPayload | null>(null)
+  const systemStatusQuery = useSystemStatus({
+    enabled: isAuthenticated,
+    refetchIntervalMs: refreshPayload ? 1_000 : 5_000,
+  })
+  const systemStatus = systemStatusQuery.data ?? null
+  const recoveryStatus = systemStatus?.network.hostHotspotRecovery ?? null
+  const active = isAutomatedHotspotRecoveryActive(systemStatus)
+  const complete = isAutomatedHotspotRecoveryComplete(systemStatus)
+  const requestKey = getRecoveryRequestKey(recoveryStatus)
+  const showRecovered =
+    refreshPayload !== null || (complete && requestKey !== null && !hasRefreshRun(requestKey))
+  const open = active || showRecovered
+  const estimateSeconds = getRecoveryEstimateSeconds(recoveryStatus)
+  const remainingSeconds = getRecoveryRemainingSeconds(recoveryStatus, nowMs)
+  const progressPercent =
+    refreshPayload || complete ? 100 : getRecoveryProgressPercent(recoveryStatus, nowMs)
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      return undefined
+    }
+
+    websocketManager.connect()
+
+    const handleRefreshRequired = (payload: unknown) => {
+      if (!isSystemRefreshPayload(payload)) {
+        return
+      }
+
+      const refreshKey = payload.requestId ?? payload.timestamp
+      if (hasRefreshRun(refreshKey)) {
+        void queryClient.invalidateQueries({ queryKey: ['system-status'] })
+        return
+      }
+
+      setRefreshPayload(payload)
+      void queryClient.invalidateQueries({ queryKey: ['system-status'] })
+    }
+
+    websocketManager.on('system:refresh-required', handleRefreshRequired)
+
+    return () => {
+      if (websocketManager.hasSocket) {
+        websocketManager.off('system:refresh-required', handleRefreshRequired)
+      }
+    }
+  }, [isAuthenticated, queryClient])
+
+  useEffect(() => {
+    if (!active) {
+      return undefined
+    }
+
+    const intervalId = window.setInterval(() => {
+      setNowMs(Date.now())
+    }, 1_000)
+
+    return () => window.clearInterval(intervalId)
+  }, [active])
+
+  useEffect(() => {
+    if (!complete || !requestKey) {
+      return undefined
+    }
+
+    if (hasRefreshRun(requestKey)) {
+      return undefined
+    }
+
+    markRefreshRun(requestKey)
+    void queryClient.invalidateQueries({ queryKey: ['system-status'] })
+
+    const timeoutId = window.setTimeout(() => {
+      window.location.reload()
+    }, REFRESH_EVENT_DELAY_MS)
+
+    return () => window.clearTimeout(timeoutId)
+  }, [complete, queryClient, recoveryStatus?.requestId, requestKey])
+
+  useEffect(() => {
+    if (!refreshPayload) {
+      return undefined
+    }
+
+    const refreshKey = refreshPayload.requestId ?? refreshPayload.timestamp
+    if (hasRefreshRun(refreshKey)) {
+      return undefined
+    }
+
+    markRefreshRun(refreshKey)
+    const timeoutId = window.setTimeout(() => {
+      window.location.reload()
+    }, REFRESH_EVENT_DELAY_MS)
+
+    return () => window.clearTimeout(timeoutId)
+  }, [refreshPayload])
+
+  if (!isAuthenticated) {
+    return null
+  }
+
+  return (
+    <Dialog open={open} dismissible={false}>
+      <DialogContent
+        size="md"
+        showCloseButton={false}
+        className={cn(
+          'border-l-4 p-(--space-5) shadow-[var(--shadow-3)]',
+          showRecovered ? 'border-success' : 'border-warning'
+        )}
+      >
+        <DialogHeader className="mb-(--space-4)">
+          <DialogTitle className="flex items-center gap-(--space-2)">
+            {showRecovered ? (
+              <CheckCircle2 aria-hidden="true" className="h-5 w-5 text-success" />
+            ) : (
+              <WifiOff aria-hidden="true" className="h-5 w-5 text-warning" />
+            )}
+            {showRecovered ? 'Hotspot connection restored' : 'Repairing hotspot connection'}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-(--space-4)" role="status" aria-live="polite">
+          <div
+            className={cn(
+              'rounded-box border p-(--space-4)',
+              showRecovered
+                ? 'border-success/40 bg-success-fadded text-success-fadded-content'
+                : 'border-warning/45 bg-warning-fadded text-warning-fadded-content'
+            )}
+          >
+            <div className="flex items-start gap-(--space-3)">
+              <span className="grid h-10 w-10 shrink-0 place-items-center rounded-box bg-base-100/80 shadow-[var(--shadow-1)]">
+                {showRecovered ? (
+                  <CheckCircle2 aria-hidden="true" className="h-5 w-5" />
+                ) : (
+                  <LoadingSpinner size="sm" />
+                )}
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-(--space-2)">
+                  <p className="font-bold">
+                    {showRecovered
+                      ? 'Sentinel is back online.'
+                      : formatStageLabel(recoveryStatus?.stage)}
+                  </p>
+                  <AppBadge
+                    status={showRecovered ? 'success' : 'warning'}
+                    size="sm"
+                    pulse={!showRecovered}
+                  >
+                    {showRecovered ? 'Restored' : 'Automatic'}
+                  </AppBadge>
+                </div>
+                <p className="mt-(--space-1) text-sm leading-relaxed">
+                  {showRecovered
+                    ? 'Connected Sentinel pages are refreshing so everyone sees the restored state.'
+                    : 'The host is repairing the USB Wi-Fi AP dongle. The hotspot may disappear briefly while it resets.'}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-box border border-base-300 bg-base-200 p-(--space-4)">
+            <div className="flex flex-wrap items-center justify-between gap-(--space-3)">
+              <div className="flex items-center gap-(--space-2)">
+                <Clock3 aria-hidden="true" className="h-4 w-4 text-base-content/60" />
+                <span className="text-sm font-semibold">
+                  {showRecovered
+                    ? 'Refreshing this page now'
+                    : `${formatRecoveryTime(remainingSeconds)} remaining`}
+                </span>
+              </div>
+              <span className="font-mono text-xs text-base-content/65">
+                Historical average: {formatRecoveryTime(estimateSeconds)}
+              </span>
+            </div>
+            <progress
+              className={cn(
+                'progress mt-(--space-3) h-2 w-full',
+                showRecovered ? 'progress-success' : 'progress-warning'
+              )}
+              value={progressPercent}
+              max={100}
+              aria-label="Automated hotspot recovery progress"
+            />
+            <p className="mt-(--space-2) text-xs leading-relaxed text-base-content/70">
+              {recoveryStatus?.message ??
+                refreshPayload?.message ??
+                'Waiting for host recovery status.'}
+            </p>
+          </div>
+
+          {!showRecovered && (
+            <div className="flex items-start gap-(--space-2) text-sm text-base-content/70">
+              <RotateCcw aria-hidden="true" className="mt-0.5 h-4 w-4 shrink-0" />
+              <p>
+                Leave this page open. Remote pages will be told to refresh automatically once
+                Sentinel confirms the hotspot is visible again.
+              </p>
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function formatStageLabel(stage: HostHotspotRecoveryStatus['stage'] | undefined): string {
+  switch (stage) {
+    case 'request_queued':
+      return 'Recovery is queued'
+    case 'processing_request':
+      return 'Starting recovery'
+    case 'moving_internet_wifi':
+      return 'Moving internet Wi-Fi'
+    case 'ensuring_profile':
+      return 'Checking hotspot profile'
+    case 'stopping_hotspot':
+      return 'Stopping hotspot'
+    case 'resetting_driver':
+      return 'Resetting Wi-Fi driver'
+    case 'resetting_usb':
+      return 'Resetting USB dongle'
+    case 'waiting_for_adapter':
+      return 'Waiting for adapter'
+    case 'starting_hotspot':
+      return 'Starting hotspot'
+    case 'verifying_visibility':
+      return 'Checking hotspot visibility'
+    default:
+      return 'Automated recovery is running'
+  }
+}

--- a/apps/frontend-admin/src/components/schedules/duty-watch-card.tsx
+++ b/apps/frontend-admin/src/components/schedules/duty-watch-card.tsx
@@ -19,6 +19,7 @@ import {
 import { AppBadge } from '@/components/ui/AppBadge'
 import { Chip } from '@/components/ui/chip'
 import { formatDutyWatchOccurrenceLabel, getWeekDutyWatchOccurrences } from '@/lib/duty-watch'
+import { isDutyWatchPublishDisabled } from './duty-watch-publish-state'
 
 import {
   AlertDialog,
@@ -510,7 +511,7 @@ export function DutyWatchCard({
               )}
               {missingRequired > 0 && (
                 <AppBadge status="error" className="whitespace-nowrap">
-                  {missingRequired} Required
+                  {missingRequired} Missing
                 </AppBadge>
               )}
             </div>
@@ -579,7 +580,10 @@ export function DutyWatchCard({
             <button
               className="btn btn-primary btn-md"
               onClick={handlePublish}
-              disabled={publishSchedule.isPending || missingRequired > 0}
+              disabled={isDutyWatchPublishDisabled({
+                isPublishPending: publishSchedule.isPending,
+                missingRequiredSlots: missingRequired,
+              })}
             >
               {publishSchedule.isPending ? <ButtonSpinner /> : <Check className="h-4 w-4 mr-2" />}
               Publish Schedule

--- a/apps/frontend-admin/src/components/schedules/duty-watch-publish-state.test.ts
+++ b/apps/frontend-admin/src/components/schedules/duty-watch-publish-state.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { isDutyWatchPublishDisabled } from './duty-watch-publish-state'
+
+describe('isDutyWatchPublishDisabled', () => {
+  it('allows a draft Duty Watch schedule to publish with missing required slots', () => {
+    expect(
+      isDutyWatchPublishDisabled({
+        isPublishPending: false,
+        missingRequiredSlots: 2,
+      })
+    ).toBe(false)
+  })
+
+  it('keeps publish disabled while the publish request is pending', () => {
+    expect(
+      isDutyWatchPublishDisabled({
+        isPublishPending: true,
+        missingRequiredSlots: 0,
+      })
+    ).toBe(true)
+  })
+})

--- a/apps/frontend-admin/src/components/schedules/duty-watch-publish-state.ts
+++ b/apps/frontend-admin/src/components/schedules/duty-watch-publish-state.ts
@@ -1,0 +1,10 @@
+export interface DutyWatchPublishStateInput {
+  isPublishPending: boolean
+  missingRequiredSlots: number
+}
+
+export function isDutyWatchPublishDisabled({
+  isPublishPending,
+}: DutyWatchPublishStateInput): boolean {
+  return isPublishPending
+}

--- a/deploy/README_DEPLOY.md
+++ b/deploy/README_DEPLOY.md
@@ -174,6 +174,7 @@ Install/update now provisions hotspot and update helpers:
 - hotspot recovery also detects when NetworkManager has connected the approved AP dongle to internet Wi-Fi, moves that saved Wi-Fi profile to the scan radio, then reserves the AP dongle for broadcasting the Sentinel hotspot
 - a local `sentinel-hotspot://connect?ssid=<approved-ssid>` URL handler that tries to reconnect the current laptop to an approved internet Wi-Fi SSID, then falls back to Wi-Fi settings
 - a host-side recovery queue watched by systemd so the webapp can ask the deployment server to repair the hosted hotspot without interactive root access
+- a host-side hotspot monitor runs on a systemd timer and automatically queues recovery when the approved AP dongle disappears, gets used by internet Wi-Fi, or the Sentinel SSID is no longer visible
 - a managed sudoers entry for the desktop operator account so hotspot recovery commands can be run non-interactively (no password prompt) when needed
 - a packaged updater bridge/socket pair so the webapp and local CLI wrappers both use the same canonical update engine
 
@@ -181,6 +182,7 @@ Relevant runtime paths:
 
 - local reconnect handler: `/opt/sentinel/deploy/sentinel-hotspot-connect.sh`
 - canonical hotspot helper: `/opt/sentinel/deploy/ensure-host-hotspot-profile.sh`
+- hotspot monitor status: `/opt/sentinel/deploy/runtime/hotspot-recovery/monitor.json`
 - queued recovery requests: `/opt/sentinel/deploy/runtime/hotspot-recovery/requests`
 - processed requests: `/opt/sentinel/deploy/runtime/hotspot-recovery/processed`
 - failed requests: `/opt/sentinel/deploy/runtime/hotspot-recovery/failed`
@@ -193,6 +195,8 @@ Relevant systemd units:
 
 - `sentinel-host-hotspot-recovery.path`
 - `sentinel-host-hotspot-recovery.service`
+- `sentinel-host-hotspot-monitor.timer`
+- `sentinel-host-hotspot-monitor.service`
 - `sentinel-update-bridge.socket`
 - `sentinel-update-bridge.service`
 - `sentinel-updater.service`

--- a/deploy/_common.sh
+++ b/deploy/_common.sh
@@ -1587,6 +1587,7 @@ DESKTOP
     "${DEPLOY_DIR}/runtime/hotspot-recovery/failed"
   run_root chmod 755 \
     "${DEPLOY_DIR}/ensure-host-hotspot-profile.sh" \
+    "${DEPLOY_DIR}/monitor-host-hotspot.sh" \
     "${DEPLOY_DIR}/recover-host-hotspot.sh" \
     "${DEPLOY_DIR}/process-host-hotspot-recovery-requests.sh" \
     "${DEPLOY_DIR}/sentinel-hotspot-connect.sh" >/dev/null 2>&1 || true
@@ -1622,11 +1623,44 @@ Unit=sentinel-host-hotspot-recovery.service
 WantedBy=multi-user.target
 UNIT
 
+  local monitor_interval_seconds
+  monitor_interval_seconds="$(env_value HOST_HOTSPOT_MONITOR_INTERVAL_SECONDS 60)"
+  if [[ ! "${monitor_interval_seconds}" =~ ^[0-9]+$ ]] || (( monitor_interval_seconds < 30 )); then
+    monitor_interval_seconds="60"
+  fi
+
+  run_root tee /etc/systemd/system/sentinel-host-hotspot-monitor.service >/dev/null <<UNIT
+[Unit]
+Description=Sentinel host hotspot monitor
+After=network-online.target sentinel-host-hotspot-recovery.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=${DEPLOY_DIR}
+ExecStart=${DEPLOY_DIR}/monitor-host-hotspot.sh
+UNIT
+
+  run_root tee /etc/systemd/system/sentinel-host-hotspot-monitor.timer >/dev/null <<UNIT
+[Unit]
+Description=Sentinel host hotspot monitor timer
+
+[Timer]
+OnBootSec=90s
+OnUnitActiveSec=${monitor_interval_seconds}s
+AccuracySec=10s
+Unit=sentinel-host-hotspot-monitor.service
+
+[Install]
+WantedBy=timers.target
+UNIT
+
   run_root systemctl daemon-reload
   run_root systemctl enable --now sentinel-host-hotspot-recovery.path
+  run_root systemctl enable --now sentinel-host-hotspot-monitor.timer
   run_root systemctl start sentinel-host-hotspot-recovery.service
 
-  log "Host hotspot recovery watcher enabled."
+  log "Host hotspot recovery watcher and monitor enabled."
 }
 
 run_host_hotspot_recovery_nonblocking() {

--- a/deploy/monitor-host-hotspot.sh
+++ b/deploy/monitor-host-hotspot.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/ensure-host-hotspot-profile.sh"
+
+REQUEST_DIR="${HOST_HOTSPOT_RECOVERY_REQUEST_DIR:-${SCRIPT_DIR}/runtime/hotspot-recovery/requests}"
+STATE_FILE="${HOST_HOTSPOT_MONITOR_STATE_FILE:-${SCRIPT_DIR}/runtime/hotspot-recovery/monitor.json}"
+RECOVERY_STATUS_FILE="${HOST_HOTSPOT_RECOVERY_STATUS_FILE:-${SCRIPT_DIR}/runtime/hotspot-recovery/status.json}"
+LOCK_FILE="${HOST_HOTSPOT_MONITOR_LOCK_FILE:-/run/lock/sentinel-host-hotspot-monitor.lock}"
+COOLDOWN_SECONDS="${HOST_HOTSPOT_MONITOR_COOLDOWN_SECONDS:-$(env_value HOST_HOTSPOT_MONITOR_COOLDOWN_SECONDS 600)}"
+DRY_RUN="$(normalize_boolean_env "${HOST_HOTSPOT_MONITOR_DRY_RUN:-false}")"
+START_SERVICE="$(normalize_boolean_env "${HOST_HOTSPOT_MONITOR_START_SERVICE:-true}")"
+
+monitor_log() {
+  printf '[host-hotspot-monitor] %s\n' "$*"
+}
+
+monitor_warn() {
+  printf '[host-hotspot-monitor] %s\n' "$*" >&2
+}
+
+monitor_json_string_or_null() {
+  local value="${1:-}"
+  if [[ -z "${value}" ]]; then
+    printf 'null'
+    return 0
+  fi
+
+  printf '"%s"' "$(json_escape "${value}")"
+}
+
+monitor_normalize_cooldown() {
+  if [[ ! "${COOLDOWN_SECONDS}" =~ ^[0-9]+$ ]] || (( COOLDOWN_SECONDS < 60 )); then
+    COOLDOWN_SECONDS="600"
+  fi
+}
+
+monitor_now_epoch() {
+  if [[ -n "${HOST_HOTSPOT_MONITOR_NOW_EPOCH:-}" ]]; then
+    printf '%s\n' "${HOST_HOTSPOT_MONITOR_NOW_EPOCH}"
+    return 0
+  fi
+
+  date -u +%s
+}
+
+monitor_now_timestamp() {
+  if [[ -n "${HOST_HOTSPOT_MONITOR_NOW_EPOCH:-}" ]]; then
+    date -u -d "@${HOST_HOTSPOT_MONITOR_NOW_EPOCH}" +'%Y-%m-%dT%H:%M:%SZ'
+    return 0
+  fi
+
+  utc_timestamp
+}
+
+monitor_json_field() {
+  local file_path="${1:-}" field_name="${2:-}" default_value="${3:-}"
+  [[ -f "${file_path}" && -n "${field_name}" ]] || {
+    printf '%s\n' "${default_value}"
+    return 0
+  }
+
+  python3 - "${file_path}" "${field_name}" "${default_value}" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+field = sys.argv[2]
+default = sys.argv[3]
+
+try:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+except (OSError, json.JSONDecodeError):
+    print(default)
+    raise SystemExit(0)
+
+value = payload.get(field, default)
+if value is None:
+    print(default)
+else:
+    print(value)
+PY
+}
+
+monitor_load_state_from_fixture() {
+  local fixture="${HOST_HOTSPOT_MONITOR_STATE_JSON_FILE:-}"
+  [[ -n "${fixture}" ]] || return 1
+
+  HOTSPOT_STATE_ISSUE_CODE="$(monitor_json_field "${fixture}" "issueCode" "none")"
+  HOTSPOT_STATE_MESSAGE="$(monitor_json_field "${fixture}" "message" "")"
+  HOTSPOT_STATE_HOTSPOT_DEVICE="$(monitor_json_field "${fixture}" "hotspotDevice" "")"
+  HOTSPOT_STATE_HOTSPOT_SCAN_DEVICE="$(monitor_json_field "${fixture}" "scanDevice" "")"
+  HOTSPOT_STATE_HOTSPOT_SSID="$(monitor_json_field "${fixture}" "hotspotSsid" "")"
+  return 0
+}
+
+monitor_collect_state() {
+  if monitor_load_state_from_fixture; then
+    return 0
+  fi
+
+  hotspot_refresh_config
+  hotspot_collect_runtime_state
+}
+
+monitor_is_recoverable_issue() {
+  case "${HOTSPOT_STATE_ISSUE_CODE}" in
+    approved_hotspot_adapter_missing|hotspot_profile_missing|hotspot_adapter_busy|hotspot_not_visible)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+monitor_request_id() {
+  local uuid timestamp
+  timestamp="$(date -u +'%Y%m%d-%H%M%S')"
+  if [[ -r /proc/sys/kernel/random/uuid ]]; then
+    uuid="$(cat /proc/sys/kernel/random/uuid)"
+  else
+    uuid="${RANDOM}${RANDOM}"
+  fi
+  printf 'monitor-%s-%s\n' "${timestamp}" "${uuid}"
+}
+
+monitor_write_status() {
+  local state="${1:-unknown}" action="${2:-none}" request_id="${3:-}" last_recovery_epoch="${4:-}" message="${5:-${HOTSPOT_STATE_MESSAGE:-}}" updated_at tmp_file
+  updated_at="$(monitor_now_timestamp)"
+  tmp_file="$(mktemp)"
+
+  cat >"${tmp_file}" <<JSON
+{
+  "schemaVersion": 1,
+  "state": "$(json_escape "${state}")",
+  "action": "$(json_escape "${action}")",
+  "issueCode": "$(json_escape "${HOTSPOT_STATE_ISSUE_CODE:-none}")",
+  "message": "$(json_escape "${message}")",
+  "requestId": $(monitor_json_string_or_null "${request_id}"),
+  "hotspotDevice": $(monitor_json_string_or_null "${HOTSPOT_STATE_HOTSPOT_DEVICE:-}"),
+  "scanDevice": $(monitor_json_string_or_null "${HOTSPOT_STATE_HOTSPOT_SCAN_DEVICE:-}"),
+  "hotspotSsid": $(monitor_json_string_or_null "${HOTSPOT_STATE_HOTSPOT_SSID:-}"),
+  "cooldownSeconds": ${COOLDOWN_SECONDS},
+  "lastRecoveryEpoch": $(monitor_json_string_or_null "${last_recovery_epoch}"),
+  "updatedAt": "$(json_escape "${updated_at}")"
+}
+JSON
+
+  mkdir -p "$(dirname "${STATE_FILE}")"
+  install -m 664 "${tmp_file}" "${STATE_FILE}"
+  rm -f "${tmp_file}"
+}
+
+monitor_queue_recovery() {
+  local request_id request_file tmp_file created_at
+  request_id="$(monitor_request_id)"
+  request_file="${REQUEST_DIR}/${request_id}.json"
+  tmp_file="$(mktemp)"
+  created_at="$(monitor_now_timestamp)"
+
+  cat >"${tmp_file}" <<JSON
+{
+  "requestId": "$(json_escape "${request_id}")",
+  "source": "host-hotspot-monitor",
+  "issueCode": "$(json_escape "${HOTSPOT_STATE_ISSUE_CODE}")",
+  "message": "$(json_escape "${HOTSPOT_STATE_MESSAGE}")",
+  "createdAt": "$(json_escape "${created_at}")"
+}
+JSON
+
+  mkdir -p "${REQUEST_DIR}"
+  install -m 664 "${tmp_file}" "${request_file}"
+  rm -f "${tmp_file}"
+
+  printf '%s\n' "${request_id}"
+}
+
+monitor_write_recovery_status() {
+  local request_id="${1:-}" updated_at tmp_file
+  updated_at="$(monitor_now_timestamp)"
+  tmp_file="$(mktemp)"
+
+  cat >"${tmp_file}" <<JSON
+{
+  "state": "queued",
+  "stage": "request_queued",
+  "message": "Automated hotspot recovery queued. Sentinel is repairing the hosted Wi-Fi signal.",
+  "requestId": $(monitor_json_string_or_null "${request_id}"),
+  "source": "host-hotspot-monitor",
+  "connectionName": null,
+  "hotspotSsid": $(monitor_json_string_or_null "${HOTSPOT_STATE_HOTSPOT_SSID:-}"),
+  "hotspotDevice": $(monitor_json_string_or_null "${HOTSPOT_STATE_HOTSPOT_DEVICE:-}"),
+  "scanDevice": $(monitor_json_string_or_null "${HOTSPOT_STATE_HOTSPOT_SCAN_DEVICE:-}"),
+  "usbDevice": null,
+  "hardwareResetApplied": null,
+  "startedAt": "$(json_escape "${updated_at}")",
+  "updatedAt": "$(json_escape "${updated_at}")",
+  "completedAt": null,
+  "durationSeconds": null
+}
+JSON
+
+  mkdir -p "$(dirname "${RECOVERY_STATUS_FILE}")"
+  install -m 664 "${tmp_file}" "${RECOVERY_STATUS_FILE}"
+  rm -f "${tmp_file}"
+}
+
+monitor_start_recovery_service() {
+  if [[ "${START_SERVICE}" != "true" ]]; then
+    return 0
+  fi
+
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl start sentinel-host-hotspot-recovery.service || monitor_warn "Unable to start sentinel-host-hotspot-recovery.service; the path watcher should process the queued request."
+  fi
+}
+
+main() {
+  local now_epoch last_recovery_epoch elapsed request_id
+  monitor_normalize_cooldown
+
+  mkdir -p "$(dirname "${LOCK_FILE}")"
+  exec 9>"${LOCK_FILE}"
+  if ! flock -n 9; then
+    monitor_log "Host hotspot monitor is already running."
+    exit 0
+  fi
+
+  monitor_collect_state
+  now_epoch="$(monitor_now_epoch)"
+
+  if [[ "${HOTSPOT_STATE_ISSUE_CODE}" == "none" ]]; then
+    monitor_write_status "healthy" "none" "" "" "${HOTSPOT_STATE_MESSAGE:-Hotspot profile and adapters are ready.}"
+    monitor_log "Hotspot is healthy."
+    exit 0
+  fi
+
+  if ! monitor_is_recoverable_issue; then
+    monitor_write_status "degraded" "none" "" "" "${HOTSPOT_STATE_MESSAGE}"
+    monitor_log "Hotspot monitor found ${HOTSPOT_STATE_ISSUE_CODE}; no automatic repair was queued."
+    exit 0
+  fi
+
+  last_recovery_epoch="$(monitor_json_field "${STATE_FILE}" "lastRecoveryEpoch" "")"
+  if [[ "${last_recovery_epoch}" =~ ^[0-9]+$ ]]; then
+    elapsed=$((now_epoch - last_recovery_epoch))
+    if (( elapsed >= 0 && elapsed < COOLDOWN_SECONDS )); then
+      monitor_write_status "cooldown" "skipped" "" "${last_recovery_epoch}" "${HOTSPOT_STATE_MESSAGE}"
+      monitor_log "Hotspot issue ${HOTSPOT_STATE_ISSUE_CODE} is within repair cooldown; skipping."
+      exit 0
+    fi
+  fi
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    monitor_write_status "would_repair" "dry_run" "" "${now_epoch}" "${HOTSPOT_STATE_MESSAGE}"
+    monitor_log "Dry run would queue hotspot recovery for ${HOTSPOT_STATE_ISSUE_CODE}."
+    exit 0
+  fi
+
+  request_id="$(monitor_queue_recovery)"
+  monitor_write_status "repair_queued" "queued_recovery" "${request_id}" "${now_epoch}" "${HOTSPOT_STATE_MESSAGE}"
+  monitor_write_recovery_status "${request_id}"
+  monitor_start_recovery_service
+  monitor_log "Queued host hotspot recovery request ${request_id} for ${HOTSPOT_STATE_ISSUE_CODE}."
+}
+
+main "$@"

--- a/deploy/process-host-hotspot-recovery-requests.sh
+++ b/deploy/process-host-hotspot-recovery-requests.sh
@@ -32,9 +32,27 @@ fi
 for request_file in "${requests[@]}"; do
   base_name="$(basename "${request_file}")"
   request_id="${base_name%.json}"
+  request_source="$(
+    python3 - "${request_file}" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+try:
+    payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError):
+    print("unknown")
+    raise SystemExit(0)
+
+source = payload.get("source")
+print(source if isinstance(source, str) and source.strip() else "unknown")
+PY
+  )"
   log "Processing host hotspot recovery request ${base_name}"
 
-  if "${SCRIPT_DIR}/recover-host-hotspot.sh" "${CONNECTION_NAME}" "${request_id}"; then
+  if HOST_HOTSPOT_RECOVERY_SOURCE="${request_source}" "${SCRIPT_DIR}/recover-host-hotspot.sh" "${CONNECTION_NAME}" "${request_id}"; then
     mv "${request_file}" "${PROCESSED_DIR}/${base_name}"
     log "Host hotspot recovery request ${base_name} completed."
   else

--- a/deploy/recover-host-hotspot.sh
+++ b/deploy/recover-host-hotspot.sh
@@ -14,6 +14,8 @@ HOTSPOT_BAND="$(env_value HOTSPOT_BAND 'bg')"
 HOTSPOT_CHANNEL="$(env_value HOTSPOT_CHANNEL '1')"
 LOCK_FILE="${LOCK_FILE:-/run/lock/sentinel-host-hotspot-recover.lock}"
 STATUS_FILE="${HOST_HOTSPOT_RECOVERY_STATUS_FILE:-${SCRIPT_DIR}/runtime/hotspot-recovery/status.json}"
+HISTORY_FILE="${HOST_HOTSPOT_RECOVERY_HISTORY_FILE:-${SCRIPT_DIR}/runtime/hotspot-recovery/history.jsonl}"
+RECOVERY_SOURCE="${HOST_HOTSPOT_RECOVERY_SOURCE:-unknown}"
 export HOTSPOT_CONNECTION_NAME_OVERRIDE="${CONNECTION_NAME}"
 
 STARTED_AT="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
@@ -43,18 +45,48 @@ json_string_or_null() {
   printf '"%s"' "$(json_escape "${value}")"
 }
 
+recovery_duration_seconds() {
+  local completed_at="${1:-}" start_epoch completed_epoch
+  [[ -n "${completed_at}" ]] || return 0
+
+  start_epoch="$(date -u -d "${STARTED_AT}" +%s 2>/dev/null || true)"
+  completed_epoch="$(date -u -d "${completed_at}" +%s 2>/dev/null || true)"
+  if [[ -z "${start_epoch}" || -z "${completed_epoch}" ]]; then
+    return 0
+  fi
+
+  printf '%s\n' "$((completed_epoch - start_epoch))"
+}
+
+recovery_append_history() {
+  local state="${1:-}" stage="${2:-}" message="${3:-}" completed_at="${4:-}" duration_seconds="${5:-}" tmp_file
+  [[ "${stage}" == "completed" || "${stage}" == "failed" ]] || return 0
+
+  mkdir -p "$(dirname "${HISTORY_FILE}")" >/dev/null 2>&1 || return 0
+  tmp_file="$(mktemp "$(dirname "${HISTORY_FILE}")/history.XXXXXX" 2>/dev/null)" || return 0
+
+  cat >"${tmp_file}" <<JSON
+{"state":"$(json_escape "${state}")","stage":"$(json_escape "${stage}")","message":"$(json_escape "${message}")","requestId":$(json_string_or_null "${REQUEST_ID}"),"source":"$(json_escape "${RECOVERY_SOURCE}")","startedAt":"$(json_escape "${STARTED_AT}")","completedAt":$(json_string_or_null "${completed_at}"),"durationSeconds":$(json_string_or_null "${duration_seconds}")}
+JSON
+  cat "${tmp_file}" >>"${HISTORY_FILE}" 2>/dev/null || true
+  rm -f "${tmp_file}"
+  chmod 664 "${HISTORY_FILE}" >/dev/null 2>&1 || true
+}
+
 recovery_write_status() {
   local state="$1"
   local stage="$2"
   local message="$3"
   local completed="${4:-false}"
-  local updated_at completed_at tmp_file had_errexit
+  local updated_at completed_at duration_seconds tmp_file had_errexit
 
   updated_at="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
   if [[ "${completed}" == "true" ]]; then
     completed_at="${updated_at}"
+    duration_seconds="$(recovery_duration_seconds "${completed_at}" || true)"
   else
     completed_at=""
+    duration_seconds=""
   fi
 
   had_errexit="false"
@@ -80,6 +112,7 @@ recovery_write_status() {
   "stage": "$(json_escape "${stage}")",
   "message": "$(json_escape "${message}")",
   "requestId": $(json_string_or_null "${REQUEST_ID}"),
+  "source": $(json_string_or_null "${RECOVERY_SOURCE}"),
   "connectionName": $(json_string_or_null "${CONNECTION_NAME}"),
   "hotspotSsid": $(json_string_or_null "${SSID:-}"),
   "hotspotDevice": $(json_string_or_null "${DEVICE:-}"),
@@ -88,11 +121,13 @@ recovery_write_status() {
   "hardwareResetApplied": $(json_bool "${hardware_reset_applied:-false}"),
   "startedAt": "$(json_escape "${STARTED_AT}")",
   "updatedAt": "$(json_escape "${updated_at}")",
-  "completedAt": $(json_string_or_null "${completed_at}")
+  "completedAt": $(json_string_or_null "${completed_at}"),
+  "durationSeconds": $(json_string_or_null "${duration_seconds}")
 }
 JSON
   chmod 664 "${tmp_file}" >/dev/null 2>&1 || true
   mv "${tmp_file}" "${STATUS_FILE}" >/dev/null 2>&1 || rm -f "${tmp_file}" >/dev/null 2>&1 || true
+  recovery_append_history "${state}" "${stage}" "${message}" "${completed_at}" "${duration_seconds}"
 
   if [[ "${had_errexit}" == "true" ]]; then
     set -e

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.3.19",
+  "version": "3.3.20",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.3.19",
+  "version": "3.3.20",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/contracts/src/schemas/system-status.schema.ts
+++ b/packages/contracts/src/schemas/system-status.schema.ts
@@ -63,6 +63,7 @@ export const HostHotspotRecoveryStatusSchema = v.object({
   stage: HostHotspotRecoveryStageSchema,
   message: v.string(),
   requestId: v.nullable(v.string()),
+  source: v.optional(v.nullable(v.string())),
   connectionName: v.nullable(v.string()),
   hotspotSsid: v.nullable(v.string()),
   hotspotDevice: v.nullable(v.string()),
@@ -72,6 +73,8 @@ export const HostHotspotRecoveryStatusSchema = v.object({
   startedAt: v.nullable(v.string()),
   updatedAt: v.string(),
   completedAt: v.nullable(v.string()),
+  durationSeconds: v.optional(v.nullable(v.number())),
+  estimatedDurationSeconds: v.optional(v.nullable(v.number())),
 })
 
 export const NetworkFactsSchema = v.object({

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.3.19",
+  "version": "3.3.20",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.3.19",
+  "version": "3.3.20",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",

--- a/scripts/test-host-hotspot-monitor.sh
+++ b/scripts/test-host-hotspot-monitor.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+assert_file_count() {
+  local expected="${1:-0}" directory="${2:-}"
+  local actual
+  shopt -s nullglob
+  local files=("${directory}"/*.json)
+  shopt -u nullglob
+  actual="${#files[@]}"
+  if [[ "${actual}" != "${expected}" ]]; then
+    printf 'Expected %s JSON files in %s, found %s\n' "${expected}" "${directory}" "${actual}" >&2
+    exit 1
+  fi
+}
+
+assert_json_field() {
+  local file_path="${1:-}" field_name="${2:-}" expected="${3:-}"
+  local actual
+  actual="$(
+    python3 - "${file_path}" "${field_name}" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+with Path(sys.argv[1]).open("r", encoding="utf-8") as handle:
+    payload = json.load(handle)
+print(payload.get(sys.argv[2], ""))
+PY
+  )"
+
+  if [[ "${actual}" != "${expected}" ]]; then
+    printf 'Expected %s=%s in %s, got %s\n' "${field_name}" "${expected}" "${file_path}" "${actual}" >&2
+    exit 1
+  fi
+}
+
+write_fixture() {
+  local file_path="${1:-}" issue_code="${2:-none}" message="${3:-}"
+  cat >"${file_path}" <<JSON
+{
+  "issueCode": "${issue_code}",
+  "message": "${message}",
+  "hotspotDevice": "wlan-ap",
+  "scanDevice": "wlan-scan",
+  "hotspotSsid": "Stone Frigate"
+}
+JSON
+}
+
+run_monitor() {
+  local fixture="${1:-}" now_epoch="${2:-1000}" request_dir="${3:-${TMP_DIR}/requests}" state_file="${4:-${TMP_DIR}/monitor.json}"
+  HOST_HOTSPOT_MONITOR_STATE_JSON_FILE="${fixture}" \
+    HOST_HOTSPOT_RECOVERY_REQUEST_DIR="${request_dir}" \
+    HOST_HOTSPOT_RECOVERY_STATUS_FILE="${TMP_DIR}/recovery-status.json" \
+    HOST_HOTSPOT_MONITOR_STATE_FILE="${state_file}" \
+    HOST_HOTSPOT_MONITOR_LOCK_FILE="${TMP_DIR}/monitor.lock" \
+    HOST_HOTSPOT_MONITOR_COOLDOWN_SECONDS="600" \
+    HOST_HOTSPOT_MONITOR_START_SERVICE="false" \
+    HOST_HOTSPOT_MONITOR_NOW_EPOCH="${now_epoch}" \
+    bash "${REPO_ROOT}/deploy/monitor-host-hotspot.sh" >/dev/null
+}
+
+REQUEST_DIR="${TMP_DIR}/requests"
+STATE_FILE="${TMP_DIR}/monitor.json"
+mkdir -p "${REQUEST_DIR}"
+
+write_fixture "${TMP_DIR}/healthy.json" "none" "Hotspot profile and adapters are ready."
+run_monitor "${TMP_DIR}/healthy.json" "1000" "${REQUEST_DIR}" "${STATE_FILE}"
+assert_file_count "0" "${REQUEST_DIR}"
+assert_json_field "${STATE_FILE}" "state" "healthy"
+
+write_fixture "${TMP_DIR}/missing.json" "approved_hotspot_adapter_missing" "No approved USB AP dongle is visible."
+run_monitor "${TMP_DIR}/missing.json" "2000" "${REQUEST_DIR}" "${STATE_FILE}"
+assert_file_count "1" "${REQUEST_DIR}"
+assert_json_field "${STATE_FILE}" "state" "repair_queued"
+assert_json_field "${STATE_FILE}" "issueCode" "approved_hotspot_adapter_missing"
+
+run_monitor "${TMP_DIR}/missing.json" "2200" "${REQUEST_DIR}" "${STATE_FILE}"
+assert_file_count "1" "${REQUEST_DIR}"
+assert_json_field "${STATE_FILE}" "state" "cooldown"
+
+write_fixture "${TMP_DIR}/scan-missing.json" "scan_adapter_missing" "A second Wi-Fi radio is unavailable for hotspot verification."
+run_monitor "${TMP_DIR}/scan-missing.json" "3000" "${TMP_DIR}/scan-requests" "${TMP_DIR}/scan-monitor.json"
+assert_file_count "0" "${TMP_DIR}/scan-requests"
+assert_json_field "${TMP_DIR}/scan-monitor.json" "state" "degraded"
+
+write_fixture "${TMP_DIR}/not-visible.json" "hotspot_not_visible" "Hotspot SSID is not visible from wlan-scan."
+run_monitor "${TMP_DIR}/not-visible.json" "4000" "${TMP_DIR}/visibility-requests" "${TMP_DIR}/visibility-monitor.json"
+assert_file_count "1" "${TMP_DIR}/visibility-requests"
+assert_json_field "${TMP_DIR}/visibility-monitor.json" "state" "repair_queued"
+
+printf 'host hotspot monitor tests passed\n'


### PR DESCRIPTION
## Summary

- Allows Duty Watch schedules to be published even when required watch positions are still missing.
- Adds an automated host hotspot monitor that can queue the existing repair flow when the USB AP dongle or hosted SSID drops out.
- Shows users a centered recovery notice while automated hotspot repair is running, including estimated time remaining from prior repair history.
- Broadcasts a refresh request to connected pages after automated hotspot recovery completes and the host reports healthy network status.
- Prepares Sentinel v3.3.20 as the next patch release.

## Why this change was needed

Operators need to publish Duty Watch even when staffing is incomplete. Separately, the hosted Sentinel hotspot can temporarily stop broadcasting when the USB Wi-Fi AP dongle or NetworkManager state becomes unstable. Users also need a clear on-screen explanation while automated repair is running so they understand that Sentinel is working and that pages will refresh once service is restored.

## What changed

### User-facing

- Added a central automated hotspot recovery dialog for authenticated app users.
- The dialog explains that Sentinel is repairing the hosted Wi-Fi signal, shows the current recovery stage, and displays estimated time remaining.
- Connected pages reload after automated recovery completes so users see restored data without manual browser refresh.

### Admin/operator-facing

- Duty Watch can now be published with missing required slots. The card still shows how many positions are missing.
- Host hotspot recovery history is recorded so future automated recovery estimates become more accurate.

### Backend/API

- Extended host hotspot recovery status with source, duration, and estimated duration fields.
- Broadcasts `system:refresh-required` when automated hotspot recovery completes and network status is healthy.
- Keeps scheduled and monitor-triggered recoveries distinguishable from manual repair requests.

### Database

- No database schema changes.

### Deployment/update

- Adds `monitor-host-hotspot.sh` and provisions `sentinel-host-hotspot-monitor.timer` through the deploy helper.
- The monitor checks the hotspot every 60 seconds by default and queues the existing recovery processor when recoverable hotspot issues are detected.
- Existing install/update provisioning enables the new timer.

### Documentation

- Updated deploy documentation with the new hotspot monitor status path and systemd units.

### Tests

- Added focused frontend logic tests for the Duty Watch publish state and automated hotspot recovery notice.
- Added a shell harness for the host hotspot monitor decision flow.
- Extended host hotspot recovery service coverage for recovery history estimates.

## User impact

Users will see a clear recovery popup if Sentinel automatically repairs the hosted hotspot. The popup explains what is happening, shows an estimated duration, and refreshes the page after recovery completes.

## Operator impact

Operators get automated hotspot recovery attempts without needing to manually press Repair Host Hotspot each time the AP dongle or hosted SSID drops out. Duty Watch publishing is less blocked by incomplete staffing while still surfacing missing positions.

## Upgrade or migration notes

No database migration is required. No manual configuration change is required. Updating to v3.3.20 provisions the new host hotspot monitor timer through the existing install/update flow.

## Risk and rollback notes

Main risk is that an unstable or fully disconnected USB dongle may still require physical reseating if Linux cannot see hardware to reset. The monitor uses cooldowns and the existing recovery processor to avoid repeated tight-loop repairs. Rollback is safe through the normal Sentinel rollback process; no data migration is introduced.

## Testing performed

- `pnpm version:check`
- `pnpm --filter frontend-admin exec vitest run src/components/network/automated-hotspot-recovery-notice.logic.test.ts src/components/schedules/duty-watch-publish-state.test.ts`
- `pnpm --filter frontend-admin exec tsc --noEmit`
- `pnpm --filter @sentinel/backend typecheck`
- `pnpm --filter @sentinel/contracts typecheck`
- `bash scripts/test-host-hotspot-monitor.sh`
- `git diff --check`
- Visual sanity check at 1920x1080 with a mocked automated hotspot recovery state.

## Changelog candidates

- Added an automated host hotspot monitor that queues repair when the USB AP dongle or hosted SSID drops out.
- Added an automated recovery popup so users know Sentinel is repairing the hotspot and roughly how long it should take.
- Refreshed connected pages after automated hotspot recovery completes so remote users see the restored state.
- Allowed Duty Watch publishing even when required positions are still missing, while continuing to show the missing count.
