### PR TITLE
Release v3.4.5

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/services/operational-report-service.test.ts
+++ b/apps/backend/src/services/operational-report-service.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest'
 import type { ReportTagSummary } from '@sentinel/contracts'
 import {
+  dailyPresenceSortableMemberHasTag,
   isStaleForcedCheckoutSession,
   filterReportMemberTagsForScheduledDuty,
   pairOperationalPresenceSessions,
   presenceSessionOverlapsRange,
+  sortDailyPresenceRows,
+  type DailyPresenceSortableRow,
   type PresenceSessionInternal,
 } from './operational-report-service.js'
 import type { OperationalReportCheckinRecord } from '../repositories/operational-report-repository.js'
@@ -30,6 +33,52 @@ function getSessions(
   memberId: string
 ): PresenceSessionInternal[] {
   return sessionsByMember.get(memberId) ?? []
+}
+
+function sortableDailyPresenceRow(input: {
+  id: string
+  firstName: string
+  lastName: string
+  tags?: string[]
+  qualificationTags?: string[]
+  department?: string
+  sessionCount?: number
+}): DailyPresenceSortableRow {
+  const tags = input.tags ?? []
+  const qualificationTags = input.qualificationTags ?? []
+
+  return {
+    memberRecord: {
+      id: input.id,
+      rank: 'S1',
+      firstName: input.firstName,
+      lastName: input.lastName,
+      displayName: `S1 ${input.lastName}, ${input.firstName}`,
+      division: input.department ? { code: input.department, name: input.department } : null,
+      memberTags: tags.map((tagId) => ({ tagId })),
+      qualifications: qualificationTags.map((tagId) => ({
+        qualificationType: { tagId },
+      })),
+    },
+    row: {
+      member: {
+        id: input.id,
+        displayName: `S1 ${input.lastName}, ${input.firstName}`,
+        rank: 'S1',
+        status: 'Active',
+        division: input.department
+          ? { id: input.department, code: input.department, name: input.department }
+          : null,
+        memberType: 'Class A',
+        tags: [],
+      },
+      firstIn: '2026-06-11T13:00:00.000Z',
+      lastOut: null,
+      sessionCount: input.sessionCount ?? 1,
+      leftAndReturned: false,
+      sessions: [],
+    },
+  }
 }
 
 describe('pairOperationalPresenceSessions', () => {
@@ -178,6 +227,70 @@ describe('presenceSessionOverlapsRange', () => {
         asOf
       )
     ).toBe(false)
+  })
+})
+
+describe('sortDailyPresenceRows', () => {
+  const cmdTagId = '11111111-1111-4111-8111-111111111111'
+  const ftsTagId = '22222222-2222-4222-8222-222222222222'
+
+  it('sorts by selected tag priorities before last name', () => {
+    const sorted = sortDailyPresenceRows(
+      [
+        sortableDailyPresenceRow({
+          id: 'reserve-zulu',
+          firstName: 'Zed',
+          lastName: 'Zulu',
+        }),
+        sortableDailyPresenceRow({
+          id: 'fts-alpha',
+          firstName: 'Amy',
+          lastName: 'Alpha',
+          tags: [ftsTagId],
+        }),
+        sortableDailyPresenceRow({
+          id: 'cmd-smith',
+          firstName: 'Sam',
+          lastName: 'Smith',
+          tags: [cmdTagId],
+        }),
+        sortableDailyPresenceRow({
+          id: 'fts-baker',
+          firstName: 'Bill',
+          lastName: 'Baker',
+          tags: [ftsTagId],
+        }),
+        sortableDailyPresenceRow({
+          id: 'reserve-able',
+          firstName: 'Ann',
+          lastName: 'Able',
+        }),
+      ],
+      [
+        { type: 'tag', tagId: cmdTagId, direction: 'asc' },
+        { type: 'tag', tagId: ftsTagId, direction: 'asc' },
+        { type: 'field', field: 'last_name', direction: 'asc' },
+      ]
+    )
+
+    expect(sorted.map((row) => row.memberRecord.id)).toEqual([
+      'cmd-smith',
+      'fts-alpha',
+      'fts-baker',
+      'reserve-able',
+      'reserve-zulu',
+    ])
+  })
+
+  it('matches qualification-backed tags when sorting by tag priority', () => {
+    const member = sortableDailyPresenceRow({
+      id: 'qualified',
+      firstName: 'Quinn',
+      lastName: 'Qualified',
+      qualificationTags: [ftsTagId],
+    }).memberRecord
+
+    expect(dailyPresenceSortableMemberHasTag(member, ftsTagId)).toBe(true)
   })
 })
 

