### PR TITLE
Release v3.4.2

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/repositories/schedule-repository.ts
+++ b/apps/backend/src/repositories/schedule-repository.ts
@@ -1,4 +1,4 @@
-import type { PrismaClientInstance } from '@sentinel/database'
+import type { Prisma, PrismaClientInstance } from '@sentinel/database'
 import { prisma as defaultPrisma } from '@sentinel/database'
 
 // ============================================================================
@@ -200,6 +200,37 @@ export interface ScheduleListFilter {
   offset?: number
 }
 
+export interface ShiftDdsAssignmentsInput {
+  startWeekDate: Date
+  direction: 'forward' | 'backward'
+}
+
+export interface ShiftDdsAssignmentsResult {
+  startWeekDate: Date
+  direction: 'forward' | 'backward'
+  affectedWeeks: number
+  assignmentsMoved: number
+  schedulesCreated: number
+  clearedWeeks: number
+}
+
+type ScheduleDbClient = PrismaClientInstance | Prisma.TransactionClient
+
+interface ShiftSourceAssignment {
+  dutyPositionId: string | null
+  memberId: string
+  status: string
+  confirmedAt: Date | null
+  releasedAt: Date | null
+  notes: string | null
+}
+
+interface ShiftWeekSnapshot {
+  scheduleId: string | null
+  status: string
+  assignment: ShiftSourceAssignment | null
+}
+
 // ============================================================================
 // Prisma Include/Select Definitions
 // ============================================================================
@@ -257,6 +288,16 @@ const overrideInclude = {
       name: true,
     },
   },
+}
+
+function addWeeks(date: Date, weeks: number): Date {
+  const next = new Date(date)
+  next.setUTCDate(next.getUTCDate() + weeks * 7)
+  return next
+}
+
+function toDateKey(date: Date): string {
+  return date.toISOString().substring(0, 10)
 }
 
 /**
@@ -517,6 +558,189 @@ export class ScheduleRepository {
   async deleteSchedule(id: string): Promise<void> {
     await this.prisma.weeklySchedule.delete({
       where: { id },
+    })
+  }
+
+  /**
+   * Shift DDS assignments by one week from the selected week onward.
+   *
+   * Forward shift clears the selected week and pushes every later DDS assignment
+   * one week later. Backward shift pulls later DDS assignments one week earlier
+   * and clears the final populated week.
+   */
+  async shiftDdsAssignments(input: ShiftDdsAssignmentsInput): Promise<ShiftDdsAssignmentsResult> {
+    return this.prisma.$transaction(async (tx) => {
+      const ddsRole = await tx.dutyRole.findUnique({
+        where: { code: 'DDS' },
+      })
+
+      if (!ddsRole) {
+        throw new Error('DDS duty role not found')
+      }
+
+      const schedules = await tx.weeklySchedule.findMany({
+        where: {
+          dutyRoleId: ddsRole.id,
+          weekStartDate: { gte: input.startWeekDate },
+        },
+        include: {
+          ...scheduleInclude,
+          assignments: {
+            where: { status: { not: 'released' } },
+            include: assignmentInclude,
+            orderBy: { createdAt: 'asc' },
+          },
+        },
+        orderBy: { weekStartDate: 'asc' },
+      })
+
+      const populatedSchedules = schedules.filter((schedule) => schedule.assignments.length > 0)
+      if (populatedSchedules.length === 0) {
+        return {
+          startWeekDate: input.startWeekDate,
+          direction: input.direction,
+          affectedWeeks: 0,
+          assignmentsMoved: 0,
+          schedulesCreated: 0,
+          clearedWeeks: 0,
+        }
+      }
+
+      const lastPopulatedSchedule = populatedSchedules[populatedSchedules.length - 1]
+      if (!lastPopulatedSchedule) {
+        throw new Error('Unable to resolve last DDS assignment')
+      }
+
+      const endWeekDate =
+        input.direction === 'forward'
+          ? addWeeks(lastPopulatedSchedule.weekStartDate, 1)
+          : lastPopulatedSchedule.weekStartDate
+
+      const snapshots = new Map<string, ShiftWeekSnapshot>()
+      for (const schedule of schedules) {
+        const assignment = schedule.assignments[0]
+        snapshots.set(toDateKey(schedule.weekStartDate), {
+          scheduleId: schedule.id,
+          status: schedule.status,
+          assignment: assignment
+            ? {
+                dutyPositionId: assignment.dutyPositionId,
+                memberId: assignment.memberId,
+                status: assignment.status,
+                confirmedAt: assignment.confirmedAt,
+                releasedAt: assignment.releasedAt,
+                notes: assignment.notes,
+              }
+            : null,
+        })
+      }
+
+      let affectedWeeks = 0
+      let assignmentsMoved = 0
+      let schedulesCreated = 0
+      let clearedWeeks = 0
+
+      for (
+        let cursor = new Date(input.startWeekDate);
+        cursor <= endWeekDate;
+        cursor = addWeeks(cursor, 1)
+      ) {
+        const targetKey = toDateKey(cursor)
+        const sourceDate =
+          input.direction === 'forward' ? addWeeks(cursor, -1) : addWeeks(cursor, 1)
+        const sourceAssignment =
+          input.direction === 'forward' && targetKey === toDateKey(input.startWeekDate)
+            ? null
+            : (snapshots.get(toDateKey(sourceDate))?.assignment ?? null)
+
+        const targetSnapshot = snapshots.get(targetKey)
+        const scheduleId =
+          targetSnapshot?.scheduleId ??
+          (sourceAssignment
+            ? await this.createDdsScheduleForShift(tx, ddsRole.id, cursor).then((schedule) => {
+                schedulesCreated += 1
+                return schedule.id
+              })
+            : null)
+
+        if (!scheduleId) {
+          continue
+        }
+
+        affectedWeeks += 1
+
+        const existingAssignments = await tx.scheduleAssignment.findMany({
+          where: { scheduleId, status: { not: 'released' } },
+          orderBy: { createdAt: 'asc' },
+        })
+        const primaryAssignment = existingAssignments[0]
+        const extraAssignmentIds = existingAssignments.slice(1).map((assignment) => assignment.id)
+
+        if (extraAssignmentIds.length > 0) {
+          await tx.scheduleAssignment.deleteMany({
+            where: { id: { in: extraAssignmentIds } },
+          })
+        }
+
+        if (!sourceAssignment) {
+          if (primaryAssignment) {
+            await tx.scheduleAssignment.delete({
+              where: { id: primaryAssignment.id },
+            })
+            clearedWeeks += 1
+          }
+          continue
+        }
+
+        const assignmentData = {
+          dutyPositionId: sourceAssignment.dutyPositionId,
+          memberId: sourceAssignment.memberId,
+          status: sourceAssignment.status,
+          confirmedAt: sourceAssignment.confirmedAt,
+          releasedAt: sourceAssignment.releasedAt,
+          notes: sourceAssignment.notes,
+        }
+
+        if (primaryAssignment) {
+          await tx.scheduleAssignment.update({
+            where: { id: primaryAssignment.id },
+            data: assignmentData,
+          })
+        } else {
+          await tx.scheduleAssignment.create({
+            data: {
+              scheduleId,
+              ...assignmentData,
+            },
+          })
+        }
+
+        assignmentsMoved += 1
+      }
+
+      return {
+        startWeekDate: input.startWeekDate,
+        direction: input.direction,
+        affectedWeeks,
+        assignmentsMoved,
+        schedulesCreated,
+        clearedWeeks,
+      }
+    })
+  }
+
+  private async createDdsScheduleForShift(
+    tx: ScheduleDbClient,
+    dutyRoleId: string,
+    weekStartDate: Date
+  ): Promise<{ id: string }> {
+    return tx.weeklySchedule.create({
+      data: {
+        dutyRoleId,
+        weekStartDate,
+        status: 'draft',
+      },
+      select: { id: true },
     })
   }
 

