### PR TITLE
Release v3.4.1

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/app/dashboard/page.tsx
+++ b/apps/frontend-admin/src/app/dashboard/page.tsx
@@ -13,9 +13,7 @@ export default function DashboardPage() {
       >
         <h1 className="sr-only">Dashboard</h1>
 
-        <section>
-          <SecurityAlertsBar />
-        </section>
+        <SecurityAlertsBar />
 
         <section>
           <StatusStats />

--- a/apps/frontend-admin/src/app/globals.css
+++ b/apps/frontend-admin/src/app/globals.css
@@ -545,6 +545,12 @@ html[data-theme='business'] .backend-status-badge {
   color: var(--btn-fg);
 }
 
+.stats-action-emphasis-error:not(:disabled) {
+  --btn-bg: var(--color-error-fadded);
+  --btn-border: var(--color-error);
+  --btn-fg: var(--color-error-fadded-content);
+}
+
 .stats-action-success:hover:not(:disabled),
 .stats-action-success:focus-visible:not(:disabled) {
   --btn-bg: var(--color-success);

--- a/apps/frontend-admin/src/components/dashboard/security-alerts-bar.tsx
+++ b/apps/frontend-admin/src/components/dashboard/security-alerts-bar.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { AlertCircle, ShieldCheck } from 'lucide-react'
+import { AlertCircle } from 'lucide-react'
 import { useSecurityAlerts, useAcknowledgeAlert } from '@/hooks/use-security-alerts'
 import { useAuthStore } from '@/store/auth-store'
 import { AccountLevel } from '@/store/auth-store'
@@ -139,25 +139,13 @@ export function SecurityAlertsBar() {
   const { data, isLoading, isError } = useSecurityAlerts()
 
   if (isLoading) {
-    return (
-      <div
-        className="mb-4 rounded-box border border-base-300 bg-base-100 px-(--space-4) py-(--space-3) shadow-sm"
-        data-help-id="dashboard.security-alerts"
-        role="status"
-        aria-label="Checking security alerts"
-      >
-        <div className="flex items-center gap-(--space-2) text-sm text-base-content/60">
-          <span className="loading loading-spinner loading-xs" />
-          Checking security alerts...
-        </div>
-      </div>
-    )
+    return null
   }
 
   if (isError) {
     return (
       <div
-        className="mb-4 rounded-box border border-warning/35 bg-warning-fadded px-(--space-4) py-(--space-3) text-warning-fadded-content shadow-sm"
+        className="rounded-box border border-warning/35 bg-warning-fadded px-(--space-4) py-(--space-3) text-warning-fadded-content shadow-sm"
         data-help-id="dashboard.security-alerts"
         role="status"
       >
@@ -177,33 +165,13 @@ export function SecurityAlertsBar() {
   }
 
   if (!data?.alerts || data.alerts.length === 0) {
-    return (
-      <div
-        className="mb-4 rounded-box border border-success/25 bg-success-fadded px-(--space-4) py-(--space-3) text-success-fadded-content shadow-sm"
-        data-help-id="dashboard.security-alerts"
-      >
-        <div className="flex items-center justify-between gap-(--space-3)">
-          <div className="flex min-w-0 items-center gap-(--space-3)">
-            <ShieldCheck className="size-5 shrink-0" />
-            <div className="min-w-0">
-              <p className="font-display text-sm font-semibold">No active security alerts</p>
-              <p className="mt-0.5 text-xs leading-5">
-                Start here each day. If alerts appear, handle them before changing building state.
-              </p>
-            </div>
-          </div>
-          <AppBadge status="success" size="sm">
-            Clear
-          </AppBadge>
-        </div>
-      </div>
-    )
+    return null
   }
 
   const alerts = data.alerts
 
   return (
-    <div className="space-y-2 mb-4" data-help-id="dashboard.security-alerts">
+    <div className="space-y-2" data-help-id="dashboard.security-alerts">
       {alerts.slice(0, 3).map((alert: SecurityAlertResponse) => (
         <SecurityAlertItem key={alert.id} alert={alert} />
       ))}

--- a/apps/frontend-admin/src/components/dashboard/status-stats.tsx
+++ b/apps/frontend-admin/src/components/dashboard/status-stats.tsx
@@ -603,20 +603,25 @@ function StatusActionsStat({
   onSetTodayDds: () => void
   onTransferLockup: () => void
 }) {
-  const actionBaseClass =
-    'btn btn-xs w-fit border font-medium transition-all duration-200 shadow-sm hover:shadow-md btn-action stats-action-button disabled:opacity-40'
+  const primaryActionClass =
+    'btn btn-sm w-full min-w-44 justify-start border font-semibold transition-all duration-200 shadow-sm hover:shadow-md btn-action stats-action-button disabled:opacity-40'
+  const transferActionClass =
+    'btn btn-xs w-full justify-center border font-medium transition-all duration-200 shadow-sm hover:shadow-md btn-action stats-action-button disabled:opacity-40'
+  const transferGridClass = isOpenWithHolder
+    ? 'grid grid-cols-2 gap-[var(--space-1)]'
+    : 'grid grid-cols-1 gap-[var(--space-1)]'
 
   return (
     <StatContainer helpId="dashboard.stat.actions">
       <div className="stat-desc">
-        <div className="mt-1 flex flex-col items-start gap-1">
+        <div className="mt-[var(--space-1)] flex min-w-48 flex-col items-stretch gap-[var(--space-2)]">
           {isSecured ? (
             <div
               className={!isAdmin ? 'tooltip tooltip-right' : ''}
               data-tip="Requires Admin level or higher"
             >
               <MotionButton
-                className={`${actionBaseClass} stats-action-success justify-start`}
+                className={`${primaryActionClass} stats-action-success`}
                 disabled={!isAdmin}
                 onClick={onOpenBuilding}
                 data-testid={TID.dashboard.quickAction.openBuilding}
@@ -632,7 +637,7 @@ function StatusActionsStat({
               data-tip={!isAdmin ? 'Requires admin role' : 'No lockup holder assigned'}
             >
               <MotionButton
-                className={`${actionBaseClass} stats-action-error justify-start`}
+                className={`${primaryActionClass} stats-action-error stats-action-emphasis-error`}
                 disabled={!isAdmin || isOpenNoHolder}
                 onClick={onExecuteLockup}
                 data-testid={TID.dashboard.quickAction.executeLockup}
@@ -644,39 +649,48 @@ function StatusActionsStat({
             </div>
           )}
 
-          <div
-            className={!isAdmin ? 'tooltip tooltip-right' : ''}
-            data-tip="Requires Admin level or higher"
-          >
-            <MotionButton
-              className={`${actionBaseClass} stats-action-warning justify-start`}
-              disabled={!isAdmin}
-              onClick={onSetTodayDds}
-              data-testid={TID.dashboard.quickAction.setTodayDds}
-              data-help-id="dashboard.quick-actions.transfer-dds"
-            >
-              <ShieldCheck className="size-[1.1em] shrink-0" />
-              {ddsActionLabel}
-            </MotionButton>
-          </div>
-
-          {isOpenWithHolder && (
-            <div
-              className={!isAdmin ? 'tooltip tooltip-right' : ''}
-              data-tip="Requires Admin level or higher"
-            >
-              <MotionButton
-                className={`${actionBaseClass} stats-action-warning justify-start`}
-                disabled={!isAdmin}
-                onClick={onTransferLockup}
-                data-testid={TID.dashboard.quickAction.transferLockup}
-                data-help-id="dashboard.quick-actions.transfer-lockup"
+          <div className="flex flex-col gap-[var(--space-1)]">
+            <p className="text-[0.68rem] leading-none font-semibold tracking-wide text-base-content/60 uppercase">
+              Transfer
+            </p>
+            <div className={transferGridClass} aria-label="Transfer quick actions">
+              <div
+                className={`w-full ${!isAdmin ? 'tooltip tooltip-right' : ''}`}
+                data-tip="Requires Admin level or higher"
               >
-                <ArrowRightLeft className="size-[1.1em] shrink-0" />
-                Transfer Lockup
-              </MotionButton>
+                <MotionButton
+                  className={`${transferActionClass} stats-action-warning`}
+                  disabled={!isAdmin}
+                  onClick={onSetTodayDds}
+                  title={ddsActionLabel}
+                  aria-label={ddsActionLabel}
+                  data-testid={TID.dashboard.quickAction.setTodayDds}
+                  data-help-id="dashboard.quick-actions.transfer-dds"
+                >
+                  <ShieldCheck className="size-[1.1em] shrink-0" />
+                  DDS
+                </MotionButton>
+              </div>
+
+              {isOpenWithHolder && (
+                <div
+                  className={`w-full ${!isAdmin ? 'tooltip tooltip-right' : ''}`}
+                  data-tip="Requires Admin level or higher"
+                >
+                  <MotionButton
+                    className={`${transferActionClass} stats-action-warning`}
+                    disabled={!isAdmin}
+                    onClick={onTransferLockup}
+                    data-testid={TID.dashboard.quickAction.transferLockup}
+                    data-help-id="dashboard.quick-actions.transfer-lockup"
+                  >
+                    <ArrowRightLeft className="size-[1.1em] shrink-0" />
+                    Lockup
+                  </MotionButton>
+                </div>
+              )}
             </div>
-          )}
+          </div>
         </div>
       </div>
     </StatContainer>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Prepares Sentinel v3.4.1 as the next patch release.
- Makes the dashboard quick actions easier to scan by emphasizing Execute Lockup and grouping transfer actions.
- Removes the non-actionable “No active security alerts” banner so the status panel moves up when there are no alerts.
- Keeps active security alerts and alert load failures visible when operator attention is needed.

## Why this change was needed

The dashboard was spending prime space on an all-clear security alert panel and the lockup/transfer controls were visually underpowered. This patch keeps the dashboard focused on current status and the next operational action.

## What changed

### User-facing

- Execute Lockup is larger and uses a soft error treatment at rest, with the normal error color on hover or focus.
- Transfer actions now sit under a Transfer label, with DDS and Lockup buttons split evenly across the action width.
- The security alert area is hidden when there are no active alerts.

### Admin/operator-facing

- Operators will only see the security alert band when alerts exist or when alerts fail to load.
- No operator action is required for the UI change.

### Deployment/update

- Bumps root and workspace package versions to 3.4.1.

### Tests

- Ran version sync checks, targeted ESLint, frontend typecheck, and the full monorepo production build.
- Performed Playwright visual sanity checks at 1920x1080 for the dashboard no-alert and active-alert states.

## User impact

Dashboard users get more vertical space for operational status and presence data when there are no security alerts. Lockup-related actions are easier to find and compare.

## Operator impact

No upgrade action required beyond deploying the patch release.

## Upgrade or migration notes

No database migration, configuration change, or manual operator action is required.

## Risk and rollback notes

Risk is limited to dashboard presentation. Active security alerts still render, and rollback is safe by reverting the patch release.

## Testing performed

- pnpm version:check
- pnpm --dir apps/frontend-admin exec eslint src/components/dashboard/security-alerts-bar.tsx src/app/dashboard/page.tsx
- pnpm --filter frontend-admin typecheck
- pnpm build
- Playwright visual sanity checks at 1920x1080 with mocked dashboard data

## Changelog candidates

- Improved dashboard quick actions so lockup execution and transfer controls are easier to scan.
- Removed the all-clear security alert banner when there are no active alerts.
- Prepared Sentinel v3.4.1 as a patch release.