--- a/apps/backend/src/services/operational-report-service.ts
+++ b/apps/backend/src/services/operational-report-service.ts
@@ -1,8 +1,10 @@
 import * as v from 'valibot'
 import { DateTime } from 'luxon'
 import type {
+  DailyPresenceRow,
   DailyPresenceReportConfig,
   DailyPresenceReportResponse,
+  DailyPresenceSortCriterion,
   KeyNight,
   MonthlyPresenceReportConfig,
   MonthlyPresenceReportResponse,
@@ -107,6 +109,22 @@ interface LockupCheckedOutMember {
   name: string
 }
 
+export interface DailyPresenceSortableMember {
+  id: string
+  rank: string
+  firstName: string
+  lastName: string
+  displayName: string | null
+  division: { code: string; name: string } | null
+  memberTags: Array<{ tagId: string }>
+  qualifications: Array<{ qualificationType: { tagId: string | null } }>
+}
+
+export interface DailyPresenceSortableRow {
+  memberRecord: DailyPresenceSortableMember
+  row: DailyPresenceRow
+}
+
 export function getScheduledDutyTagRole(
   tag: ReportTagSummary
 ): OperationalReportScheduledDutyRoleCode | null {
@@ -161,6 +179,109 @@ export function filterReportMemberTagsForScheduledDuty(
     return (
       scheduledRoleCodes.has(requiredRoleCode) ||
       (requiredRoleCode !== 'DDS' && scheduledRoleCodes.has('DUTY_WATCH'))
+    )
+  })
+}
+
+export function dailyPresenceSortableMemberHasTag(
+  member: DailyPresenceSortableMember,
+  tagId: string
+): boolean {
+  return (
+    member.memberTags.some((memberTag) => memberTag.tagId === tagId) ||
+    member.qualifications.some((qualification) => qualification.qualificationType.tagId === tagId)
+  )
+}
+
+function compareNullableString(left: string | null | undefined, right: string | null | undefined) {
+  const leftValue = left?.trim() ?? ''
+  const rightValue = right?.trim() ?? ''
+
+  if (leftValue.length === 0 && rightValue.length > 0) return 1
+  if (leftValue.length > 0 && rightValue.length === 0) return -1
+
+  return leftValue.localeCompare(rightValue, undefined, {
+    sensitivity: 'base',
+    numeric: true,
+  })
+}
+
+function compareDailyPresenceField(
+  left: DailyPresenceSortableRow,
+  right: DailyPresenceSortableRow,
+  field: Extract<DailyPresenceSortCriterion, { type: 'field' }>['field']
+): number {
+  switch (field) {
+    case 'first_name':
+      return (
+        compareNullableString(left.memberRecord.firstName, right.memberRecord.firstName) ||
+        compareNullableString(left.memberRecord.lastName, right.memberRecord.lastName)
+      )
+    case 'department':
+      return (
+        compareNullableString(
+          left.memberRecord.division?.code,
+          right.memberRecord.division?.code
+        ) || compareNullableString(left.memberRecord.lastName, right.memberRecord.lastName)
+      )
+    case 'first_in':
+      return compareNullableString(left.row.firstIn, right.row.firstIn)
+    case 'last_out':
+      return compareNullableString(left.row.lastOut, right.row.lastOut)
+    case 'sessions':
+      return left.row.sessionCount - right.row.sessionCount
+    case 'last_name':
+      return (
+        compareNullableString(left.memberRecord.lastName, right.memberRecord.lastName) ||
+        compareNullableString(left.memberRecord.firstName, right.memberRecord.firstName)
+      )
+  }
+}
+
+function compareDailyPresenceCriterion(
+  left: DailyPresenceSortableRow,
+  right: DailyPresenceSortableRow,
+  criterion: DailyPresenceSortCriterion
+): number {
+  const direction = criterion.direction === 'desc' ? -1 : 1
+
+  if (criterion.type === 'tag') {
+    const leftHasTag = dailyPresenceSortableMemberHasTag(left.memberRecord, criterion.tagId)
+    const rightHasTag = dailyPresenceSortableMemberHasTag(right.memberRecord, criterion.tagId)
+
+    if (leftHasTag === rightHasTag) {
+      return 0
+    }
+
+    return (leftHasTag ? -1 : 1) * direction
+  }
+
+  return compareDailyPresenceField(left, right, criterion.field) * direction
+}
+
+export function sortDailyPresenceRows<T extends DailyPresenceSortableRow>(
+  rows: T[],
+  sort: DailyPresenceSortCriterion[] | undefined
+): T[] {
+  const sortCriteria = sort ?? []
+
+  if (sortCriteria.length === 0) {
+    return rows
+  }
+
+  return [...rows].sort((left, right) => {
+    for (const criterion of sortCriteria) {
+      const result = compareDailyPresenceCriterion(left, right, criterion)
+      if (result !== 0) {
+        return result
+      }
+    }
+
+    return (
+      compareNullableString(left.memberRecord.lastName, right.memberRecord.lastName) ||
+      compareNullableString(left.memberRecord.firstName, right.memberRecord.firstName) ||
+      compareNullableString(left.memberRecord.displayName, right.memberRecord.displayName) ||
+      left.memberRecord.id.localeCompare(right.memberRecord.id)
     )
   })
 }