--- a/apps/backend/src/routes/schedules.ts
+++ b/apps/backend/src/routes/schedules.ts
@@ -11,6 +11,7 @@ import type {
   UpdateScheduleInput,
   CreateAssignmentInput,
   UpdateAssignmentInput,
+  ShiftDdsScheduleInput,
   CreateDwOverrideInput,
   DwOverrideParams,
   DwOverrideQuery,
@@ -916,6 +917,43 @@ export const schedulesRouter = s.router(scheduleContract, {
         body: {
           error: 'INTERNAL_ERROR',
           message: error instanceof Error ? error.message : 'Failed to fetch DDS',
+        },
+      }
+    }
+  },
+
+  shiftDdsSchedule: async ({ body }: { body: ShiftDdsScheduleInput }) => {
+    try {
+      const startWeekDate = parseOperationalDate(body.startWeekDate)
+      const result = await scheduleService.shiftDdsSchedule(startWeekDate, body.direction)
+      return {
+        status: 200 as const,
+        body: result,
+      }
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('Invalid')) {
+        return {
+          status: 400 as const,
+          body: {
+            error: 'VALIDATION_ERROR',
+            message: error.message,
+          },
+        }
+      }
+      if (error instanceof Error && error.message.includes('not found')) {
+        return {
+          status: 404 as const,
+          body: {
+            error: 'NOT_FOUND',
+            message: error.message,
+          },
+        }
+      }
+      return {
+        status: 500 as const,
+        body: {
+          error: 'INTERNAL_ERROR',
+          message: error instanceof Error ? error.message : 'Failed to shift DDS schedule',
         },
       }
     }

--- a/apps/backend/src/services/schedule-service.test.ts
+++ b/apps/backend/src/services/schedule-service.test.ts
@@ -26,6 +26,7 @@ interface RepositoryMock {
   findDutyWatchForWeek: ReturnType<typeof vi.fn>
   findOverridesBySchedule: ReturnType<typeof vi.fn>
   findMemberDutyAssignmentsBetween: ReturnType<typeof vi.fn>
+  shiftDdsAssignments: ReturnType<typeof vi.fn>
 }
 
 function createRepositoryMock(): RepositoryMock {
@@ -37,6 +38,7 @@ function createRepositoryMock(): RepositoryMock {
     findDutyWatchForWeek: vi.fn(),
     findOverridesBySchedule: vi.fn(),
     findMemberDutyAssignmentsBetween: vi.fn(),
+    shiftDdsAssignments: vi.fn(),
   }
 }
 
@@ -291,6 +293,47 @@ describe('ScheduleService.getMemberAssignmentSummary', () => {
       expect.any(Date),
       expect.any(Date)
     )
+  })
+})
+
+describe('ScheduleService.shiftDdsSchedule', () => {
+  let repositoryMock: RepositoryMock
+
+  beforeEach(() => {
+    repositoryMock = createRepositoryMock()
+  })
+
+  function createServiceWithRepositoryMock(): ScheduleService {
+    const service = new ScheduleService({} as PrismaClientInstance)
+    ;(service as unknown as { repository: RepositoryMock }).repository = repositoryMock
+    return service
+  }
+
+  it('normalizes the selected week and returns shift metrics', async () => {
+    repositoryMock.shiftDdsAssignments.mockResolvedValue({
+      startWeekDate: new Date('2026-03-02T00:00:00.000Z'),
+      direction: 'forward',
+      affectedWeeks: 4,
+      assignmentsMoved: 3,
+      schedulesCreated: 1,
+      clearedWeeks: 1,
+    })
+
+    const service = createServiceWithRepositoryMock()
+    const result = await service.shiftDdsSchedule(new Date('2026-03-04T00:00:00.000Z'), 'forward')
+
+    expect(repositoryMock.shiftDdsAssignments).toHaveBeenCalledWith({
+      startWeekDate: new Date('2026-03-02T00:00:00.000Z'),
+      direction: 'forward',
+    })
+    expect(result).toEqual({
+      startWeekDate: '2026-03-02',
+      direction: 'forward',
+      affectedWeeks: 4,
+      assignmentsMoved: 3,
+      schedulesCreated: 1,
+      clearedWeeks: 1,
+    })
   })
 })
 

--- a/apps/backend/src/services/schedule-service.ts
+++ b/apps/backend/src/services/schedule-service.ts
@@ -100,6 +100,15 @@ export interface MemberAssignmentSummary {
   upcomingDutyWatchWeeks: string[]
 }
 
+export interface ShiftDdsScheduleResult {
+  startWeekDate: string
+  direction: 'forward' | 'backward'
+  affectedWeeks: number
+  assignmentsMoved: number
+  schedulesCreated: number
+  clearedWeeks: number
+}
+
 const MEMBER_ASSIGNMENT_LOOKAHEAD_WEEKS = 8
 const MEMBER_ASSIGNMENT_PREVIEW_LIMIT = 4
 
@@ -543,6 +552,38 @@ export class ScheduleService {
         status: result.assignment.status as 'assigned' | 'confirmed' | 'released',
       },
       operationalDate,
+    }
+  }
+
+  /**
+   * Shift DDS assignments forward or backward one week from a selected week onward.
+   */
+  async shiftDdsSchedule(
+    startWeekDate: Date,
+    direction: 'forward' | 'backward'
+  ): Promise<ShiftDdsScheduleResult> {
+    const adjustedDate = this.ensureMonday(startWeekDate)
+    const result = await this.repository.shiftDdsAssignments({
+      startWeekDate: adjustedDate,
+      direction,
+    })
+
+    broadcastScheduleUpdate({
+      action: 'updated',
+      scheduleId: 'dds-shift',
+      dutyRoleCode: 'DDS',
+      weekStartDate: adjustedDate.toISOString().substring(0, 10),
+      status: 'updated',
+      timestamp: new Date().toISOString(),
+    })
+
+    return {
+      startWeekDate: result.startWeekDate.toISOString().substring(0, 10),
+      direction: result.direction,
+      affectedWeeks: result.affectedWeeks,
+      assignmentsMoved: result.assignmentsMoved,
+      schedulesCreated: result.schedulesCreated,
+      clearedWeeks: result.clearedWeeks,
     }
   }
 

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/app/dashboard/page.tsx
+++ b/apps/frontend-admin/src/app/dashboard/page.tsx
@@ -3,6 +3,7 @@ import { PersonCardGrid } from '@/components/dashboard/person-card-grid'
 import { DashboardDdsChecklistDrawer } from '@/components/dashboard/dashboard-dds-checklist-drawer'
 import { DashboardHelpLauncher } from '@/components/help/dashboard-help-launcher'
 import { SecurityAlertsBar } from '@/components/dashboard/security-alerts-bar'
