### PR TITLE
Release v3.4.3

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/app/dashboard/page.tsx
+++ b/apps/frontend-admin/src/app/dashboard/page.tsx
@@ -8,10 +8,7 @@ import { DashboardScanPanel } from '@/components/dashboard/dashboard-scan-panel'
 export default function DashboardPage() {
   return (
     <DashboardDdsChecklistDrawer>
-      <main
-        className="mx-auto w-full max-w-[1600px] space-y-6 pb-24 sm:pb-20"
-        data-help-id="dashboard.root"
-      >
+      <main className="mx-auto w-full max-w-[1760px] space-y-6 pb-44" data-help-id="dashboard.root">
         <h1 className="sr-only">Dashboard</h1>
 
         <SecurityAlertsBar />
@@ -22,12 +19,10 @@ export default function DashboardPage() {
         <section>
           <PersonCardGrid />
         </section>
-        <section>
-          <DashboardScanPanel />
-        </section>
 
         <DashboardHelpLauncher />
       </main>
+      <DashboardScanPanel />
     </DashboardDdsChecklistDrawer>
   )
 }

--- a/apps/frontend-admin/src/app/globals.css
+++ b/apps/frontend-admin/src/app/globals.css
@@ -787,8 +787,7 @@ html[data-theme='business'] .backend-status-badge {
 
 /* Person card grid: container-query-based columns
    Self-contained — no dependency on drawer/layout ancestor classes.
-   With 290px sidebar on 1920px screen: container ≈ 1550px → 6 cols
-   Without sidebar on 1920px screen: container ≈ 1840px → 7 cols */
+   With the widened dashboard on a 1920px screen: container ≈ 1720px → 6 cols */
 .presence-card-grid {
   grid-template-columns: repeat(2, 1fr);
 }
@@ -817,9 +816,15 @@ html[data-theme='business'] .backend-status-badge {
   }
 }
 
-@container (min-width: 1650px) {
+@container (min-width: 1540px) {
   .presence-card-grid {
     grid-template-columns: repeat(6, 1fr);
+  }
+}
+
+@container (min-width: 1840px) {
+  .presence-card-grid {
+    grid-template-columns: repeat(7, 1fr);
   }
 }
 

--- a/apps/frontend-admin/src/components/dashboard/dashboard-scan-panel.tsx
+++ b/apps/frontend-admin/src/components/dashboard/dashboard-scan-panel.tsx
@@ -22,6 +22,19 @@ import {
 } from '@/components/kiosk/kiosk-domain'
 
 const DASHBOARD_BROW_KIOSK_ID = 'DASHBOARD_BROW'
+const SCAN_RESULT_VISIBLE_MS = 4000
+const SCAN_INPUT_REFOCUS_MS = 1500
+const FOCUS_HOLD_SELECTOR = [
+  `input:not([data-testid="${TID.dashboard.scan.input}"])`,
+  'textarea',
+  'select',
+  '[contenteditable="true"]',
+].join(',')
+const ACTIVE_WORK_SURFACE_SELECTOR = [
+  '.modal[open]',
+  '.presence-member-drawer[data-open="true"]',
+  `[data-testid="${TID.dashboard.help.launcher}"] [aria-expanded="true"]`,
+].join(',')
 
 type DashboardScanMutationResult =
   | {
@@ -75,6 +88,29 @@ const INITIAL_SCAN_RESULT: DashboardScanResult = {
   eyebrow: 'Ready',
   title: 'Brow scanner',
   message: 'Awaiting badge scan.',
+}
+
+function isInitialScanResult(result: DashboardScanResult): boolean {
+  return (
+    result.tone === INITIAL_SCAN_RESULT.tone &&
+    result.eyebrow === INITIAL_SCAN_RESULT.eyebrow &&
+    result.title === INITIAL_SCAN_RESULT.title &&
+    result.message === INITIAL_SCAN_RESULT.message
+  )
+}
+
+function shouldRefocusScanInput(input: HTMLInputElement | null): boolean {
+  if (!input || document.hidden) return false
+  if (document.querySelector(ACTIVE_WORK_SURFACE_SELECTOR)) return false
+
+  const activeElement = document.activeElement
+  if (activeElement === input) return false
+
+  if (activeElement instanceof HTMLElement) {
+    return !activeElement.closest(FOCUS_HOLD_SELECTOR)
+  }
+
+  return true
 }
 
 function getResultSurfaceClass(tone: ResultTone): string {
@@ -310,6 +346,37 @@ export function DashboardScanPanel() {
     }
   }, [lockupOptionsOpen, refocusInput, scanMutation.isPending])
 
+  useEffect(() => {
+    if (scanMutation.isPending || lockupOptionsOpen) return
+
+    const refocusWhenIdle = () => {
+      if (shouldRefocusScanInput(inputRef.current)) {
+        inputRef.current?.focus({ preventScroll: true })
+      }
+    }
+
+    const intervalId = window.setInterval(refocusWhenIdle, SCAN_INPUT_REFOCUS_MS)
+
+    window.addEventListener('focus', refocusWhenIdle)
+    document.addEventListener('visibilitychange', refocusWhenIdle)
+
+    return () => {
+      window.clearInterval(intervalId)
+      window.removeEventListener('focus', refocusWhenIdle)
+      document.removeEventListener('visibilitychange', refocusWhenIdle)
+    }
+  }, [lockupOptionsOpen, scanMutation.isPending])
+
+  useEffect(() => {
+    if (lockupOptionsOpen || isInitialScanResult(result)) return
+
+    const clearResult = window.setTimeout(() => {
+      setResult(INITIAL_SCAN_RESULT)
+    }, SCAN_RESULT_VISIBLE_MS)
+
+    return () => window.clearTimeout(clearResult)
+  }, [lockupOptionsOpen, result])
+
   const handleSubmit = () => {
     if (scanMutation.isPending) return
 
@@ -393,58 +460,60 @@ export function DashboardScanPanel() {
 
   return (
     <>
-      <AppCard
-        className="border border-base-300 bg-base-100 shadow-md"
-        data-help-id="dashboard.scan-panel"
-      >
-        <AppCardContent style={{ padding: 'var(--space-3)' }}>
-          <form
-            className={cn(
-              'grid min-h-24 items-center gap-(--space-3) rounded-box border px-(--space-4) py-(--space-3) lg:grid-cols-[auto_minmax(0,1fr)_minmax(16rem,24rem)]',
-              getResultSurfaceClass(result.tone)
-            )}
-            onSubmit={(event) => {
-              event.preventDefault()
-              handleSubmit()
-            }}
-            data-testid={TID.dashboard.scan.result}
-          >
-            {getDirectionIcon(result.direction, result.tone)}
-            <div
-              className="min-w-0"
-              role={result.tone === 'error' || result.tone === 'warning' ? 'alert' : 'status'}
-              aria-live={
-                result.tone === 'error' || result.tone === 'warning' ? 'assertive' : 'polite'
-              }
+      <div className="pointer-events-none fixed inset-x-0 bottom-0 z-(--z-sticky) px-(--space-4) pb-(--space-4) lg:px-(--space-6)">
+        <AppCard
+          className="pointer-events-auto mx-auto w-full max-w-[1760px] border border-base-300 bg-base-100 shadow-[var(--shadow-3)]"
+          data-help-id="dashboard.scan-panel"
+        >
+          <AppCardContent style={{ padding: 'var(--space-3)' }}>
+            <form
+              className={cn(
+                'grid min-h-20 items-center gap-(--space-3) rounded-box border px-(--space-4) py-(--space-3) lg:grid-cols-[auto_minmax(0,1fr)_minmax(18rem,24rem)]',
+                getResultSurfaceClass(result.tone)
+              )}
+              onSubmit={(event) => {
+                event.preventDefault()
+                handleSubmit()
+              }}
+              data-testid={TID.dashboard.scan.result}
             >
-              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-base-content/60">
-                {result.eyebrow}
-              </p>
-              <p className="mt-(--space-1) truncate text-lg font-semibold leading-tight">
-                {result.title}
-              </p>
-              <p className="mt-(--space-1) text-sm leading-5 text-base-content/75">
-                {result.message}
-              </p>
-            </div>
-            <label className="input input-sm flex h-10 w-full items-center gap-(--space-2) border-base-300 bg-base-100 lg:justify-self-end">
-              <Keyboard className="size-4 shrink-0 text-base-content/45" />
-              <input
-                ref={inputRef}
-                value={serial}
-                type="text"
-                autoComplete="off"
-                aria-label="Scan badge"
-                className="min-w-0 flex-1 font-mono text-sm tracking-[0.12em] uppercase placeholder:normal-case placeholder:tracking-normal"
-                placeholder="Scan badge"
-                disabled={scanMutation.isPending}
-                onChange={(event) => setSerial(event.target.value)}
-                data-testid={TID.dashboard.scan.input}
-              />
-            </label>
-          </form>
-        </AppCardContent>
-      </AppCard>
+              {getDirectionIcon(result.direction, result.tone)}
+              <div
+                className="min-w-0"
+                role={result.tone === 'error' || result.tone === 'warning' ? 'alert' : 'status'}
+                aria-live={
+                  result.tone === 'error' || result.tone === 'warning' ? 'assertive' : 'polite'
+                }
+              >
+                <p className="text-xs font-semibold uppercase tracking-[0.16em] text-base-content/60">
+                  {result.eyebrow}
+                </p>
+                <p className="mt-(--space-1) truncate text-lg font-semibold leading-tight">
+                  {result.title}
+                </p>
+                <p className="mt-(--space-1) text-sm leading-5 text-base-content/75">
+                  {result.message}
+                </p>
+              </div>
+              <label className="input input-sm flex h-10 w-full items-center gap-(--space-2) border-base-300 bg-base-100 lg:justify-self-end">
+                <Keyboard className="size-4 shrink-0 text-base-content/45" />
+                <input
+                  ref={inputRef}
+                  value={serial}
+                  type="text"
+                  autoComplete="off"
+                  aria-label="Scan badge"
+                  className="min-w-0 flex-1 font-mono text-sm tracking-[0.12em] uppercase placeholder:normal-case placeholder:tracking-normal"
+                  placeholder="Scan badge"
+                  disabled={scanMutation.isPending}
+                  onChange={(event) => setSerial(event.target.value)}
+                  data-testid={TID.dashboard.scan.input}
+                />
+              </label>
+            </form>
+          </AppCardContent>
+        </AppCard>
+      </div>
 
       {pendingLockup && checkoutOptions && (
         <LockupOptionsModal

--- a/apps/frontend-admin/src/components/help/dashboard-help-launcher.tsx
+++ b/apps/frontend-admin/src/components/help/dashboard-help-launcher.tsx
@@ -37,6 +37,7 @@ export function DashboardHelpLauncher() {
       procedures={dashboardProcedureDefinitions}
       minAccountLevel={AccountLevel.ADMIN}
       testId={TID.dashboard.help.launcher}
+      launcherClassName="sm:bottom-40"
     />
   )
 }

--- a/apps/frontend-admin/src/components/help/procedure-help-launcher.tsx
+++ b/apps/frontend-admin/src/components/help/procedure-help-launcher.tsx
@@ -11,6 +11,7 @@ import { DriverJsProcedureDriver } from '@/help/driver-adapter'
 import { subscribeHelpTourRequest } from '@/help/help-events'
 import { loadProcedureProgress } from '@/help/persistence'
 import { useAuthStore } from '@/store/auth-store'
+import { cn } from '@/lib/utils'
 import type {
   ProcedureController,
   ProcedureDefinition,
@@ -34,6 +35,7 @@ interface ProcedureHelpLauncherProps {
   procedures: ProcedureDefinition[]
   minAccountLevel?: number
   testId?: string
+  launcherClassName?: string
 }
 
 function getBadgeStatus(status?: ProcedureStatus): AppBadgeStatus {
@@ -64,6 +66,7 @@ export function ProcedureHelpLauncher({
   procedures,
   minAccountLevel = 0,
   testId,
+  launcherClassName,
 }: ProcedureHelpLauncherProps) {
   const pathname = usePathname()
   const member = useAuthStore((state) => state.member)
@@ -170,7 +173,10 @@ export function ProcedureHelpLauncher({
 
   return (
     <div
-      className="fixed bottom-3 left-3 right-3 z-(--z-sticky) hidden sm:block sm:bottom-20 sm:left-auto sm:right-6"
+      className={cn(
+        'fixed bottom-3 left-3 right-3 z-(--z-sticky) hidden sm:block sm:left-auto sm:right-6',
+        launcherClassName ?? 'sm:bottom-20'
+      )}
       data-testid={testId}
     >
       {!isOpen && (

--- a/deploy/README_DEPLOY.md
+++ b/deploy/README_DEPLOY.md
@@ -260,6 +260,12 @@ This guided flow handles both install and update:
 - runs `/opt/sentinel/deploy/update.sh --version vX.Y.Z`, which is now a compatibility wrapper around the packaged updater.
 - `--no-firewall`
 
+The packaged updater retries transient container image pull failures before it rolls back. It pulls Sentinel
+backend/frontend images first, then pulls the full stack. If a third-party registry briefly fails after all
+required images are already cached locally, the updater records a warning and continues instead of rolling
+back a healthy Sentinel package install. Tune retry behavior with `SENTINEL_IMAGE_PULL_ATTEMPTS` and
+`SENTINEL_IMAGE_PULL_RETRY_DELAY_SECONDS` in the updater environment when needed.
+
 ## Automatic upgrade helper
 
 If you want unattended upgrade checks on the Sentinel server laptop, use:

--- a/deploy/deb/assets/usr/lib/sentinel/sentinel-updater
+++ b/deploy/deb/assets/usr/lib/sentinel/sentinel-updater
@@ -71,6 +71,8 @@ NONINTERACTIVE_ENV = {
 INSTALL_TIMEOUT_SECONDS = int(os.environ.get("SENTINEL_INSTALL_TIMEOUT_SECONDS", "1800"))
 COMMAND_TIMEOUT_SECONDS = int(os.environ.get("SENTINEL_COMMAND_TIMEOUT_SECONDS", "900"))
 HEALTH_TIMEOUT_SECONDS = int(os.environ.get("SENTINEL_HEALTH_TIMEOUT_SECONDS", "240"))
+IMAGE_PULL_ATTEMPTS = int(os.environ.get("SENTINEL_IMAGE_PULL_ATTEMPTS", "3"))
+IMAGE_PULL_RETRY_DELAY_SECONDS = int(os.environ.get("SENTINEL_IMAGE_PULL_RETRY_DELAY_SECONDS", "20"))
 CHECKSUM_NAME_PATTERN = re.compile(r"(sha256|checksum)", re.IGNORECASE)
 TRACE_COMPONENT = "updater"
 UPDATER_UNIT = os.environ.get("SENTINEL_UPDATER_UNIT", "sentinel-updater.service")
@@ -711,6 +713,50 @@ def run_command(
     return result
 
 
+def run_command_with_retries(
+    command: list[str],
+    *,
+    job_logger: JobLogger,
+    timeout: int,
+    step: str,
+    env: dict[str, str] | None = None,
+    attempts: int,
+    retry_delay_seconds: int,
+    retry_context: str,
+) -> subprocess.CompletedProcess[str]:
+    bounded_attempts = max(1, attempts)
+    last_result: subprocess.CompletedProcess[str] | None = None
+    for attempt in range(1, bounded_attempts + 1):
+        if bounded_attempts > 1:
+            job_logger.write_line(f"{retry_context} attempt {attempt} of {bounded_attempts}.")
+            trace("info", f"{retry_context} attempt {attempt} of {bounded_attempts}.")
+
+        last_result = run_command(
+            command,
+            job_logger=job_logger,
+            timeout=timeout,
+            step=step,
+            env=env,
+        )
+        if last_result.returncode == 0 or attempt >= bounded_attempts:
+            return last_result
+
+        job_logger.write_line(
+            f"{retry_context} failed with status {last_result.returncode}; "
+            f"retrying in {retry_delay_seconds}s."
+        )
+        trace(
+            "warning",
+            f"{retry_context} failed with status {last_result.returncode}; "
+            f"retrying in {retry_delay_seconds}s.",
+        )
+        time.sleep(max(0, retry_delay_seconds))
+
+    if last_result is None:
+        raise UpdaterError(step, f"{retry_context} did not run.")
+    return last_result
+
+
 def refreshed_appliance_env(*, overrides: dict[str, str] | None = None) -> dict[str, str]:
     env = dict(os.environ)
     env.update(read_env_file(APPLIANCE_ENV_PATH))
@@ -955,25 +1001,93 @@ def run_backend_post_update(
     trace("info", "Backend post-update commands completed successfully.")
 
 
+def compose_images_available_locally(
+    state: dict[str, Any],
+    command_env: dict[str, str],
+    job_logger: JobLogger,
+) -> bool:
+    config_result = run_command(
+        compose_command(state, "config", "--images"),
+        job_logger=job_logger,
+        timeout=COMMAND_TIMEOUT_SECONDS,
+        step="post_install",
+        env=command_env,
+    )
+    if config_result.returncode != 0:
+        trace("warning", "Could not resolve compose image list after a failed image pull.")
+        return False
+
+    images = list(
+        dict.fromkeys(line.strip() for line in config_result.stdout.splitlines() if line.strip())
+    )
+    if not images:
+        trace("warning", "Compose image list was empty after a failed image pull.")
+        return False
+
+    inspect_result = run_command(
+        ["docker", "image", "inspect", "--format", "{{.Id}}", *images],
+        job_logger=job_logger,
+        timeout=COMMAND_TIMEOUT_SECONDS,
+        step="post_install",
+        env=command_env,
+    )
+    return inspect_result.returncode == 0
+
+
 def pull_stack_images(
     state: dict[str, Any],
     job_logger: JobLogger,
     *,
     version_override: str | None = None,
 ) -> None:
-    trace("info", "Pulling fresh container images for the Sentinel stack.")
     command_env = refreshed_appliance_env(
         overrides={"SENTINEL_VERSION": version_override} if version_override else None
     )
-    pull_result = run_command(
+
+    trace("info", "Pulling Sentinel application container images.")
+    app_pull_result = run_command_with_retries(
+        compose_command(state, "pull", "backend", "frontend"),
+        job_logger=job_logger,
+        timeout=COMMAND_TIMEOUT_SECONDS,
+        step="post_install",
+        env=command_env,
+        attempts=IMAGE_PULL_ATTEMPTS,
+        retry_delay_seconds=IMAGE_PULL_RETRY_DELAY_SECONDS,
+        retry_context="Sentinel application image pull",
+    )
+    if app_pull_result.returncode != 0:
+        raise UpdaterError(
+            "post_install",
+            "docker compose pull failed for Sentinel application images.",
+        )
+
+    trace("info", "Pulling fresh container images for the Sentinel stack.")
+    pull_result = run_command_with_retries(
         compose_command(state, "pull"),
         job_logger=job_logger,
         timeout=COMMAND_TIMEOUT_SECONDS,
         step="post_install",
         env=command_env,
+        attempts=IMAGE_PULL_ATTEMPTS,
+        retry_delay_seconds=IMAGE_PULL_RETRY_DELAY_SECONDS,
+        retry_context="Full stack image pull",
     )
-    if pull_result.returncode != 0:
-        raise UpdaterError("post_install", "docker compose pull failed.")
+    if pull_result.returncode == 0:
+        return
+
+    if compose_images_available_locally(state, command_env, job_logger):
+        message = (
+            "Full stack image pull failed after retries, but every compose image is available "
+            "locally. Continuing with cached third-party images."
+        )
+        job_logger.write_line(message)
+        trace("warning", message)
+        return
+
+    raise UpdaterError(
+        "post_install",
+        "docker compose pull failed and one or more compose images are missing locally.",
+    )
 
 
 def restart_stack_services(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Widens the Dashboard content area and lets Presence show an additional column of person cards on desktop screens.
- Pins the Brow Scan Badge panel to the bottom of the Dashboard so staff can keep scanning while the rest of the page scrolls behind it.
- Automatically returns keyboard focus to the Scan Badge input when the Dashboard is idle, while leaving active forms, modals, drawers, and search fields alone.
- Clears the last scan result after four seconds so stale scan feedback does not sit on the screen.
- Hardens the packaged updater so transient container image pull failures are retried and do not roll back a healthy install when all images are already cached.
- Prepares Sentinel v3.4.3.

## Why this change was needed

Brow staff need the Dashboard visible while USB NFC scanners continue to behave like keyboard input devices. The old scan panel consumed page space and could lose focus during normal Dashboard use. The updater also needed to avoid unnecessary rollback when a package install succeeded but a later image pull hit a temporary registry failure.

## What changed

### User-facing

- Dashboard Presence has more horizontal room and can display six cards per row at 1920px desktop widths.
- The Scan Badge panel is fixed at the bottom of the Dashboard.
- Last Scan feedback resets back to Ready after four seconds.
- Idle Dashboard focus returns to the scan input for keyboard-style NFC scanners.

### Admin/operator-facing

- Dashboard procedure help is moved above the pinned scanner so it remains accessible.
- The updater now retries Sentinel image pulls and full stack image pulls before failing.

### Deployment/update

- The updater pulls Sentinel backend/frontend images first.
- If the full stack pull fails after retries but every compose image is already present locally, the update continues with a warning instead of rolling back.
- Retry behavior can be tuned with `SENTINEL_IMAGE_PULL_ATTEMPTS` and `SENTINEL_IMAGE_PULL_RETRY_DELAY_SECONDS`.

### Documentation

- Deployment notes now document the updater image-pull retry and cached-image behavior.

### Tests

- `pnpm lint` completed with existing warnings and no errors.
- `pnpm typecheck` passed.
- `pnpm build` passed.
- `pnpm version:check` passed for v3.4.3.

## User impact

Brow staff should see more People Cards at once and can keep scanning badges from the Dashboard without leaving the operational overview.

## Operator impact

Appliance updates should be less likely to roll back because of brief container registry or third-party image pull issues after the Sentinel package has already installed successfully.

## Upgrade or migration notes

No database migration required. No manual upgrade action required beyond installing v3.4.3 through the normal updater path.

## Risk and rollback notes

Main risk is focus returning to the scan input sooner than expected when the Dashboard is idle. It intentionally avoids active inputs, modals, drawers, and open help surfaces. Rollback to v3.4.2 is safe if needed.

## Changelog candidates

- Dashboard scan input now stays ready for USB NFC scanners while the Dashboard remains visible.
- Dashboard Presence can show an additional desktop card column.
- Last scan feedback clears automatically after four seconds.
- Updater retries image pulls and can continue with cached images when the full stack is already available locally.