@@ -303,7 +424,7 @@ export class OperationalReportService {
     const sessionsByMember = await this.getSessionsByMember(members, range, warnings)
     const scheduledDutyRolesByMember = await this.getScheduledDutyRolesByMember(members, range)
 
-    const rows = members
+    const sortableRows = members
       .map((member) => {
         const memberSessions = sessionsByMember.get(member.id) ?? []
         const overlappingSessions = memberSessions.filter((session) =>
@@ -317,17 +438,21 @@ export class OperationalReportService {
         const stats = this.getPresenceStats(overlappingSessions, range.start, range.end)
 
         return {
-          member: this.toMemberSummary(member, scheduledDutyRolesByMember.get(member.id)),
-          firstIn: stats.firstIn,
-          lastOut: stats.lastOut,
-          sessionCount: stats.sessionCount,
-          leftAndReturned: stats.sessionCount > 1,
-          sessions: overlappingSessions.map((session) =>
-            this.toPresenceSession(session, range.start, range.end)
-          ),
+          memberRecord: member,
+          row: {
+            member: this.toMemberSummary(member, scheduledDutyRolesByMember.get(member.id)),
+            firstIn: stats.firstIn,
+            lastOut: stats.lastOut,
+            sessionCount: stats.sessionCount,
+            leftAndReturned: stats.sessionCount > 1,
+            sessions: overlappingSessions.map((session) =>
+              this.toPresenceSession(session, range.start, range.end)
+            ),
+          },
         }
       })
       .filter((row): row is NonNullable<typeof row> => row !== null)
+    const rows = sortDailyPresenceRows(sortableRows, config.sort).map(({ row }) => row)
 
     return {
       ...this.getEnvelopeBase('daily_presence', 'Daily Presence Report', actor, range, {

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/app/globals.css
+++ b/apps/frontend-admin/src/app/globals.css
@@ -266,7 +266,8 @@
 }
 
 @page {
-  margin: 0.45in;
+  size: letter portrait;
+  margin: 0.36in 0.42in;
 }
 
 @page reports-landscape {
@@ -278,6 +279,9 @@
   html,
   body {
     background: white !important;
+    height: auto !important;
+    min-height: 0 !important;
+    overflow: visible !important;
   }
 
   body * {
@@ -297,19 +301,73 @@
     display: inline !important;
   }
 
+  .reports-screen-tag-list {
+    display: none !important;
+  }
+
+  .reports-print-tag-text {
+    display: inline !important;
+  }
+
+  body:has(.reports-print-document)
+    :where(.drawer, .drawer-content, main, section, div):has(.reports-print-document) {
+    display: contents !important;
+    height: auto !important;
+    min-height: 0 !important;
+    margin: 0 !important;
+    overflow: visible !important;
+    padding: 0 !important;
+    background: white !important;
+  }
+
+  body:has(.reports-print-document)
+    :not(:has(.reports-print-document)):not(.reports-print-document):not(
+      .reports-print-document *
+    ) {
+    display: none !important;
+  }
+
   .reports-print-document {
-    position: absolute !important;
-    inset: 0 auto auto 0 !important;
+    position: static !important;
     width: 100% !important;
     border: 0 !important;
     border-radius: 0 !important;
     box-shadow: none !important;
     color: black !important;
     background: white !important;
+    font-size: 8.8pt !important;
+    line-height: 1.14 !important;
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
   }
 
   .reports-print-landscape {
     page: reports-landscape;
+  }
+
+  .reports-print-document > div {
+    padding: 0.1in 0 !important;
+  }
+
+  .reports-print-document > div:first-child {
+    padding-top: 0 !important;
+    padding-bottom: 0.1in !important;
+  }
+
+  .reports-print-document h2 {
+    margin-top: 0.02in !important;
+    font-size: 16pt !important;
+    line-height: 1.05 !important;
+  }
+
+  .reports-print-document p,
+  .reports-print-document dd,
+  .reports-print-document dt {
+    line-height: 1.14 !important;
+  }
+
+  .reports-print-document dl {
+    gap: 0.03in !important;
   }
 
   .reports-summary-grid,
@@ -318,20 +376,114 @@
     break-inside: avoid;
   }
 
+  .reports-summary-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr)) !important;
+    margin-bottom: 0.1in !important;
+    border-radius: 0 !important;
+  }
+
+  .reports-summary-grid > div {
+    padding: 0.06in 0.1in !important;
+  }
+
+  .reports-summary-grid dt {
+    font-size: 7.2pt !important;
+    letter-spacing: 0.02em !important;
+  }
+
+  .reports-summary-grid dd {
+    margin-top: 0.01in !important;
+    font-size: 14pt !important;
+    line-height: 1 !important;
+  }
+
   .reports-table {
     border-collapse: collapse !important;
     width: 100% !important;
-    font-size: 10pt !important;
+    table-layout: fixed !important;
+    font-size: 8pt !important;
+    line-height: 1.12 !important;
   }
 
   .reports-table thead {
     display: table-header-group;
   }
 
+  .reports-table th {
+    color: oklch(37% 0.013 285.805) !important;
+    font-size: 7.4pt !important;
+    font-weight: 700 !important;
+    letter-spacing: 0.02em !important;
+    text-transform: uppercase !important;
+  }
+
   .reports-table th,
   .reports-table td {
     border-bottom: 1px solid oklch(86% 0.005 56.366) !important;
-    padding: 0.18rem 0.25rem !important;
+    padding: 0.038in 0.045in !important;
+    vertical-align: top !important;
+  }
+
+  .reports-table td {
+    overflow-wrap: anywhere !important;
+  }
+
+  .reports-table .reports-time-cell,
+  .reports-table .reports-session-cell {
+    white-space: nowrap !important;
+  }
+
+  .reports-table .reports-member-cell,
+  .reports-table .reports-department-cell,
+  .reports-table .reports-tags-cell {
+    overflow-wrap: normal !important;
+    word-break: normal !important;
+  }
+
+  .reports-table .reports-member-cell p:first-child {
+    font-weight: 700 !important;
+  }
+
+  .reports-table .reports-member-cell p + p {
+    margin-top: 0.01in !important;
+    color: oklch(37% 0.013 285.805) !important;
+    font-size: 6.8pt !important;
+  }
+
+  .reports-daily-member-col {
+    width: 22%;
+  }
+
+  .reports-daily-department-col {
+    width: 11%;
+  }
+
+  .reports-daily-tags-col {
+    width: 23%;
+  }
+
+  .reports-daily-time-col {
+    width: 9%;
+  }
+
+  .reports-daily-last-out-col {
+    width: 11%;
+  }
+
+  .reports-daily-returned-col {
+    width: 12%;
+  }
+
+  .reports-daily-session-col {
+    width: 8%;
+  }
+
+  .reports-daily-presence-table .reports-tags-cell {
+    color: oklch(21% 0.006 285.885) !important;
+  }
+
+  .reports-daily-presence-table .reports-session-cell {
+    text-align: right !important;
   }
 }
 

--- a/apps/frontend-admin/src/components/admin/reports/AdminReportsPage.tsx
+++ b/apps/frontend-admin/src/components/admin/reports/AdminReportsPage.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useMemo, useState } from 'react'
-import { FileText, Play, Printer, RotateCcw } from 'lucide-react'
+import { ArrowDown, ArrowUp, FileText, Play, Plus, Printer, RotateCcw, X } from 'lucide-react'
+import type { DailyPresenceSortCriterion } from '@sentinel/contracts'
 import {
   AppCard,
   AppCardContent,
@@ -25,6 +26,7 @@ import {
   getReportDefinition,
   REPORT_DEFINITIONS,
   type AdminReportType,
+  type DailyPresenceSortRule,
   type ReportFilters,
   type ReportScopeType,
 } from './report-definitions'
@@ -45,6 +47,27 @@ function scopeRequiresTag(scopeType: ReportScopeType): boolean {
   return scopeType === 'tag'
 }
 
+function createDailyPresenceSortRuleId(): string {
+  return `daily-sort-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+function toDailyPresenceSortCriteria(rules: DailyPresenceSortRule[]): DailyPresenceSortCriterion[] {
+  const criteria: DailyPresenceSortCriterion[] = []
+
+  for (const rule of rules) {
+    if (rule.type === 'tag') {
+      if (rule.tagId) {
+        criteria.push({ type: 'tag', tagId: rule.tagId, direction: rule.direction })
+      }
+      continue
+    }
+
+    criteria.push({ type: 'field', field: rule.field, direction: rule.direction })
+  }
+
+  return criteria
+}
+
 function buildRunInput(filters: ReportFilters): RunAdminReportInput {
   const scopeType = filters.scopeType
   const divisionId = scopeRequiresDepartment(scopeType)
@@ -61,6 +84,7 @@ function buildRunInput(filters: ReportFilters): RunAdminReportInput {
           scopeType,
           divisionId,
           tagId,
+          sort: toDailyPresenceSortCriteria(filters.dailyPresenceSort),
         },
       }
     case 'weekly_presence':
@@ -153,6 +177,13 @@ export function AdminReportsPage() {
 
     if (scopeRequiresTag(filters.scopeType) && !filters.tagId) {
       messages.push('Select a tag for the specific tag scope.')
+    }
+
+    if (
+      filters.reportType === 'daily_presence' &&
+      filters.dailyPresenceSort.some((rule) => rule.type === 'tag' && !rule.tagId)
+    ) {
+      messages.push('Select a tag for each tag sort rule.')
     }
 
     if (shortcutWarning) {
@@ -329,6 +360,7 @@ function ReportsFilterPanel({
     visible.has('divisionId') &&
     (filters.reportType === 'training_night_monthly' || filters.scopeType === 'department')
   const showTag = visible.has('tagId') && filters.scopeType === 'tag'
+  const showDailyPresenceSort = visible.has('dailyPresenceSort')
 
   return (
     <div className="grid gap-(--space-3) md:grid-cols-2 xl:grid-cols-3">
@@ -436,6 +468,15 @@ function ReportsFilterPanel({
           </select>
         </label>
       )}
+      {showDailyPresenceSort && (
+        <div className="md:col-span-2 xl:col-span-3">
+          <DailyPresenceSortBuilder
+            rules={filters.dailyPresenceSort}
+            tags={tags}
+            onChange={(dailyPresenceSort) => updateFilters({ dailyPresenceSort })}
+          />
+        </div>
+      )}
       {visible.has('visitType') && (
         <label className="form-control w-full">
           <span className="label pb-(--space-1)">
@@ -519,6 +560,269 @@ function ReportsFilterPanel({
         </label>
       )}
     </div>
+  )
+}
+
+const DAILY_PRESENCE_FIELD_OPTIONS: Array<{
+  value: Extract<DailyPresenceSortCriterion, { type: 'field' }>['field']
+  label: string
+}> = [
+  { value: 'last_name', label: 'Last name' },
+  { value: 'first_name', label: 'First name' },
+  { value: 'department', label: 'Department' },
+  { value: 'first_in', label: 'First in' },
+  { value: 'last_out', label: 'Last out' },
+  { value: 'sessions', label: 'Sessions' },
+]
+
+function DailyPresenceSortBuilder({
+  rules,
+  tags,
+  onChange,
+}: {
+  rules: DailyPresenceSortRule[]
+  tags: Array<{ id: string; name: string }>
+  onChange: (rules: DailyPresenceSortRule[]) => void
+}) {
+  function replaceRule(ruleId: string, nextRule: DailyPresenceSortRule) {
+    onChange(rules.map((rule) => (rule.id === ruleId ? nextRule : rule)))
+  }
+
+  function updateTagRule(
+    ruleId: string,
+    next: Partial<Omit<Extract<DailyPresenceSortRule, { type: 'tag' }>, 'id' | 'type'>>
+  ) {
+    onChange(
+      rules.map((rule) => {
+        if (rule.id !== ruleId || rule.type !== 'tag') {
+          return rule
+        }
+
+        return { ...rule, ...next }
+      })
+    )
+  }
+
+  function updateFieldRule(
+    ruleId: string,
+    next: Partial<Omit<Extract<DailyPresenceSortRule, { type: 'field' }>, 'id' | 'type'>>
+  ) {
+    onChange(
+      rules.map((rule) => {
+        if (rule.id !== ruleId || rule.type !== 'field') {
+          return rule
+        }
+
+        return { ...rule, ...next }
+      })
+    )
+  }
+
+  function moveRule(ruleId: string, direction: -1 | 1) {
+    const currentIndex = rules.findIndex((rule) => rule.id === ruleId)
+    const nextIndex = currentIndex + direction
+    if (currentIndex < 0 || nextIndex < 0 || nextIndex >= rules.length) {
+      return
+    }
+
+    const nextRules = [...rules]
+    const [rule] = nextRules.splice(currentIndex, 1)
+    if (!rule) {
+      return
+    }
+    nextRules.splice(nextIndex, 0, rule)
+    onChange(nextRules)
+  }
+
+  function removeRule(ruleId: string) {
+    onChange(rules.filter((rule) => rule.id !== ruleId))
+  }
+
+  function addTagRule() {
+    const tag = tags[0]
+    if (!tag) {
+      return
+    }
+
+    const nextRule: DailyPresenceSortRule = {
+      id: createDailyPresenceSortRuleId(),
+      type: 'tag',
+      tagId: tag.id,
+      direction: 'asc',
+    }
+    const firstFieldIndex = rules.findIndex((rule) => rule.type === 'field')
+
+    if (firstFieldIndex === -1) {
+      onChange([...rules, nextRule])
+      return
+    }
+
+    onChange([...rules.slice(0, firstFieldIndex), nextRule, ...rules.slice(firstFieldIndex)])
+  }
+
+  function addFieldRule() {
+    onChange([
+      ...rules,
+      {
+        id: createDailyPresenceSortRuleId(),
+        type: 'field',
+        field: 'last_name',
+        direction: 'asc',
+      },
+    ])
+  }
+
+  return (
+    <fieldset className="rounded-box border border-base-300 bg-base-200/45 p-(--space-3)">
+      <div className="flex flex-wrap items-start justify-between gap-(--space-3)">
+        <div>
+          <legend className="font-semibold">Sort order</legend>
+          <p className="mt-(--space-1) text-sm text-base-content/65">
+            Rules run from top to bottom. Add tag priorities first, then a name or time field.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-(--space-2)">
+          <button
+            type="button"
+            className="btn btn-outline btn-sm"
+            onClick={addTagRule}
+            disabled={tags.length === 0}
+          >
+            <Plus className="h-4 w-4" aria-hidden="true" />
+            Tag priority
+          </button>
+          <button type="button" className="btn btn-outline btn-sm" onClick={addFieldRule}>
+            <Plus className="h-4 w-4" aria-hidden="true" />
+            Field sort
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-(--space-3) space-y-(--space-2)">
+        {rules.length === 0 ? (
+          <p className="rounded-box border border-dashed border-base-300 bg-base-100 p-(--space-3) text-sm text-base-content/60">
+            No custom sort rules. The report will use the backend default order.
+          </p>
+        ) : (
+          rules.map((rule, index) => (
+            <div
+              key={rule.id}
+              className="grid items-center gap-(--space-2) rounded-box border border-base-300 bg-base-100 p-(--space-2) md:grid-cols-[2rem_8rem_minmax(0,1fr)_8rem_auto]"
+            >
+              <span className="text-center text-xs font-semibold text-base-content/55">
+                {index + 1}
+              </span>
+              <select
+                className="select select-bordered select-sm w-full"
+                value={rule.type}
+                onChange={(event) => {
+                  if (event.target.value === 'tag') {
+                    const tag = tags[0]
+                    if (!tag) return
+                    replaceRule(rule.id, {
+                      id: rule.id,
+                      type: 'tag',
+                      tagId: tag.id,
+                      direction: 'asc',
+                    })
+                    return
+                  }
+
+                  replaceRule(rule.id, {
+                    id: rule.id,
+                    type: 'field',
+                    field: 'last_name',
+                    direction: 'asc',
+                  })
+                }}
+              >
+                <option value="tag">Tag</option>
+                <option value="field">Field</option>
+              </select>
+
+              {rule.type === 'tag' ? (
+                <select
+                  className="select select-bordered select-sm w-full"
+                  value={rule.tagId}
+                  onChange={(event) => updateTagRule(rule.id, { tagId: event.target.value })}
+                >
+                  {tags.map((tag) => (
+                    <option key={tag.id} value={tag.id}>
+                      {tag.name}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <select
+                  className="select select-bordered select-sm w-full"
+                  value={rule.field}
+                  onChange={(event) =>
+                    updateFieldRule(rule.id, {
+                      field: event.target.value as Extract<
+                        DailyPresenceSortCriterion,
+                        { type: 'field' }
+                      >['field'],
+                    })
+                  }
+                >
+                  {DAILY_PRESENCE_FIELD_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              )}
+
+              <select
+                className="select select-bordered select-sm w-full"
+                value={rule.direction}
+                onChange={(event) =>
+                  rule.type === 'tag'
+                    ? updateTagRule(rule.id, {
+                        direction: event.target.value as DailyPresenceSortCriterion['direction'],
+                      })
+                    : updateFieldRule(rule.id, {
+                        direction: event.target.value as DailyPresenceSortCriterion['direction'],
+                      })
+                }
+              >
+                <option value="asc">{rule.type === 'tag' ? 'First' : 'A to Z'}</option>
+                <option value="desc">{rule.type === 'tag' ? 'Last' : 'Z to A'}</option>
+              </select>
+
+              <div className="flex items-center justify-end gap-(--space-1)">
+                <button
+                  type="button"
+                  className="btn btn-ghost btn-square btn-sm"
+                  onClick={() => moveRule(rule.id, -1)}
+                  disabled={index === 0}
+                  aria-label="Move sort rule up"
+                >
+                  <ArrowUp className="h-4 w-4" aria-hidden="true" />
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-ghost btn-square btn-sm"
+                  onClick={() => moveRule(rule.id, 1)}
+                  disabled={index === rules.length - 1}
+                  aria-label="Move sort rule down"
+                >
+                  <ArrowDown className="h-4 w-4" aria-hidden="true" />
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-ghost btn-square btn-sm text-error"
+                  onClick={() => removeRule(rule.id)}
+                  aria-label="Remove sort rule"
+                >
+                  <X className="h-4 w-4" aria-hidden="true" />
+                </button>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </fieldset>
   )
 }
 

--- a/apps/frontend-admin/src/components/admin/reports/report-definitions.ts
+++ b/apps/frontend-admin/src/components/admin/reports/report-definitions.ts
@@ -1,4 +1,5 @@
 import { addDays, endOfMonth, format, startOfMonth, startOfWeek } from 'date-fns'
+import type { DailyPresenceSortCriterion } from '@sentinel/contracts'
 
 export type AdminReportType =
   | 'daily_presence'
@@ -24,6 +25,17 @@ export type ReportFilterKey =
   | 'eventLinked'
   | 'hostMemberId'
   | 'organization'
+  | 'dailyPresenceSort'
+
+export type DailyPresenceTagSortRule = Extract<DailyPresenceSortCriterion, { type: 'tag' }> & {
+  id: string
+}
+
+export type DailyPresenceFieldSortRule = Extract<DailyPresenceSortCriterion, { type: 'field' }> & {
+  id: string
+}
+
+export type DailyPresenceSortRule = DailyPresenceTagSortRule | DailyPresenceFieldSortRule
 
 export interface ReportFilters {
   reportType: AdminReportType
@@ -40,6 +52,7 @@ export interface ReportFilters {
   eventLinked: 'all' | 'linked' | 'unlinked'
   hostMemberId: string
   organization: string
+  dailyPresenceSort: DailyPresenceSortRule[]
 }
 
 export interface ReportDefinition {
@@ -98,6 +111,14 @@ export function getBaseReportFilters(reportType: AdminReportType): ReportFilters
     eventLinked: 'all',
     hostMemberId: '',
     organization: '',
+    dailyPresenceSort: [
+      {
+        id: 'daily-sort-last-name',
+        type: 'field',
+        field: 'last_name',
+        direction: 'asc',
+      },
+    ],
   }
 }
 
@@ -108,7 +129,7 @@ export const REPORT_DEFINITIONS = [
     description: 'Who was present on a selected day, including first arrival and final departure.',
     defaultFilters: () => getBaseReportFilters('daily_presence'),
     requiredFilters: ['date'],
-    visibleFilters: ['date', 'scopeType', 'divisionId', 'tagId'],
+    visibleFilters: ['date', 'scopeType', 'divisionId', 'tagId', 'dailyPresenceSort'],
     runMutation: 'generateDailyPresence',
     previewComponent: 'DailyPresenceReport',
   },

--- a/apps/frontend-admin/src/components/admin/reports/report-preview.tsx
+++ b/apps/frontend-admin/src/components/admin/reports/report-preview.tsx
@@ -259,7 +259,16 @@ function DailyPresenceReport({ report }: { report: DailyPresenceReportResponse }
         />
       ) : (
         <div className="overflow-x-auto">
-          <table className="table table-sm reports-table">
+          <table className="table table-sm reports-table reports-daily-presence-table">
+            <colgroup>
+              <col className="reports-daily-member-col" />
+              <col className="reports-daily-department-col" />
+              <col className="reports-daily-tags-col" />
+              <col className="reports-daily-time-col" />
+              <col className="reports-daily-last-out-col" />
+              <col className="reports-daily-returned-col" />
+              <col className="reports-daily-session-col" />
+            </colgroup>
             <thead>
               <tr>
                 <th>Member</th>
@@ -267,30 +276,44 @@ function DailyPresenceReport({ report }: { report: DailyPresenceReportResponse }
                 <th>Tags</th>
                 <th>First in</th>
                 <th>Last out</th>
-                <th>Left / returned</th>
-                <th>Sessions</th>
+                <th>Returned</th>
+                <th className="text-right">Sessions</th>
               </tr>
             </thead>
             <tbody>
               {rows.map((row) => (
                 <tr key={row.member.id}>
-                  <td>
+                  <td className="reports-member-cell">
                     <MemberName member={row.member} />
                   </td>
-                  <td>{row.member.division?.code ?? row.member.division?.name ?? 'Unassigned'}</td>
-                  <td>
+                  <td className="reports-department-cell">
+                    {row.member.division?.code ?? row.member.division?.name ?? 'Unassigned'}
+                  </td>
+                  <td className="reports-tags-cell">
                     <TagList tags={row.member.tags} />
                   </td>
-                  <td className="font-mono">{formatReportTime(row.firstIn)}</td>
-                  <td className="font-mono">
-                    {row.lastOut ? formatReportTime(row.lastOut) : 'Still present'}
+                  <td className="reports-time-cell font-mono">{formatReportTime(row.firstIn)}</td>
+                  <td className="reports-time-cell font-mono">
+                    {row.lastOut ? (
+                      formatReportTime(row.lastOut)
+                    ) : (
+                      <>
+                        <span className="reports-screen-only">Still present</span>
+                        <span className="hidden reports-print-inline">Present</span>
+                      </>
+                    )}
                   </td>
                   <td>
-                    <AppBadge status={row.leftAndReturned ? 'warning' : 'neutral'} size="sm">
-                      {row.leftAndReturned ? `Yes — ${row.sessionCount} sessions` : 'No'}
-                    </AppBadge>
+                    <span className="reports-screen-only">
+                      <AppBadge status={row.leftAndReturned ? 'warning' : 'neutral'} size="sm">
+                        {row.leftAndReturned ? `Yes — ${row.sessionCount} sessions` : 'No'}
+                      </AppBadge>
+                    </span>
+                    <span className="hidden reports-print-inline font-mono">
+                      {row.leftAndReturned ? 'Yes' : 'No'}
+                    </span>
                   </td>
-                  <td>
+                  <td className="reports-session-cell text-right font-mono">
                     <details className="reports-screen-only">
                       <summary className="cursor-pointer text-sm font-semibold text-info">
                         {row.sessionCount}
@@ -764,20 +787,27 @@ function TagList({ tags }: { tags: ReportTagSummary[] }) {
     return <span className="text-xs text-base-content/45">No tags</span>
   }
 
+  const printLabel = tags.map((tag) => tag.name).join(', ')
+
   return (
-    <div className="flex max-w-72 flex-wrap gap-(--space-1)">
-      {tags.slice(0, 4).map((tag) => (
-        <Chip
-          key={`${tag.id}-${tag.source}`}
-          size="sm"
-          variant={getChipVariant(tag.chipVariant)}
-          color={getChipColor(tag.chipColor)}
-        >
-          {tag.name}
-        </Chip>
-      ))}
-      {tags.length > 4 && <span className="text-xs text-base-content/55">+{tags.length - 4}</span>}
-    </div>
+    <>
+      <div className="reports-screen-tag-list flex max-w-72 flex-wrap gap-(--space-1)">
+        {tags.slice(0, 4).map((tag) => (
+          <Chip
+            key={`${tag.id}-${tag.source}`}
+            size="sm"
+            variant={getChipVariant(tag.chipVariant)}
+            color={getChipColor(tag.chipColor)}
+          >
+            {tag.name}
+          </Chip>
+        ))}
+        {tags.length > 4 && (
+          <span className="text-xs text-base-content/55">+{tags.length - 4}</span>
+        )}
+      </div>
+      <span className="reports-print-tag-text hidden">{printLabel}</span>
+    </>
   )
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/contracts/src/schemas/report.schema.ts
+++ b/packages/contracts/src/schemas/report.schema.ts
@@ -56,6 +56,16 @@ export const KeyNightSourceEnum = v.picklist([
 
 export const KeyNightRequirementEnum = v.picklist(['required', 'optional', 'not_expected'])
 
+export const DailyPresenceSortDirectionEnum = v.picklist(
+  ['asc', 'desc'],
+  'Invalid daily presence sort direction'
+)
+
+export const DailyPresenceSortFieldEnum = v.picklist(
+  ['last_name', 'first_name', 'department', 'first_in', 'last_out', 'sessions'],
+  'Invalid daily presence sort field'
+)
+
 const LocalDateSchema = v.pipe(
   v.string('Date is required'),
   v.regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format')
@@ -157,11 +167,36 @@ export const PresenceReportConfigSchema = v.object({
 
 export type PresenceReportConfig = v.InferOutput<typeof PresenceReportConfigSchema>
 
+export const DailyPresenceTagSortCriterionSchema = v.object({
+  type: v.literal('tag'),
+  tagId: UuidSchema,
+  direction: v.optional(DailyPresenceSortDirectionEnum, 'asc'),
+})
+
+export const DailyPresenceFieldSortCriterionSchema = v.object({
+  type: v.literal('field'),
+  field: DailyPresenceSortFieldEnum,
+  direction: v.optional(DailyPresenceSortDirectionEnum, 'asc'),
+})
+
+export const DailyPresenceSortCriterionSchema = v.variant('type', [
+  DailyPresenceTagSortCriterionSchema,
+  DailyPresenceFieldSortCriterionSchema,
+])
+
+export type DailyPresenceSortCriterion = v.InferOutput<typeof DailyPresenceSortCriterionSchema>
+
+export const DailyPresenceSortSchema = v.pipe(
+  v.array(DailyPresenceSortCriterionSchema),
+  v.maxLength(8, 'Daily presence reports support up to 8 sort rules')
+)
+
 export const DailyPresenceReportConfigSchema = v.object({
   date: LocalDateSchema,
   scopeType: v.optional(OperationalReportScopeEnum, 'everyone'),
   divisionId: v.optional(UuidSchema),
   tagId: v.optional(UuidSchema),
+  sort: v.optional(DailyPresenceSortSchema),
 })
 
 export type DailyPresenceReportConfig = v.InferOutput<typeof DailyPresenceReportConfigSchema>

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Adds multi-rule sorting to the Daily Presence report so admins can prioritize tags before applying a field sort.
- Supports workflows such as CMD tag first, FTS tag second, then Last name.
- Improves Daily Presence print/PDF output with cleaner table columns, plain-text print tags, and a one-page Letter PDF layout for the current daily report size.
- Bumps the monorepo version to `3.4.5`.

## Why this change was needed

The Daily Presence report needed more operational control over row ordering. Admins need to group important tagged members first while still keeping a predictable name-based order inside each group. The printed report also had layout issues, including noisy tag pills and an extra blank PDF page.

## What changed

### User-facing

- Daily Presence report setup now includes a Sort order builder.
- Sort rules can be tag priorities or field sorts.
- Rules can be moved up/down or removed.
- Tag priority rules insert before field sorts by default.

### Backend/API

- Daily Presence report requests now accept optional sort criteria.
- Backend sorting applies the criteria in sequence and falls back to stable last-name ordering.
- Tag sorting checks both direct member tags and qualification-backed tags.

### Documentation

- No documentation files changed.

### Tests

- Added focused backend service coverage for tag priority sorting and qualification-backed tag matching.
- Verified backend typecheck, frontend typecheck, version sync, and focused report tests locally.

## User impact

Admins can produce Daily Presence reports ordered for command review, staffing review, or other tag-priority workflows without manually rearranging rows after export.

## Operator impact

Printed/PDF Daily Presence output is cleaner and should avoid the extra blank trailing page caused by the admin shell layout.

## Upgrade or migration notes

No database migration required. No manual configuration change required beyond the normal release deployment.

## Risk and rollback notes

Risk is limited to Daily Presence report setup, Daily Presence report sorting, and report print CSS. Roll back this release if report ordering or print layout behaves unexpectedly.