+import { DashboardScanPanel } from '@/components/dashboard/dashboard-scan-panel'
 
 export default function DashboardPage() {
   return (
@@ -20,6 +21,9 @@ export default function DashboardPage() {
         </section>
         <section>
           <PersonCardGrid />
+        </section>
+        <section>
+          <DashboardScanPanel />
         </section>
 
         <DashboardHelpLauncher />

--- a/apps/frontend-admin/src/app/schedules/page.tsx
+++ b/apps/frontend-admin/src/app/schedules/page.tsx
@@ -6,14 +6,15 @@ import { AnimatePresence, motion } from 'motion/react'
 import { WeekPicker, type NavigationDirection } from '@/components/schedules/week-picker'
 import { WeekColumn } from '@/components/schedules/week-column'
 import { ScheduleViewTabs, type ScheduleView } from '@/components/schedules/schedule-view-tabs'
-import { MonthPicker } from '@/components/schedules/month-picker'
 import { QuarterPicker } from '@/components/schedules/quarter-picker'
-import { MonthCalendarView } from '@/components/schedules/month-calendar-view'
 import { QuarterView } from '@/components/schedules/quarter-view'
+import { WeeklyDdsPanel } from '@/components/schedules/weekly-dds-panel'
 import { ScheduleErrorBoundary } from '@/components/schedules/error-boundary'
+import { ModalProvider } from '@/components/schedules/modals/modal-context'
+import { DdsModal } from '@/components/schedules/modals/dds-modal'
 import { SchedulesHelpLauncher } from '@/components/help/section-help-launchers'
 import { CalendarDays } from 'lucide-react'
-import { getMonday, formatDateISO, getQuarterStart, parseDateString } from '@/lib/date-utils'
+import { getMonday, formatDateISO, parseDateString } from '@/lib/date-utils'
 import { usePrefersReducedMotion } from '@/hooks/use-prefers-reduced-motion'
 
 const EASE_STANDARD: [number, number, number, number] = [0.25, 0.1, 0.25, 1]
@@ -64,11 +65,9 @@ export default function SchedulesPage() {
     return formatDateISO(addDays(current, 7))
   }, [weekStartDate])
 
-  // Month view state
-  const [currentMonth, setCurrentMonth] = useState(() => startOfMonth(new Date()))
-
-  // Quarter view state
-  const [quarterStart, setQuarterStart] = useState(() => getQuarterStart(new Date()))
+  // Monthly range view state
+  const [monthlyRangeStart, setMonthlyRangeStart] = useState(() => startOfMonth(new Date()))
+  const ddsPanelStartDate = useMemo(() => formatDateISO(getMonday(new Date())), [])
 
   const handleWeekChange = (newDate: string, dir: NavigationDirection) => {
     setDirection(dir)
@@ -102,14 +101,12 @@ export default function SchedulesPage() {
               <WeekPicker weekStartDate={weekStartDate} onWeekChange={handleWeekChange} />
             </div>
           )}
-          {activeView === 'month' && (
+          {activeView === 'monthly' && (
             <div data-help-id="schedules.date-picker">
-              <MonthPicker currentMonth={currentMonth} onMonthChange={setCurrentMonth} />
-            </div>
-          )}
-          {activeView === 'quarter' && (
-            <div data-help-id="schedules.date-picker">
-              <QuarterPicker quarterStart={quarterStart} onQuarterChange={setQuarterStart} />
+              <QuarterPicker
+                quarterStart={monthlyRangeStart}
+                onQuarterChange={setMonthlyRangeStart}
+              />
             </div>
           )}
         </div>
@@ -119,35 +116,38 @@ export default function SchedulesPage() {
       <div id="schedule-view-panel" role="tabpanel">
         <ScheduleErrorBoundary>
           {activeView === 'week' && (
-            <AnimatePresence mode="wait" custom={direction}>
-              <motion.div
-                key={weekStartDate}
-                custom={direction}
-                variants={activeVariants}
-                initial="initial"
-                animate="animate"
-                exit="exit"
-                className="grid grid-cols-1 lg:grid-cols-2 gap-6"
-                data-help-id="schedules.week-columns"
-              >
-                <WeekColumn weekStartDate={weekStartDate} />
-                <WeekColumn weekStartDate={nextWeekStartDate} />
-              </motion.div>
-            </AnimatePresence>
+            <ModalProvider>
+              <AnimatePresence mode="wait" custom={direction}>
+                <motion.div
+                  key={weekStartDate}
+                  custom={direction}
+                  variants={activeVariants}
+                  initial="initial"
+                  animate="animate"
+                  exit="exit"
+                  className="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(17rem,21rem)_minmax(0,1fr)]"
+                  data-help-id="schedules.week-columns"
+                >
+                  <WeeklyDdsPanel
+                    startWeekDate={ddsPanelStartDate}
+                    selectedWeekDate={weekStartDate}
+                  />
+                  <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+                    <WeekColumn weekStartDate={weekStartDate} />
+                    <WeekColumn weekStartDate={nextWeekStartDate} />
+                  </div>
+                </motion.div>
+              </AnimatePresence>
+              <DdsModal />
+            </ModalProvider>
           )}
 
-          {activeView === 'month' && (
+          {activeView === 'monthly' && (
             <div data-help-id="schedules.month-quarter-view">
-              <MonthCalendarView
-                currentMonth={currentMonth}
+              <QuarterView
+                quarterStart={monthlyRangeStart}
                 onWeekClick={handleWeekClickFromCalendar}
               />
-            </div>
-          )}
-
-          {activeView === 'quarter' && (
-            <div data-help-id="schedules.month-quarter-view">
-              <QuarterView quarterStart={quarterStart} onWeekClick={handleWeekClickFromCalendar} />
             </div>
           )}
         </ScheduleErrorBoundary>

--- a/apps/frontend-admin/src/components/dashboard/dashboard-scan-panel.tsx
+++ b/apps/frontend-admin/src/components/dashboard/dashboard-scan-panel.tsx
@@ -1,0 +1,467 @@
+'use client'
+
+/* global HTMLInputElement */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { BadgeCheck, CircleAlert, Keyboard, LogIn, LogOut } from 'lucide-react'
+import { LockupOptionsModal } from '@/components/lockup/lockup-options-modal'
+import { AppCard, AppCardContent } from '@/components/ui/AppCard'
+import { useCheckoutOptions } from '@/hooks/use-lockup'
+import { apiClient } from '@/lib/api-client'
+import { invalidateDashboardQueries } from '@/lib/dashboard-query-invalidation'
+import { TID } from '@/lib/test-ids'
+import { cn } from '@/lib/utils'
+import {
+  createMemberCheckin,
+  extractErrorMessage,
+  formatTimestamp,
+  toMemberName,
+  type ScanDirection,
+  type ResultTone,
+} from '@/components/kiosk/kiosk-domain'
+
+const DASHBOARD_BROW_KIOSK_ID = 'DASHBOARD_BROW'
+
+type DashboardScanMutationResult =
+  | {
+      type: 'member'
+      serial: string
+      memberId: string
+      memberName: string
+      direction: ScanDirection
+      timestamp: string
+    }
+  | {
+      type: 'temporary_personnel'
+      serial: string
+      displayName: string
+      assignmentName: string
+      direction: ScanDirection
+      timestamp: string
+    }
+  | {
+      type: 'visitor'
+      serial: string
+      message: string
+    }
+  | {
+      type: 'lockup'
+      serial: string
+      memberId: string
+      memberName: string
+      badgeId: string
+      message: string
+    }
+
+interface PendingDashboardLockup {
+  memberId: string
+  memberName: string
+  badgeId: string
+  serial: string
+}
+
+interface DashboardScanResult {
+  tone: ResultTone
+  eyebrow: string
+  title: string
+  message: string
+  direction?: ScanDirection
+  timestamp?: string
+}
+
+const INITIAL_SCAN_RESULT: DashboardScanResult = {
+  tone: 'neutral',
+  eyebrow: 'Ready',
+  title: 'Brow scanner',
+  message: 'Awaiting badge scan.',
+}
+
+function getResultSurfaceClass(tone: ResultTone): string {
+  if (tone === 'success') return 'border-success/30 bg-success-fadded text-base-content'
+  if (tone === 'warning') return 'border-warning/35 bg-warning-fadded text-base-content'
+  if (tone === 'error') return 'border-error/35 bg-error-fadded text-base-content'
+  if (tone === 'info') return 'border-info/30 bg-info-fadded text-base-content'
+  return 'border-base-300 bg-base-200/60 text-base-content'
+}
+
+function getDirectionIcon(direction: ScanDirection | undefined, tone: ResultTone) {
+  if (direction === 'in') return <LogIn className="size-5 shrink-0 text-success" />
+  if (direction === 'out') return <LogOut className="size-5 shrink-0 text-error" />
+  if (tone === 'error' || tone === 'warning') {
+    return <CircleAlert className="size-5 shrink-0 text-current" />
+  }
+  return <BadgeCheck className="size-5 shrink-0 text-info" />
+}
+
+export function DashboardScanPanel() {
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const queryClient = useQueryClient()
+  const [serial, setSerial] = useState('')
+  const [result, setResult] = useState<DashboardScanResult>(INITIAL_SCAN_RESULT)
+  const [pendingLockup, setPendingLockup] = useState<PendingDashboardLockup | null>(null)
+  const [lockupOptionsOpen, setLockupOptionsOpen] = useState(false)
+  const { data: checkoutOptions } = useCheckoutOptions(pendingLockup?.memberId ?? '')
+
+  const refocusInput = useCallback(() => {
+    window.setTimeout(() => inputRef.current?.focus({ preventScroll: true }), 0)
+  }, [])
+
+  const refreshDashboard = () => {
+    queryClient.invalidateQueries({ queryKey: ['checkins'] })
+    queryClient.invalidateQueries({ queryKey: ['recent-checkins'] })
+    queryClient.invalidateQueries({ queryKey: ['recent-activity'] })
+    void invalidateDashboardQueries(queryClient)
+  }
+
+  const scanMutation = useMutation({
+    mutationFn: async (rawSerial: string): Promise<DashboardScanMutationResult> => {
+      const scannedSerial = rawSerial.trim()
+      if (!scannedSerial) {
+        throw new Error('Badge serial is required.')
+      }
+
+      const badgeResponse = await apiClient.badges.getBadgeBySerialNumber({
+        params: { serialNumber: scannedSerial },
+      })
+
+      if (badgeResponse.status !== 200) {
+        throw new Error(extractErrorMessage(badgeResponse.body, 'Badge lookup failed.'))
+      }
+
+      const badge = badgeResponse.body
+
+      if (badge.status !== 'active') {
+        throw new Error(`Badge is ${badge.status}.`)
+      }
+
+      if (badge.assignmentType === 'visitor') {
+        return {
+          type: 'visitor',
+          serial: scannedSerial,
+          message: 'Use visitor sign-in for visitor badges.',
+        }
+      }
+
+      if (badge.assignmentType === 'temporary_personnel') {
+        const scanResponse = await apiClient.temporaryPersonnel.scan({
+          body: {
+            serialNumber: scannedSerial,
+            kioskId: DASHBOARD_BROW_KIOSK_ID,
+          },
+        })
+
+        if (scanResponse.status !== 200) {
+          throw new Error(
+            extractErrorMessage(scanResponse.body, 'Temporary personnel scan failed.')
+          )
+        }
+
+        return {
+          type: 'temporary_personnel',
+          serial: scannedSerial,
+          displayName: scanResponse.body.temporaryPersonnel.displayName,
+          assignmentName: scanResponse.body.assignment.name,
+          direction: scanResponse.body.direction,
+          timestamp: scanResponse.body.checkin.timestamp,
+        }
+      }
+
+      if (badge.assignmentType !== 'member' || !badge.assignedToId) {
+        throw new Error('Badge is not assigned to a member.')
+      }
+
+      const memberId = badge.assignedToId
+      const memberName = badge.assignedTo?.name ?? 'Assigned member'
+      const latestResponse = await apiClient.checkins.getCheckins({
+        query: {
+          memberId,
+          page: '1',
+          limit: '1',
+        },
+      })
+
+      if (latestResponse.status !== 200) {
+        throw new Error(extractErrorMessage(latestResponse.body, 'Unable to determine direction.'))
+      }
+
+      const lastDirection = latestResponse.body.checkins[0]?.direction
+      const direction: ScanDirection = lastDirection === 'in' ? 'out' : 'in'
+      const createResult = await createMemberCheckin({
+        memberId,
+        badgeId: badge.id,
+        direction,
+        kioskId: DASHBOARD_BROW_KIOSK_ID,
+        method: 'badge',
+        timestamp: new Date().toISOString(),
+      })
+
+      if (createResult.kind === 'lockup') {
+        return {
+          type: 'lockup',
+          serial: scannedSerial,
+          memberId,
+          memberName,
+          badgeId: badge.id,
+          message: createResult.message,
+        }
+      }
+
+      return {
+        type: 'member',
+        serial: scannedSerial,
+        memberId,
+        memberName: toMemberName(createResult.checkin, memberName),
+        direction: createResult.checkin.direction === 'out' ? 'out' : 'in',
+        timestamp: createResult.checkin.timestamp,
+      }
+    },
+    onSuccess: (scanResult) => {
+      setSerial('')
+
+      if (scanResult.type === 'visitor') {
+        setPendingLockup(null)
+        setLockupOptionsOpen(false)
+        setResult({
+          tone: 'warning',
+          eyebrow: 'Visitor badge',
+          title: 'Visitor flow required',
+          message: scanResult.message,
+          timestamp: new Date().toISOString(),
+        })
+        refocusInput()
+        return
+      }
+
+      if (scanResult.type === 'lockup') {
+        setPendingLockup({
+          memberId: scanResult.memberId,
+          memberName: scanResult.memberName,
+          badgeId: scanResult.badgeId,
+          serial: scanResult.serial,
+        })
+        setLockupOptionsOpen(true)
+        setResult({
+          tone: 'warning',
+          eyebrow: 'Lockup hold',
+          title: scanResult.memberName,
+          message: scanResult.message,
+          direction: 'out',
+          timestamp: new Date().toISOString(),
+        })
+        refocusInput()
+        return
+      }
+
+      if (scanResult.type === 'temporary_personnel') {
+        setPendingLockup(null)
+        setLockupOptionsOpen(false)
+        setResult({
+          tone: scanResult.direction === 'in' ? 'success' : 'error',
+          eyebrow:
+            scanResult.direction === 'in'
+              ? 'Temporary check-in recorded'
+              : 'Temporary check-out recorded',
+          title: scanResult.displayName,
+          message: `${scanResult.assignmentName} - ${scanResult.direction === 'in' ? 'arrived' : 'departed'} at ${formatTimestamp(scanResult.timestamp)}.`,
+          direction: scanResult.direction,
+          timestamp: scanResult.timestamp,
+        })
+        refreshDashboard()
+        refocusInput()
+        return
+      }
+
+      setPendingLockup(null)
+      setLockupOptionsOpen(false)
+      setResult({
+        tone: scanResult.direction === 'in' ? 'success' : 'error',
+        eyebrow: scanResult.direction === 'in' ? 'Check-in recorded' : 'Check-out recorded',
+        title: scanResult.memberName,
+        message: `${scanResult.direction === 'in' ? 'Arrived' : 'Departed'} at ${formatTimestamp(scanResult.timestamp)}.`,
+        direction: scanResult.direction,
+        timestamp: scanResult.timestamp,
+      })
+      refreshDashboard()
+      refocusInput()
+    },
+    onError: (error) => {
+      setSerial('')
+      setPendingLockup(null)
+      setLockupOptionsOpen(false)
+      setResult({
+        tone: 'error',
+        eyebrow: 'Scan rejected',
+        title: 'Badge not accepted',
+        message: error instanceof Error ? error.message : 'Badge scan failed.',
+        timestamp: new Date().toISOString(),
+      })
+      refocusInput()
+    },
+  })
+
+  useEffect(() => {
+    refocusInput()
+  }, [refocusInput])
+
+  useEffect(() => {
+    if (!scanMutation.isPending && !lockupOptionsOpen) {
+      refocusInput()
+    }
+  }, [lockupOptionsOpen, refocusInput, scanMutation.isPending])
+
+  const handleSubmit = () => {
+    if (scanMutation.isPending) return
+
+    const liveSerial = inputRef.current?.value ?? serial
+    if (!liveSerial.trim()) return
+
+    setPendingLockup(null)
+    setLockupOptionsOpen(false)
+    scanMutation.mutate(liveSerial)
+  }
+
+  const handleLockupCheckoutComplete = async (action: 'transfer' | 'execute') => {
+    if (!pendingLockup) return
+
+    const checkout = pendingLockup
+
+    if (action === 'execute') {
+      setPendingLockup(null)
+      setLockupOptionsOpen(false)
+      setResult({
+        tone: 'warning',
+        eyebrow: 'Lockup completed',
+        title: `${checkout.memberName} checked out`,
+        message: 'Building lockup was executed and the building is secured.',
+        direction: 'out',
+        timestamp: new Date().toISOString(),
+      })
+      refreshDashboard()
+      refocusInput()
+      return
+    }
+
+    try {
+      const createResult = await createMemberCheckin({
+        memberId: checkout.memberId,
+        badgeId: checkout.badgeId,
+        direction: 'out',
+        kioskId: DASHBOARD_BROW_KIOSK_ID,
+        method: 'badge',
+      })
+
+      if (createResult.kind === 'lockup') {
+        setLockupOptionsOpen(true)
+        setResult({
+          tone: 'warning',
+          eyebrow: 'Lockup hold',
+          title: checkout.memberName,
+          message: createResult.message,
+          direction: 'out',
+          timestamp: new Date().toISOString(),
+        })
+        return
+      }
+
+      setPendingLockup(null)
+      setLockupOptionsOpen(false)
+      setResult({
+        tone: 'error',
+        eyebrow: 'Check-out recorded',
+        title: toMemberName(createResult.checkin, checkout.memberName),
+        message: `Departed at ${formatTimestamp(createResult.checkin.timestamp)}.`,
+        direction: 'out',
+        timestamp: createResult.checkin.timestamp,
+      })
+      refreshDashboard()
+      refocusInput()
+    } catch (error) {
+      setPendingLockup(null)
+      setLockupOptionsOpen(false)
+      setResult({
+        tone: 'error',
+        eyebrow: 'Checkout failed',
+        title: 'Unable to finish checkout',
+        message: error instanceof Error ? error.message : 'Failed to complete checkout.',
+        direction: 'out',
+        timestamp: new Date().toISOString(),
+      })
+      refocusInput()
+    }
+  }
+
+  return (
+    <>
+      <AppCard
+        className="border border-base-300 bg-base-100 shadow-md"
+        data-help-id="dashboard.scan-panel"
+      >
+        <AppCardContent style={{ padding: 'var(--space-3)' }}>
+          <form
+            className={cn(
+              'grid min-h-24 items-center gap-(--space-3) rounded-box border px-(--space-4) py-(--space-3) lg:grid-cols-[auto_minmax(0,1fr)_minmax(16rem,24rem)]',
+              getResultSurfaceClass(result.tone)
+            )}
+            onSubmit={(event) => {
+              event.preventDefault()
+              handleSubmit()
+            }}
+            data-testid={TID.dashboard.scan.result}
+          >
+            {getDirectionIcon(result.direction, result.tone)}
+            <div
+              className="min-w-0"
+              role={result.tone === 'error' || result.tone === 'warning' ? 'alert' : 'status'}
+              aria-live={
+                result.tone === 'error' || result.tone === 'warning' ? 'assertive' : 'polite'
+              }
+            >
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-base-content/60">
+                {result.eyebrow}
+              </p>
+              <p className="mt-(--space-1) truncate text-lg font-semibold leading-tight">
+                {result.title}
+              </p>
+              <p className="mt-(--space-1) text-sm leading-5 text-base-content/75">
+                {result.message}
+              </p>
+            </div>
+            <label className="input input-sm flex h-10 w-full items-center gap-(--space-2) border-base-300 bg-base-100 lg:justify-self-end">
+              <Keyboard className="size-4 shrink-0 text-base-content/45" />
+              <input
+                ref={inputRef}
+                value={serial}
+                type="text"
+                autoComplete="off"
+                aria-label="Scan badge"
+                className="min-w-0 flex-1 font-mono text-sm tracking-[0.12em] uppercase placeholder:normal-case placeholder:tracking-normal"
+                placeholder="Scan badge"
+                disabled={scanMutation.isPending}
+                onChange={(event) => setSerial(event.target.value)}
+                data-testid={TID.dashboard.scan.input}
+              />
+            </label>
+          </form>
+        </AppCardContent>
+      </AppCard>
+
+      {pendingLockup && checkoutOptions && (
+        <LockupOptionsModal
+          open={lockupOptionsOpen}
+          onOpenChange={(open) => {
+            setLockupOptionsOpen(open)
+            if (!open) {
+              setPendingLockup(null)
+              refocusInput()
+            }
+          }}
+          memberId={pendingLockup.memberId}
+          memberName={pendingLockup.memberName}
+          checkoutOptions={checkoutOptions}
+          onCheckoutComplete={handleLockupCheckoutComplete}
+        />
+      )}
+    </>
+  )
+}

--- a/apps/frontend-admin/src/components/schedules/quarter-picker.tsx
+++ b/apps/frontend-admin/src/components/schedules/quarter-picker.tsx
@@ -4,17 +4,17 @@ import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { format, addMonths, subMonths } from 'date-fns'
 
 /**
- * Quarter navigation component for viewing 3-month periods.
+ * Month range navigation component for viewing six-month periods.
  *
  * @example
  * ```tsx
- * const [quarterStart, setQuarterStart] = useState(startOfQuarter(new Date()))
- * <QuarterPicker quarterStart={quarterStart} onQuarterChange={setQuarterStart} />
+ * const [rangeStart, setRangeStart] = useState(startOfMonth(new Date()))
+ * <QuarterPicker quarterStart={rangeStart} onQuarterChange={setRangeStart} />
  * ```
  */
 
 interface QuarterPickerProps {
-  /** First day of the first month in quarter */
+  /** First day of the first month in range */
   quarterStart: Date
   /** Callback when quarter changes */
   onQuarterChange: (start: Date) => void
@@ -30,8 +30,12 @@ export function QuarterPicker({ quarterStart, onQuarterChange }: QuarterPickerPr
   }
 
   const year = format(quarterStart, 'yyyy')
-  const endMonth = addMonths(quarterStart, 2)
-  const quarterLabel = `${format(quarterStart, 'MMM')} - ${format(endMonth, 'MMM')} ${year}`
+  const endMonth = addMonths(quarterStart, 5)
+  const endYear = format(endMonth, 'yyyy')
+  const quarterLabel =
+    year === endYear
+      ? `${format(quarterStart, 'MMM')} - ${format(endMonth, 'MMM')} ${year}`
+      : `${format(quarterStart, 'MMM yyyy')} - ${format(endMonth, 'MMM yyyy')}`
   const shortLabel = `${format(quarterStart, 'MMM')} - ${format(endMonth, 'MMM')}`
 
   return (

--- a/apps/frontend-admin/src/components/schedules/quarter-view.tsx
+++ b/apps/frontend-admin/src/components/schedules/quarter-view.tsx
@@ -222,11 +222,18 @@ function HoverDetail({
 
 export function QuarterView({ quarterStart, onWeekClick }: QuarterViewProps) {
   const months = useMemo(
-    () => [quarterStart, addMonths(quarterStart, 1), addMonths(quarterStart, 2)],
+    () => [
+      quarterStart,
+      addMonths(quarterStart, 1),
+      addMonths(quarterStart, 2),
+      addMonths(quarterStart, 3),
+      addMonths(quarterStart, 4),
+      addMonths(quarterStart, 5),
+    ],
     [quarterStart]
   )
 
-  const quarterEnd = endOfMonth(addMonths(quarterStart, 2))
+  const quarterEnd = endOfMonth(addMonths(quarterStart, 5))
   const gridStart = startOfWeek(quarterStart, { weekStartsOn: 1 })
   const gridEnd = addDays(startOfWeek(addDays(quarterEnd, 1), { weekStartsOn: 1 }), -3)
 
@@ -316,7 +323,7 @@ export function QuarterView({ quarterStart, onWeekClick }: QuarterViewProps) {
     return (
       <AppCard status="error">
         <AppCardHeader>
-          <AppCardTitle>Quarter View</AppCardTitle>
+          <AppCardTitle>Monthly View</AppCardTitle>
         </AppCardHeader>
         <AppCardContent>
           <div className="flex items-center gap-2 text-error">

--- a/apps/frontend-admin/src/components/schedules/schedule-view-tabs.tsx
+++ b/apps/frontend-admin/src/components/schedules/schedule-view-tabs.tsx
@@ -10,7 +10,7 @@
  * ```
  */
 
-export type ScheduleView = 'week' | 'month' | 'quarter'
+export type ScheduleView = 'week' | 'monthly'
 
 interface ScheduleViewTabsProps {
   /** Currently active view */
@@ -39,23 +39,13 @@ export function ScheduleViewTabs({ activeView, onViewChange }: ScheduleViewTabsP
       </button>
       <button
         role="tab"
-        className={`tab ${activeView === 'month' ? 'tab-active' : ''}`}
-        onClick={() => onViewChange('month')}
-        aria-selected={activeView === 'month'}
+        className={`tab ${activeView === 'monthly' ? 'tab-active' : ''}`}
+        onClick={() => onViewChange('monthly')}
+        aria-selected={activeView === 'monthly'}
         aria-controls="schedule-view-panel"
         type="button"
       >
-        Month
-      </button>
-      <button
-        role="tab"
-        className={`tab ${activeView === 'quarter' ? 'tab-active' : ''}`}
-        onClick={() => onViewChange('quarter')}
-        aria-selected={activeView === 'quarter'}
-        aria-controls="schedule-view-panel"
-        type="button"
-      >
-        Quarter
+        Monthly
       </button>
     </div>
   )

--- a/apps/frontend-admin/src/components/schedules/weekly-dds-panel.tsx
+++ b/apps/frontend-admin/src/components/schedules/weekly-dds-panel.tsx
@@ -1,0 +1,243 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { useQueries } from '@tanstack/react-query'
+import { addDays, format } from 'date-fns'
+import { ArrowDown, ArrowUp, CalendarClock, UserRound } from 'lucide-react'
+import { toast } from 'sonner'
+import { AppBadge } from '@/components/ui/AppBadge'
+import { AppCard, AppCardContent, AppCardHeader, AppCardTitle } from '@/components/ui/AppCard'
+import { ButtonSpinner } from '@/components/ui/loading-spinner'
+import { scheduleKeys, useShiftDdsSchedule } from '@/hooks/use-schedules'
+import { apiClient } from '@/lib/api-client'
+import { formatDateISO, parseDateString } from '@/lib/date-utils'
+import { cn } from '@/lib/utils'
+import { useModalContext } from './modals/modal-context'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+
+const DDS_PANEL_WEEK_COUNT = 24
+
+interface WeeklyDdsPanelProps {
+  startWeekDate: string
+  selectedWeekDate: string
+}
+
+interface PendingShift {
+  weekStartDate: string
+  direction: 'forward' | 'backward'
+}
+
+function formatWeekLabel(weekStartDate: string): string {
+  const startDate = parseDateString(weekStartDate)
+  return format(startDate, 'MMM d')
+}
+
+function formatMemberName(
+  member:
+    | {
+        rank: string
+        firstName: string
+        lastName: string
+      }
+    | undefined
+): string {
+  if (!member) return 'Assign DDS'
+  return `${member.rank} ${member.lastName}, ${member.firstName}`
+}
+
+function getShiftDescription(pendingShift: PendingShift | null): string {
+  if (!pendingShift) return ''
+
+  const weekLabel = formatWeekLabel(pendingShift.weekStartDate)
+  if (pendingShift.direction === 'forward') {
+    return `This clears ${weekLabel} and moves each later DDS assignment one week down the list.`
+  }
+
+  return `This pulls later DDS assignments one week up the list starting at ${weekLabel}.`
+}
+
+export function WeeklyDdsPanel({ startWeekDate, selectedWeekDate }: WeeklyDdsPanelProps) {
+  const { openDdsModal } = useModalContext()
+  const shiftDdsSchedule = useShiftDdsSchedule()
+  const [pendingShift, setPendingShift] = useState<PendingShift | null>(null)
+
+  const weekDateStrings = useMemo(() => {
+    const startDate = parseDateString(startWeekDate)
+    return Array.from({ length: DDS_PANEL_WEEK_COUNT }, (_, index) =>
+      formatDateISO(addDays(startDate, index * 7))
+    )
+  }, [startWeekDate])
+
+  const weekQueries = useQueries({
+    queries: weekDateStrings.map((date) => ({
+      queryKey: scheduleKeys.week(date),
+      queryFn: async () => {
+        const response = await apiClient.schedules.getSchedulesByWeek({
+          params: { date },
+        })
+        if (response.status !== 200) {
+          throw new Error('Failed to fetch schedules for week')
+        }
+        return response.body
+      },
+      enabled: !!date,
+    })),
+  })
+
+  const isLoading = weekQueries.some((query) => query.isLoading)
+  const isError = weekQueries.some((query) => query.isError)
+
+  const handleConfirmShift = async () => {
+    if (!pendingShift) return
+
+    const shift = pendingShift
+
+    try {
+      const result = await shiftDdsSchedule.mutateAsync({
+        startWeekDate: shift.weekStartDate,
+        direction: shift.direction,
+      })
+      toast.success(
+        `DDS schedule shifted ${result.direction}; ${result.assignmentsMoved} assignment${result.assignmentsMoved === 1 ? '' : 's'} moved.`
+      )
+      setPendingShift(null)
+      if (shift.direction === 'forward') {
+        openDdsModal(shift.weekStartDate)
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to shift DDS schedule'
+      toast.error(message)
+    }
+  }
+
+  return (
+    <>
+      <AppCard className="h-fit" data-help-id="schedules.weekly-dds-panel">
+        <AppCardHeader>
+          <AppCardTitle className="flex items-center gap-(--space-2) text-base">
+            <CalendarClock className="size-5 text-info" />
+            DDS sequence
+          </AppCardTitle>
+        </AppCardHeader>
+        <AppCardContent className="p-0">
+          {isLoading && (
+            <div className="flex h-32 items-center justify-center">
+              <span className="loading loading-dots loading-md" aria-label="Loading DDS list" />
+            </div>
+          )}
+
+          {isError && (
+            <div className="p-(--space-4) text-sm text-error">Failed to load DDS sequence.</div>
+          )}
+
+          {!isLoading && !isError && (
+            <div className="max-h-[calc(100vh-10rem)] overflow-y-auto">
+              <table className="table table-xs">
+                <tbody>
+                  {weekDateStrings.map((weekStartDate, index) => {
+                    const schedules = weekQueries[index]?.data?.data ?? []
+                    const ddsSchedule = schedules.find(
+                      (schedule) => schedule.dutyRole.code === 'DDS'
+                    )
+                    const assignment = ddsSchedule?.assignments.find(
+                      (item) => item.status !== 'released'
+                    )
+                    const isSelected = weekStartDate === selectedWeekDate
+
+                    return (
+                      <tr
+                        key={weekStartDate}
+                        className={cn(
+                          'cursor-pointer align-middle hover:bg-base-200/70',
+                          isSelected && 'bg-primary-fadded text-primary-fadded-content'
+                        )}
+                        onClick={() => openDdsModal(weekStartDate)}
+                      >
+                        <td className="w-20">
+                          <div className="font-mono text-xs">{formatWeekLabel(weekStartDate)}</div>
+                          {ddsSchedule?.status === 'draft' && (
+                            <AppBadge status="warning" size="sm">
+                              Draft
+                            </AppBadge>
+                          )}
+                        </td>
+                        <td className="min-w-0">
+                          <div className="flex min-w-0 items-center gap-(--space-2)">
+                            <UserRound className="size-4 shrink-0 text-base-content/55" />
+                            <span className="truncate text-sm font-medium">
+                              {formatMemberName(assignment?.member)}
+                            </span>
+                          </div>
+                        </td>
+                        <td className="w-20">
+                          <div className="flex justify-end gap-(--space-1)">
+                            <button
+                              type="button"
+                              className="btn btn-ghost btn-xs btn-square"
+                              title="Shift DDS backward from this week"
+                              disabled={shiftDdsSchedule.isPending}
+                              onClick={(event) => {
+                                event.stopPropagation()
+                                setPendingShift({ weekStartDate, direction: 'backward' })
+                              }}
+                            >
+                              <ArrowUp className="size-3.5" />
+                            </button>
+                            <button
+                              type="button"
+                              className="btn btn-ghost btn-xs btn-square"
+                              title="Shift DDS forward from this week"
+                              disabled={shiftDdsSchedule.isPending}
+                              onClick={(event) => {
+                                event.stopPropagation()
+                                setPendingShift({ weekStartDate, direction: 'forward' })
+                              }}
+                            >
+                              <ArrowDown className="size-3.5" />
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </AppCardContent>
+      </AppCard>
+
+      <AlertDialog
+        open={pendingShift !== null}
+        onOpenChange={(open) => !open && setPendingShift(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Shift DDS schedule?</AlertDialogTitle>
+            <AlertDialogDescription>{getShiftDescription(pendingShift)}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={shiftDdsSchedule.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirmShift}
+              disabled={shiftDdsSchedule.isPending}
+              className="btn-primary"
+            >
+              {shiftDdsSchedule.isPending && <ButtonSpinner />}
+              Shift
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}

--- a/apps/frontend-admin/src/hooks/use-schedules.ts
+++ b/apps/frontend-admin/src/hooks/use-schedules.ts
@@ -10,6 +10,7 @@ import type {
   UpdateScheduleInput,
   CreateAssignmentInput,
   UpdateAssignmentInput,
+  ShiftDdsScheduleInput,
   CreateDwOverrideInput,
   CreateLiveDutyAssignmentInput,
   ClearLiveDutyAssignmentInput,
@@ -424,6 +425,28 @@ export function useDdsByWeek(date: string) {
       return response.body
     },
     enabled: !!date,
+  })
+}
+
+export function useShiftDdsSchedule() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (data: ShiftDdsScheduleInput) => {
+      const response = await apiClient.schedules.shiftDdsSchedule({
+        body: data,
+      })
+      if (response.status !== 200) {
+        const errorBody = response.body as { message?: string }
+        throw new Error(errorBody?.message ?? 'Failed to shift DDS schedule')
+      }
+      return response.body
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: scheduleKeys.all })
+      queryClient.invalidateQueries({ queryKey: ['dds'] })
+      void invalidateDashboardQueries(queryClient)
+    },
   })
 }
 

--- a/apps/frontend-admin/src/lib/test-ids.ts
+++ b/apps/frontend-admin/src/lib/test-ids.ts
@@ -342,6 +342,10 @@ export const TID = {
       transferLockup: 'quick-action-transfer-lockup',
       simulateScan: 'quick-action-simulate-scan',
     },
+    scan: {
+      input: 'dashboard-scan-input',
+      result: 'dashboard-scan-result',
+    },
     kiosk: {
       launchTab: 'dashboard-kiosk-launch-tab',
       badgeInput: 'kiosk-badge-input',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/contracts/src/contracts/schedule.contract.ts
+++ b/packages/contracts/src/contracts/schedule.contract.ts
@@ -11,6 +11,8 @@ import {
   UpdateScheduleInputSchema,
   CreateAssignmentInputSchema,
   UpdateAssignmentInputSchema,
+  ShiftDdsScheduleInputSchema,
+  ShiftDdsScheduleResponseSchema,
   ScheduleListQuerySchema,
   DateParamSchema, // from lockup.schema.ts
   ScheduleIdParamSchema,
@@ -376,6 +378,25 @@ export const scheduleContract = c.router({
     },
     summary: 'Get DDS by week',
     description: 'Get DDS for the week containing the specified date',
+  },
+
+  /**
+   * Shift DDS assignments by one week from a selected week onward
+   */
+  shiftDdsSchedule: {
+    method: 'POST',
+    path: '/api/schedules/dds/shift',
+    body: ShiftDdsScheduleInputSchema,
+    responses: {
+      200: ShiftDdsScheduleResponseSchema,
+      400: ErrorResponseSchema,
+      401: ErrorResponseSchema,
+      404: ErrorResponseSchema,
+      500: ErrorResponseSchema,
+    },
+    summary: 'Shift DDS schedule',
+    description:
+      'Shift DDS assignments forward or backward by one week from a selected week onward.',
   },
 
   // ==========================================================================

--- a/packages/contracts/src/schemas/schedule.schema.ts
+++ b/packages/contracts/src/schemas/schedule.schema.ts
@@ -223,6 +223,26 @@ export const UpdateAssignmentInputSchema = v.object({
   notes: v.optional(v.nullable(v.string())),
 })
 
+/**
+ * Shift DDS assignments forward or backward by one week from a selected week.
+ */
+export const ShiftDdsScheduleInputSchema = v.object({
+  startWeekDate: v.pipe(
+    v.string('Start week date is required'),
+    v.regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format')
+  ),
+  direction: v.picklist(['forward', 'backward']),
+})
+
+export const ShiftDdsScheduleResponseSchema = v.object({
+  startWeekDate: v.string(),
+  direction: v.picklist(['forward', 'backward']),
+  affectedWeeks: v.number(),
+  assignmentsMoved: v.number(),
+  schedulesCreated: v.number(),
+  clearedWeeks: v.number(),
+})
+
 // ============================================================================
 // Query Schemas
 // ============================================================================
@@ -390,6 +410,8 @@ export type CreateScheduleInput = v.InferOutput<typeof CreateScheduleInputSchema
 export type UpdateScheduleInput = v.InferOutput<typeof UpdateScheduleInputSchema>
 export type CreateAssignmentInput = v.InferOutput<typeof CreateAssignmentInputSchema>
 export type UpdateAssignmentInput = v.InferOutput<typeof UpdateAssignmentInputSchema>
+export type ShiftDdsScheduleInput = v.InferOutput<typeof ShiftDdsScheduleInputSchema>
+export type ShiftDdsScheduleResponse = v.InferOutput<typeof ShiftDdsScheduleResponseSchema>
 export type ScheduleListQuery = v.InferOutput<typeof ScheduleListQuerySchema>
 // DateParam type is exported from lockup.schema.ts
 export type ScheduleIdParam = v.InferOutput<typeof ScheduleIdParamSchema>

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Adds a compact Brow scan panel to the Dashboard so staff can scan members from the dashboard workstation.
- Reworks Schedules to use Week and six-month Monthly views, removing the old month view.
- Adds a DDS sequence panel with forward/back shift actions for inserting or removing DDS weeks without manually editing every later week.
- Prepares the Sentinel workspace for patch release `v3.4.2`.

## Why this change was needed

Brow staff were keeping the kiosk page open on both front-entrance and dashboard workstations, which made it harder to monitor dashboard issues while members scanned in. The Schedules page also needed a faster way to manage DDS rotations when adding or changing a week mid-sequence.

## What changed

### User-facing

- Dashboard now includes a smaller badge scan input and result panel at the bottom of the page.
- Schedules now has `Week` and `Monthly` tabs only.
- The Monthly view shows six months at once.
- Weekly view includes a DDS sequence list from the current week onward.
- DDS sequence dates show only the start date, without the year.
- DDS sequence rows can open the DDS assignment modal.
- Shift buttons can move DDS assignments forward or backward from the selected week.

### Admin/operator-facing

- Operators must deploy the matching backend with the matching frontend. The shift UI calls the new `POST /api/schedules/dds/shift` endpoint, so an older backend will respond with `Cannot POST`.

### Backend/API

- Adds `POST /api/schedules/dds/shift` to shift DDS assignments forward or backward from a selected week.
- Adds contract schemas for the shift request and response.
- Adds repository/service logic to move, create, and clear DDS assignments in a transaction.

### Database

- No schema migration required.

### Deployment/update

- Workspace package versions are bumped to `3.4.2`.

### Tests

- Adds service coverage for DDS schedule shifting.

## User impact

Members can scan at either the entrance kiosk or the Brow dashboard workstation. Brow staff can keep the operational dashboard visible while still processing scans.

## Operator impact

Schedule managers can shift a DDS rotation instead of manually changing every later DDS assignment. Operators should update backend and frontend together for this patch.

## Upgrade or migration notes

No database migration required. Deploy the backend and frontend from the same `v3.4.2` release.

## Risk and rollback notes

The main compatibility risk is running the new frontend against an older backend. Verify the deployed backend includes `POST /api/schedules/dds/shift` before using the shift buttons. Rollback is safe because no database schema change is included, but any DDS assignment changes made through the new shift action are real schedule data and should be reviewed before rollback.

## Testing performed

- `pnpm --filter @sentinel/contracts build`
- `pnpm --filter @sentinel/backend typecheck`
- `pnpm --filter frontend-admin typecheck`
- `pnpm --filter @sentinel/backend build`
- `pnpm --filter frontend-admin build`
- `pnpm build`
- Targeted backend ESLint on touched schedule files
- Targeted frontend ESLint on touched dashboard/schedule files
- `pnpm version:check`
- In-process backend route probe confirmed `POST /api/schedules/dds/shift` is mounted
- `playwright-cli` visual sanity check at `1920x1080` with mocked API data confirmed no horizontal overflow, clean console, and successful shift POST interaction

## Changelog candidates

- Added Dashboard badge scanning for Brow staff.
- Added a DDS sequence panel and one-click schedule shifting on the Schedules page.
- Replaced the old Schedules month/quarter views with Week and six-month Monthly views.