### PR TITLE
Patch release v3.3.22: stabilize login and dashboard refresh

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.3.21",
+  "version": "3.3.22",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.3.21",
+  "version": "3.3.22",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/components/auth/auth-hydrator.logic.test.ts
+++ b/apps/frontend-admin/src/components/auth/auth-hydrator.logic.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { shouldIgnoreStaleUnauthorizedSessionCheck } from './auth-hydrator.logic'
+import {
+  shouldIgnoreStaleUnauthorizedSessionCheck,
+  shouldRunSessionHeartbeat,
+} from './auth-hydrator.logic'
 
 describe('auth hydrator logic', () => {
   it('ignores stale unauthorized responses when login completed during the request', () => {
@@ -25,6 +28,33 @@ describe('auth hydrator logic', () => {
       shouldIgnoreStaleUnauthorizedSessionCheck({
         wasAuthenticatedAtRequestStart: true,
         isAuthenticatedNow: true,
+      })
+    ).toBe(false)
+  })
+
+  it('does not start session heartbeats while a fresh login is still on the login page', () => {
+    expect(
+      shouldRunSessionHeartbeat({
+        isAuthenticated: true,
+        pathname: '/login',
+      })
+    ).toBe(false)
+  })
+
+  it('starts session heartbeats for authenticated protected routes', () => {
+    expect(
+      shouldRunSessionHeartbeat({
+        isAuthenticated: true,
+        pathname: '/dashboard',
+      })
+    ).toBe(true)
+  })
+
+  it('does not start session heartbeats before authentication', () => {
+    expect(
+      shouldRunSessionHeartbeat({
+        isAuthenticated: false,
+        pathname: '/dashboard',
       })
     ).toBe(false)
   })

--- a/apps/frontend-admin/src/components/auth/auth-hydrator.logic.ts
+++ b/apps/frontend-admin/src/components/auth/auth-hydrator.logic.ts
@@ -5,3 +5,11 @@ export function shouldIgnoreStaleUnauthorizedSessionCheck(input: {
   const { wasAuthenticatedAtRequestStart, isAuthenticatedNow } = input
   return !wasAuthenticatedAtRequestStart && isAuthenticatedNow
 }
+
+export function shouldRunSessionHeartbeat(input: {
+  isAuthenticated: boolean
+  pathname: string
+}): boolean {
+  const { isAuthenticated, pathname } = input
+  return isAuthenticated && pathname !== '/login'
+}

--- a/apps/frontend-admin/src/components/auth/auth-hydrator.tsx
+++ b/apps/frontend-admin/src/components/auth/auth-hydrator.tsx
@@ -11,7 +11,10 @@ import {
 } from '@/lib/post-login-destination'
 import { isKioskRoute } from '@/lib/kiosk-device-auth'
 import { useAuthStore } from '@/store/auth-store'
-import { shouldIgnoreStaleUnauthorizedSessionCheck } from './auth-hydrator.logic'
+import {
+  shouldIgnoreStaleUnauthorizedSessionCheck,
+  shouldRunSessionHeartbeat,
+} from './auth-hydrator.logic'
 
 /**
  * Validates the session cookie on mount and syncs the Zustand auth store.
@@ -24,6 +27,7 @@ export function AuthHydrator() {
   const { isAuthenticated, setAuth, updateSession, logout } = useAuthStore()
   const hasValidated = useRef(false)
   const kioskRoute = isKioskRoute(pathname)
+  const shouldHeartbeat = shouldRunSessionHeartbeat({ isAuthenticated, pathname })
 
   const validateSession = useEffectEvent(async () => {
     const wasAuthenticatedAtRequestStart = useAuthStore.getState().isAuthenticated
@@ -116,7 +120,7 @@ export function AuthHydrator() {
   }, [])
 
   useEffect(() => {
-    if (!isAuthenticated) {
+    if (!shouldHeartbeat) {
       return
     }
 
@@ -144,7 +148,7 @@ export function AuthHydrator() {
       window.removeEventListener('focus', handleFocus)
       document.removeEventListener('visibilitychange', handleVisibilityChange)
     }
-  }, [isAuthenticated, kioskRoute])
+  }, [shouldHeartbeat, kioskRoute])
 
   return null
 }

--- a/apps/frontend-admin/src/lib/websocket.test.ts
+++ b/apps/frontend-admin/src/lib/websocket.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Socket } from 'socket.io-client'
+import { io } from 'socket.io-client'
+import { WebSocketManager } from './websocket'
+
+interface MockSocket {
+  connected: boolean
+  connect: ReturnType<typeof vi.fn>
+  disconnect: ReturnType<typeof vi.fn>
+  emit: ReturnType<typeof vi.fn>
+  on: ReturnType<typeof vi.fn>
+  off: ReturnType<typeof vi.fn>
+}
+
+const handlers = new Map<string, Array<(payload?: unknown) => void>>()
+
+function createMockSocket(): MockSocket {
+  return {
+    connected: false,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    emit: vi.fn(),
+    on: vi.fn((event: string, handler: (payload?: unknown) => void) => {
+      const registeredHandlers = handlers.get(event) ?? []
+      registeredHandlers.push(handler)
+      handlers.set(event, registeredHandlers)
+    }),
+    off: vi.fn(),
+  }
+}
+
+function emitSocketEvent(event: string, payload?: unknown) {
+  for (const handler of handlers.get(event) ?? []) {
+    handler(payload)
+  }
+}
+
+vi.mock('socket.io-client', () => ({
+  io: vi.fn(),
+}))
+
+describe('WebSocketManager', () => {
+  let socket: MockSocket
+
+  beforeEach(() => {
+    handlers.clear()
+    socket = createMockSocket()
+    vi.mocked(io).mockReturnValue(socket as unknown as Socket)
+  })
+
+  it('keeps one room subscription until every caller has unsubscribed', () => {
+    const manager = new WebSocketManager()
+    manager.connect()
+
+    manager.subscribe('presence')
+    manager.subscribe('presence')
+    manager.unsubscribe('presence')
+
+    expect(socket.emit).toHaveBeenCalledTimes(1)
+    expect(socket.emit).toHaveBeenNthCalledWith(1, 'presence:subscribe')
+
+    manager.unsubscribe('presence')
+
+    expect(socket.emit).toHaveBeenCalledTimes(2)
+    expect(socket.emit).toHaveBeenNthCalledWith(2, 'presence:unsubscribe')
+  })
+
+  it('resubscribes active rooms after Socket.IO reconnects', () => {
+    const manager = new WebSocketManager()
+    manager.connect()
+    manager.subscribe('checkins')
+    manager.subscribe('presence')
+
+    socket.emit.mockClear()
+
+    emitSocketEvent('connect')
+
+    expect(socket.emit).toHaveBeenCalledWith('checkins:subscribe')
+    expect(socket.emit).toHaveBeenCalledWith('presence:subscribe')
+  })
+
+  it('reconnects an existing disconnected socket when a hook asks to connect again', () => {
+    const manager = new WebSocketManager()
+    manager.connect()
+
+    manager.connect()
+
+    expect(socket.connect).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/frontend-admin/src/lib/websocket.ts
+++ b/apps/frontend-admin/src/lib/websocket.ts
@@ -1,8 +1,9 @@
 /* global process */
 import { io, Socket } from 'socket.io-client'
 
-class WebSocketManager {
+export class WebSocketManager {
   private socket: Socket | null = null
+  private subscriptionCounts = new Map<string, number>()
 
   get hasSocket(): boolean {
     return this.socket !== null
@@ -13,7 +14,12 @@ class WebSocketManager {
   }
 
   connect() {
-    if (this.socket) return
+    if (this.socket) {
+      if (!this.socket.connected) {
+        this.socket.connect()
+      }
+      return
+    }
 
     const socketUrl = process.env.NEXT_PUBLIC_WS_URL || undefined
     this.socket = io(socketUrl, {
@@ -27,6 +33,7 @@ class WebSocketManager {
 
     this.socket.on('connect', () => {
       console.log('[WebSocket] Connected:', this.socket?.id)
+      this.resubscribeActiveChannels()
     })
 
     this.socket.on('disconnect', (reason) => {
@@ -40,12 +47,26 @@ class WebSocketManager {
 
   subscribe(channel: string) {
     if (!this.socket) throw new Error('Socket not initialized')
-    this.socket.emit(`${channel}:subscribe`)
+
+    const currentCount = this.subscriptionCounts.get(channel) ?? 0
+    this.subscriptionCounts.set(channel, currentCount + 1)
+
+    if (currentCount === 0) {
+      this.socket.emit(`${channel}:subscribe`)
+    }
   }
 
   unsubscribe(channel: string) {
     if (!this.socket) throw new Error('Socket not initialized')
-    this.socket.emit(`${channel}:unsubscribe`)
+
+    const currentCount = this.subscriptionCounts.get(channel) ?? 0
+    if (currentCount <= 1) {
+      this.subscriptionCounts.delete(channel)
+      this.socket.emit(`${channel}:unsubscribe`)
+      return
+    }
+
+    this.subscriptionCounts.set(channel, currentCount - 1)
   }
 
   on(event: string, handler: (data: unknown) => void) {
@@ -67,6 +88,15 @@ class WebSocketManager {
     if (this.socket) {
       this.socket.disconnect()
       this.socket = null
+    }
+    this.subscriptionCounts.clear()
+  }
+
+  private resubscribeActiveChannels() {
+    if (!this.socket) return
+
+    for (const channel of this.subscriptionCounts.keys()) {
+      this.socket.emit(`${channel}:subscribe`)
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.3.21",
+  "version": "3.3.22",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.3.21",
+  "version": "3.3.22",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.3.21",
+  "version": "3.3.22",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.3.21",
+  "version": "3.3.22",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Fixes a login race where the first correct PIN/password attempt could appear to fail before reaching the dashboard.
- Fixes intermittent dashboard refresh gaps after kiosk tag scans when the browser or network reconnects.
- Prepares Sentinel v3.3.22 as the next patch release.

## Why this change was needed

Operators reported that a correct first login could fail, then succeed on the second attempt. They also reported that the Dashboard sometimes did not update immediately after someone scanned a tag at the Kiosk. Both problems were caused by frontend timing and realtime connection edge cases rather than bad attendance data.

## What changed

### User-facing

- Login no longer starts session heartbeats while the user is still on the login page after a successful authentication response.
- Dashboard realtime subscriptions now survive Socket.IO reconnects, so kiosk tag scans continue to refresh the presence view after transient network drops.

### Admin/operator-facing

- Operators should see more reliable first-attempt login behavior.
- Staff watching the Dashboard should see kiosk scan updates without waiting for the polling fallback after a reconnect.

### Backend/API

- No backend API behavior changed.

### Database

- No database schema changes.

### Deployment/update

- Workspace package versions were synchronized to v3.3.22.

### Tests

- Added regression coverage for WebSocket room reference counts, reconnect resubscription, and reconnecting a stale socket.
- Added regression coverage for suppressing session heartbeats on the login page.

## User impact

Members and staff should be able to sign in on the first correct attempt. Dashboard viewers should see kiosk tag scans refresh reliably after browser or network reconnects.

## Operator impact

No manual operator action is required beyond applying the patch release. Existing browser sessions may need the normal application reload that comes with deployment.

## Upgrade or migration notes

No upgrade action required. No database migration is required. No configuration change is required.

## Risk and rollback notes

Main risk is limited to frontend session heartbeat timing and Socket.IO subscription behavior. Rollback is safe because no database schema or data format changes are included. Verify by logging in once with the bootstrap account and confirming that a kiosk tag scan refreshes the Dashboard after reconnecting the browser/network.

## Testing performed

- `pnpm version:check`
- `pnpm --filter frontend-admin exec vitest run src/lib/websocket.test.ts src/components/auth/auth-hydrator.logic.test.ts src/components/kiosk/kiosk-domain.test.ts src/hooks/use-log-viewer.test.ts`
- `pnpm --filter frontend-admin type-check`
- `git diff --check`

## Changelog candidates

- Fixed a login race that could make a correct first login attempt appear to fail. This helps members and staff get into Sentinel without needing to click Login a second time.
- Fixed dashboard realtime refresh after Socket.IO reconnects. This keeps kiosk tag scans visible on the Dashboard after transient network drops.
- Prepared Sentinel v3.3.22 as a patch release. No database migration or configuration change is required.