### PR TITLE
Release v3.4.7

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -96,6 +96,7 @@ import { networkSettingsRouter } from './routes/network-settings.js'
 import { systemStatusRouter } from './routes/system-status.js'
 import { systemUpdateRouter } from './routes/system-update.js'
 import { adminNavigationEventsRouter } from './routes/admin-navigation-events.js'
+import { kioskSoundsRouter } from './routes/kiosk-sounds.js'
 import { authRouter } from './routes/auth.js'
 import authRfidRouter from './routes/auth-rfid.js'
 import adminRouter from './routes/admin.js'
@@ -118,6 +119,7 @@ export function createApp(): Express {
           styleSrc: ["'self'", "'unsafe-inline'"],
           scriptSrc: ["'self'"],
           imgSrc: ["'self'", 'data:', 'https:'],
+          mediaSrc: ["'self'", 'data:', 'blob:'],
         },
       },
       crossOriginEmbedderPolicy: false, // Allow loading external resources
@@ -536,6 +538,8 @@ export function createApp(): Express {
       })
     },
   })
+
+  app.use('/api/kiosk-sounds', kioskSoundsRouter)
 
   // Custom auth routes
   app.use('/api/auth', authRfidRouter)

--- a/apps/backend/src/repositories/operational-report-repository.ts
+++ b/apps/backend/src/repositories/operational-report-repository.ts
@@ -24,6 +24,11 @@ const reportMemberInclude = {
       name: true,
     },
   },
+  rankRef: {
+    select: {
+      displayOrder: true,
+    },
+  },
   memberTags: {
     include: {
       tag: true,

--- a/apps/backend/src/routes/kiosk-sounds.test.ts
+++ b/apps/backend/src/routes/kiosk-sounds.test.ts
@@ -1,0 +1,58 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import express from 'express'
+import request from 'supertest'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createKioskSoundsRouter } from './kiosk-sounds.js'
+
+const tempDirs: string[] = []
+
+function createTestApp(soundPath: string) {
+  const app = express()
+  app.use(
+    '/api/kiosk-sounds',
+    createKioskSoundsRouter([
+      {
+        id: 'test-sound',
+        path: soundPath,
+        contentType: 'audio/ogg',
+      },
+    ])
+  )
+  return app
+}
+
+describe('kiosk sounds route', () => {
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('streams an allowlisted system sound file', async () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'sentinel-kiosk-sound-'))
+    tempDirs.push(tempDir)
+    const soundPath = path.join(tempDir, 'scan.oga')
+    writeFileSync(soundPath, 'sound-data')
+
+    const response = await request(createTestApp(soundPath)).get(
+      '/api/kiosk-sounds/system/test-sound'
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers['content-type']).toContain('audio/ogg')
+    expect(response.body.toString('utf8')).toBe('sound-data')
+  })
+
+  it('rejects unknown sound ids', async () => {
+    const response = await request(createTestApp('/tmp/missing.oga')).get(
+      '/api/kiosk-sounds/system/not-allowed'
+    )
+
+    expect(response.status).toBe(404)
+    expect(response.body).toMatchObject({
+      error: 'NOT_FOUND',
+    })
+  })
+})

--- a/apps/backend/src/routes/kiosk-sounds.ts
+++ b/apps/backend/src/routes/kiosk-sounds.ts
@@ -1,0 +1,48 @@
+import { existsSync } from 'node:fs'
+import { Router, type Request, type Response } from 'express'
+import { KIOSK_SYSTEM_SOUND_OPTIONS } from '@sentinel/contracts'
+
+type KioskSoundCatalog = readonly {
+  id: string
+  path: string
+  contentType: string
+}[]
+
+function sendSoundNotFound(res: Response) {
+  return res.status(404).json({
+    error: 'NOT_FOUND',
+    message: 'Kiosk sound file not found',
+  })
+}
+
+export function createKioskSoundsRouter(
+  catalog: KioskSoundCatalog = KIOSK_SYSTEM_SOUND_OPTIONS
+): Router {
+  const router = Router()
+
+  router.get('/system/:id', (req: Request, res: Response) => {
+    const sound = catalog.find((candidate) => candidate.id === req.params.id)
+
+    if (!sound || !existsSync(sound.path)) {
+      return sendSoundNotFound(res)
+    }
+
+    res.type(sound.contentType)
+    res.setHeader('Cache-Control', 'public, max-age=86400')
+
+    return res.sendFile(sound.path, (error) => {
+      if (!error || res.headersSent) {
+        return
+      }
+
+      res.status(500).json({
+        error: 'INTERNAL_ERROR',
+        message: 'Failed to stream kiosk sound file',
+      })
+    })
+  })
+
+  return router
+}
+
+export const kioskSoundsRouter = createKioskSoundsRouter()

--- a/apps/backend/src/services/operational-report-service.test.ts
+++ b/apps/backend/src/services/operational-report-service.test.ts
@@ -10,8 +10,13 @@ import {
   sortDailyPresenceRows,
   type DailyPresenceSortableRow,
   type PresenceSessionInternal,
+  OperationalReportService,
 } from './operational-report-service.js'
-import type { OperationalReportCheckinRecord } from '../repositories/operational-report-repository.js'
+import type {
+  OperationalReportCheckinRecord,
+  OperationalReportMemberRecord,
+  OperationalReportRepository,
+} from '../repositories/operational-report-repository.js'
 
 function checkin(
   id: string,
@@ -36,10 +41,62 @@ function getSessions(
   return sessionsByMember.get(memberId) ?? []
 }
 
+function operationalReportMember(input: {
+  id: string
+  displayName: string
+  rank: string
+  firstName: string
+  lastName: string
+}): OperationalReportMemberRecord {
+  return {
+    id: input.id,
+    serviceNumber: input.id,
+    employeeNumber: null,
+    displayName: input.displayName,
+    rank: input.rank,
+    firstName: input.firstName,
+    lastName: input.lastName,
+    initials: null,
+    divisionId: null,
+    memberType: 'Class A',
+    memberTypeId: null,
+    memberStatusId: null,
+    status: 'active',
+    memberSource: 'internal',
+    accountLevel: 'member',
+    mustChangePin: false,
+    classDetails: null,
+    mess: null,
+    moc: null,
+    email: null,
+    homePhone: null,
+    mobilePhone: null,
+    badgeId: null,
+    pinHash: null,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    division: null,
+    memberTypeRef: {
+      id: 'member-type-class-a',
+      code: 'class_a',
+      name: 'Class A',
+    },
+    memberStatusRef: {
+      id: 'member-status-active',
+      code: 'active',
+      name: 'Active',
+    },
+    memberTags: [],
+    qualifications: [],
+  } as unknown as OperationalReportMemberRecord
+}
+
 function sortableDailyPresenceRow(input: {
   id: string
   firstName: string
   lastName: string
+  rank?: string
+  rankOrder?: number
   tags?: string[]
   qualificationTags?: string[]
   reportTags?: ReportTagSummary[]
@@ -53,10 +110,11 @@ function sortableDailyPresenceRow(input: {
   return {
     memberRecord: {
       id: input.id,
-      rank: 'S1',
+      rank: input.rank ?? 'S1',
       firstName: input.firstName,
       lastName: input.lastName,
       displayName: `S1 ${input.lastName}, ${input.firstName}`,
+      rankRef: typeof input.rankOrder === 'number' ? { displayOrder: input.rankOrder } : undefined,
       division: input.department ? { code: input.department, name: input.department } : null,
       memberTags: tags.map((tagId) => ({ tagId })),
       qualifications: qualificationTags.map((tagId) => ({
@@ -67,7 +125,7 @@ function sortableDailyPresenceRow(input: {
       member: {
         id: input.id,
         displayName: `S1 ${input.lastName}, ${input.firstName}`,
-        rank: 'S1',
+        rank: input.rank ?? 'S1',
         status: 'Active',
         division: input.department
           ? { id: input.department, code: input.department, name: input.department }
@@ -150,6 +208,75 @@ describe('pairOperationalPresenceSessions', () => {
     expect(Array.from(warnings)).toContain(
       'Some checkout records could not be paired with a prior check-in and were ignored.'
     )
+  })
+
+  it('tracks affected member IDs for unmatched checkout warnings', () => {
+    const warnings = new Set<string>()
+    const warningMemberIds = new Map<string, Set<string>>()
+    pairOperationalPresenceSessions(
+      [
+        checkin('1', 'member-1', 'out', '2026-05-05T12:00:00.000Z'),
+        checkin('2', 'member-2', 'out', '2026-05-05T12:05:00.000Z'),
+      ],
+      warnings,
+      { warningMemberIds }
+    )
+
+    expect(
+      Array.from(
+        warningMemberIds.get(
+          'Some checkout records could not be paired with a prior check-in and were ignored.'
+        ) ?? []
+      )
+    ).toEqual(['member-1', 'member-2'])
+  })
+})
+
+describe('generateDailyPresence', () => {
+  it('includes affected account names for unmatched checkout warnings', async () => {
+    const member = operationalReportMember({
+      id: '11111111-1111-4111-8111-111111111111',
+      displayName: 'S1 Example, A',
+      rank: 'S1',
+      firstName: 'Alex',
+      lastName: 'Example',
+    })
+    const repository = {
+      findActiveMembers: async () => [member],
+      findCheckinsForMembers: async () => [
+        checkin(
+          'checkin-1',
+          '11111111-1111-4111-8111-111111111111',
+          'out',
+          '2026-06-12T14:00:00.000Z'
+        ),
+      ],
+      findScheduledDutyAssignmentsForMembers: async () => [],
+    } as unknown as OperationalReportRepository
+    const service = new OperationalReportService(undefined, repository)
+
+    const report = await service.generateDailyPresence(
+      { date: '2026-06-12', scopeType: 'everyone' },
+      { id: 'actor-1', rank: 'MS', firstName: 'Report', lastName: 'Runner' }
+    )
+
+    expect(report.warnings).toContain(
+      'Some checkout records could not be paired with a prior check-in and were ignored.'
+    )
+    expect(report.warningDetails).toEqual([
+      {
+        message:
+          'Some checkout records could not be paired with a prior check-in and were ignored.',
+        accounts: [
+          {
+            id: '11111111-1111-4111-8111-111111111111',
+            displayName: 'S1 Example, A',
+            division: null,
+            memberType: 'Class A',
+          },
+        ],
+      },
+    ])
   })
 })
 
@@ -321,6 +448,40 @@ describe('sortDailyPresenceRows', () => {
     }).memberRecord
 
     expect(dailyPresenceSortableMemberHasTag(member, ftsTagId)).toBe(true)
+  })
+
+  it('sorts by rank display order before last name', () => {
+    const sorted = sortDailyPresenceRows(
+      [
+        sortableDailyPresenceRow({
+          id: 's1-zulu',
+          firstName: 'Zed',
+          lastName: 'Zulu',
+          rank: 'S1',
+          rankOrder: 3,
+        }),
+        sortableDailyPresenceRow({
+          id: 'ms-baker',
+          firstName: 'Bill',
+          lastName: 'Baker',
+          rank: 'MS',
+          rankOrder: 5,
+        }),
+        sortableDailyPresenceRow({
+          id: 's1-able',
+          firstName: 'Ann',
+          lastName: 'Able',
+          rank: 'S1',
+          rankOrder: 3,
+        }),
+      ],
+      [
+        { type: 'field', field: 'rank', direction: 'asc' },
+        { type: 'field', field: 'last_name', direction: 'asc' },
+      ]
+    )
+
+    expect(sorted.map((row) => row.memberRecord.id)).toEqual(['s1-able', 's1-zulu', 'ms-baker'])
   })
 
   it('sorts by configured tag priority before last name', () => {

--- a/apps/backend/src/services/operational-report-service.ts
+++ b/apps/backend/src/services/operational-report-service.ts
@@ -18,6 +18,8 @@ import type {
   ReportDutyPerson,
   ReportMemberSummary,
   ReportTagSummary,
+  ReportWarningDetail,
+  ReportWarningAccountSummary,
   TrainingNightMonthlyReportConfig,
   TrainingNightMonthlyReportResponse,
   VisitorActivityReportConfig,
@@ -48,6 +50,14 @@ import { isSentinelBootstrapMember } from '../lib/system-bootstrap.js'
 const UNIT_NAME = 'HMCS Chippawa'
 const REPORT_LOOKBACK_DAYS = 1
 const OPERATIONAL_TIMINGS_SETTING_KEY_V3 = 'operational.timings.v3'
+const REPEATED_CHECKIN_WARNING =
+  'Some members have multiple check-ins without an intervening checkout; affected sessions are marked as degraded.'
+const UNMATCHED_CHECKOUT_WARNING =
+  'Some checkout records could not be paired with a prior check-in and were ignored.'
+const EARLY_CHECKOUT_WARNING =
+  'Some checkout records were earlier than their paired check-in and were ignored.'
+const UNKNOWN_DIRECTION_WARNING =
+  'Some check-in records used an unknown direction and were ignored.'
 
 type ReportScopeType = 'everyone' | 'department' | 'tag' | 'fts' | 'geo'
 type KeyNightCategory = 'training' | 'administrative'
@@ -109,12 +119,17 @@ interface LockupCheckedOutMember {
   name: string
 }
 
+interface PairPresenceSessionsOptions {
+  warningMemberIds?: Map<string, Set<string>>
+}
+
 export interface DailyPresenceSortableMember {
   id: string
   rank: string
   firstName: string
   lastName: string
   displayName: string | null
+  rankRef?: { displayOrder: number } | null
   division: { code: string; name: string } | null
   memberTags: Array<{ tagId: string }>
   qualifications: Array<{ qualificationType: { tagId: string | null } }>
@@ -232,6 +247,19 @@ function compareDailyPresenceField(
         compareNullableString(left.memberRecord.firstName, right.memberRecord.firstName) ||
         compareNullableString(left.memberRecord.lastName, right.memberRecord.lastName)
       )
+    case 'rank': {
+      const leftRankOrder = left.memberRecord.rankRef?.displayOrder ?? null
+      const rightRankOrder = right.memberRecord.rankRef?.displayOrder ?? null
+
+      if (leftRankOrder !== null && rightRankOrder !== null && leftRankOrder !== rightRankOrder) {
+        return leftRankOrder - rightRankOrder
+      }
+
+      return (
+        compareNullableString(left.memberRecord.rank, right.memberRecord.rank) ||
+        compareNullableString(left.memberRecord.lastName, right.memberRecord.lastName)
+      )
+    }
     case 'department':
       return (
         compareNullableString(
@@ -361,7 +389,8 @@ export function isStaleForcedCheckoutSession(
 
 export function pairOperationalPresenceSessions(
   checkins: OperationalReportCheckinRecord[],
-  warnings: Set<string>
+  warnings: Set<string>,
+  options: PairPresenceSessionsOptions = {}
 ): Map<string, PresenceSessionInternal[]> {
   const grouped = new Map<string, OperationalReportCheckinRecord[]>()
   for (const checkin of checkins) {
@@ -387,9 +416,7 @@ export function pairOperationalPresenceSessions(
 
       if (direction === 'in') {
         if (openIn) {
-          warnings.add(
-            'Some members have multiple check-ins without an intervening checkout; affected sessions are marked as degraded.'
-          )
+          addPresenceWarning(warnings, REPEATED_CHECKIN_WARNING, options, memberId)
           sessions.push({
             memberId,
             inAt: openIn.timestamp,
@@ -403,16 +430,12 @@ export function pairOperationalPresenceSessions(
 
       if (direction === 'out') {
         if (!openIn) {
-          warnings.add(
-            'Some checkout records could not be paired with a prior check-in and were ignored.'
-          )
+          addPresenceWarning(warnings, UNMATCHED_CHECKOUT_WARNING, options, memberId)
           continue
         }
 
         if (record.timestamp < openIn.timestamp) {
-          warnings.add(
-            'Some checkout records were earlier than their paired check-in and were ignored.'
-          )
+          addPresenceWarning(warnings, EARLY_CHECKOUT_WARNING, options, memberId)
           openIn = null
           continue
         }
@@ -428,7 +451,7 @@ export function pairOperationalPresenceSessions(
         continue
       }
 
-      warnings.add('Some check-in records used an unknown direction and were ignored.')
+      addPresenceWarning(warnings, UNKNOWN_DIRECTION_WARNING, options, memberId)
     }
 
     if (openIn) {
@@ -446,6 +469,23 @@ export function pairOperationalPresenceSessions(
   return sessionsByMember
 }
 
+function addPresenceWarning(
+  warnings: Set<string>,
+  warning: string,
+  options: PairPresenceSessionsOptions,
+  memberId?: string | null
+) {
+  warnings.add(warning)
+
+  if (!memberId || !options.warningMemberIds) {
+    return
+  }
+
+  const memberIds = options.warningMemberIds.get(warning) ?? new Set<string>()
+  memberIds.add(memberId)
+  options.warningMemberIds.set(warning, memberIds)
+}
+
 export class OperationalReportService {
   private repository: OperationalReportRepository
 
@@ -459,6 +499,7 @@ export class OperationalReportService {
   ): Promise<DailyPresenceReportResponse> {
     const range = this.getDayRange(config.date)
     const warnings = new Set<string>()
+    const warningMemberIds = new Map<string, Set<string>>()
     const scope = await this.resolveScope(config, warnings)
     const members = scope.noResults
       ? []
@@ -466,7 +507,12 @@ export class OperationalReportService {
           divisionId: scope.divisionId,
           tagId: scope.tagId,
         })
-    const sessionsByMember = await this.getSessionsByMember(members, range, warnings)
+    const sessionsByMember = await this.getSessionsByMember(
+      members,
+      range,
+      warnings,
+      warningMemberIds
+    )
     const scheduledDutyRolesByMember = await this.getScheduledDutyRolesByMember(members, range)
 
     const sortableRows = members
@@ -506,6 +552,7 @@ export class OperationalReportService {
         tagId: scope.tagId,
       }),
       warnings: Array.from(warnings),
+      warningDetails: this.getWarningDetails(warnings, warningMemberIds, members),
       data: {
         summary: {
           totalScopedMembers: members.length,
@@ -947,6 +994,7 @@ export class OperationalReportService {
         label: range.label,
       },
       filters,
+      warningDetails: [],
     }
   }
 
@@ -1047,21 +1095,27 @@ export class OperationalReportService {
   private async getSessionsByMember(
     members: OperationalReportMemberRecord[],
     range: DateRange,
-    warnings: Set<string>
+    warnings: Set<string>,
+    warningMemberIds?: Map<string, Set<string>>
   ): Promise<Map<string, PresenceSessionInternal[]>> {
     const memberIds = members.map((member) => member.id)
     const queryStart = DateTime.fromJSDate(range.start, { zone: DEFAULT_TIMEZONE })
       .minus({ days: REPORT_LOOKBACK_DAYS })
       .toJSDate()
     const checkins = await this.repository.findCheckinsForMembers(memberIds, queryStart, range.end)
-    return this.pairSessions(checkins, warnings)
+    return this.pairSessions(checkins, warnings, warningMemberIds)
   }
 
   private pairSessions(
     checkins: OperationalReportCheckinRecord[],
-    warnings: Set<string>
+    warnings: Set<string>,
+    warningMemberIds?: Map<string, Set<string>>
   ): Map<string, PresenceSessionInternal[]> {
-    return pairOperationalPresenceSessions(checkins, warnings)
+    return pairOperationalPresenceSessions(
+      checkins,
+      warnings,
+      warningMemberIds ? { warningMemberIds } : {}
+    )
   }
 
   private getPresenceMarker(
@@ -1473,6 +1527,53 @@ export class OperationalReportService {
       member.memberTags.some((memberTag) => memberTag.tagId === tagId) ||
       member.qualifications.some((qualification) => qualification.qualificationType.tagId === tagId)
     )
+  }
+
+  private getWarningDetails(
+    warnings: ReadonlySet<string>,
+    warningMemberIds: ReadonlyMap<string, ReadonlySet<string>>,
+    members: OperationalReportMemberRecord[]
+  ): ReportWarningDetail[] {
+    const memberById = new Map(members.map((member) => [member.id, member]))
+
+    return Array.from(warnings)
+      .map((warning) => {
+        const accounts = Array.from(warningMemberIds.get(warning) ?? [])
+          .map((memberId) => memberById.get(memberId))
+          .filter((member): member is OperationalReportMemberRecord => member !== undefined)
+          .map((member) => this.toWarningAccountSummary(member))
+          .sort((left, right) =>
+            left.displayName.localeCompare(right.displayName, undefined, {
+              sensitivity: 'base',
+              numeric: true,
+            })
+          )
+
+        return {
+          message: warning,
+          accounts,
+        }
+      })
+      .filter((detail) => detail.accounts.length > 0)
+  }
+
+  private toWarningAccountSummary(
+    member: OperationalReportMemberRecord
+  ): ReportWarningAccountSummary {
+    return {
+      id: member.id,
+      displayName:
+        member.displayName ??
+        [member.rank, member.firstName, member.lastName].filter(Boolean).join(' '),
+      division: member.division
+        ? {
+            id: member.division.id,
+            code: member.division.code,
+            name: member.division.name,
+          }
+        : null,
+      memberType: member.memberTypeRef?.name ?? member.memberType,
+    }
   }
 
   private toMemberSummary(

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/app/admin/kiosk-sounds/page.tsx
+++ b/apps/frontend-admin/src/app/admin/kiosk-sounds/page.tsx
@@ -1,0 +1,5 @@
+import { AdminKioskSoundsPage } from '@/components/admin/admin-kiosk-sounds-page'
+
+export default function AdminKioskSoundsRoute() {
+  return <AdminKioskSoundsPage />
+}

--- a/apps/frontend-admin/src/app/api/kiosk-sounds/system/[id]/route.ts
+++ b/apps/frontend-admin/src/app/api/kiosk-sounds/system/[id]/route.ts
@@ -1,0 +1,14 @@
+import { createKioskSystemSoundResponse } from '@/lib/kiosk-system-sound-response.server'
+
+export const dynamic = 'force-dynamic'
+
+type RouteContext = {
+  params: Promise<{
+    id: string
+  }>
+}
+
+export async function GET(_request: globalThis.Request, context: RouteContext) {
+  const { id } = await context.params
+  return createKioskSystemSoundResponse(id)
+}

--- a/apps/frontend-admin/src/app/globals.css
+++ b/apps/frontend-admin/src/app/globals.css
@@ -451,31 +451,27 @@
   }
 
   .reports-daily-member-col {
-    width: 22%;
+    width: 24%;
   }
 
   .reports-daily-department-col {
-    width: 11%;
+    width: 10%;
   }
 
   .reports-daily-tags-col {
-    width: 23%;
+    width: 28%;
   }
 
   .reports-daily-time-col {
-    width: 9%;
-  }
-
-  .reports-daily-last-out-col {
-    width: 11%;
-  }
-
-  .reports-daily-returned-col {
     width: 12%;
   }
 
-  .reports-daily-session-col {
-    width: 8%;
+  .reports-daily-last-out-col {
+    width: 12%;
+  }
+
+  .reports-daily-presence-col {
+    width: 14%;
   }
 
   .reports-daily-presence-table .reports-tags-cell {

--- a/apps/frontend-admin/src/app/media/kiosk-sounds/system/[id]/route.ts
+++ b/apps/frontend-admin/src/app/media/kiosk-sounds/system/[id]/route.ts
@@ -1,0 +1,14 @@
+import { createKioskSystemSoundResponse } from '@/lib/kiosk-system-sound-response.server'
+
+export const dynamic = 'force-dynamic'
+
+type RouteContext = {
+  params: Promise<{
+    id: string
+  }>
+}
+
+export async function GET(_request: globalThis.Request, context: RouteContext) {
+  const { id } = await context.params
+  return createKioskSystemSoundResponse(id)
+}

--- a/apps/frontend-admin/src/components/admin/admin-icons.tsx
+++ b/apps/frontend-admin/src/components/admin/admin-icons.tsx
@@ -14,6 +14,7 @@ import {
   Shield,
   Terminal,
   UserPlus,
+  Volume2,
 } from 'lucide-react'
 import type { AdminIconKey } from '@/lib/admin-routes'
 
@@ -47,6 +48,8 @@ export function AdminIcon({ icon, ...props }: AdminIconProps) {
       return <Network {...props} />
     case 'shield':
       return <Shield {...props} />
+    case 'volume':
+      return <Volume2 {...props} />
     case 'terminal':
       return <Terminal {...props} />
     case 'user-plus':

--- a/apps/frontend-admin/src/components/admin/admin-kiosk-sounds-page.tsx
+++ b/apps/frontend-admin/src/components/admin/admin-kiosk-sounds-page.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { KioskSoundSettingsPanel } from '@/components/settings/kiosk-sound-settings-panel'
+
+export function AdminKioskSoundsPage() {
+  return (
+    <div className="space-y-(--space-4)">
+      <div>
+        <h1 id="admin-page-title" className="font-display text-3xl font-bold">
+          Kiosk Sounds
+        </h1>
+        <p className="mt-(--space-1) max-w-3xl text-sm text-base-content/65">
+          Configure the audio feedback operators hear when badges scan in or out.
+        </p>
+      </div>
+
+      <KioskSoundSettingsPanel />
+    </div>
+  )
+}

--- a/apps/frontend-admin/src/components/admin/reports/AdminReportsPage.tsx
+++ b/apps/frontend-admin/src/components/admin/reports/AdminReportsPage.tsx
@@ -26,6 +26,7 @@ import {
   getReportDefinition,
   REPORT_DEFINITIONS,
   type AdminReportType,
+  type DailyPresenceSortGroup,
   type DailyPresenceSortRule,
   type ReportFilters,
   type ReportScopeType,
@@ -54,7 +55,12 @@ function createDailyPresenceSortRuleId(): string {
 function toDailyPresenceSortCriteria(rules: DailyPresenceSortRule[]): DailyPresenceSortCriterion[] {
   const criteria: DailyPresenceSortCriterion[] = []
 
-  for (const rule of rules) {
+  const orderedRules = [
+    ...rules.filter((rule) => rule.sortGroup === 'primary'),
+    ...rules.filter((rule) => rule.sortGroup === 'secondary'),
+  ]
+
+  for (const rule of orderedRules) {
     if (rule.type === 'tag') {
       if (rule.tagId) {
         criteria.push({ type: 'tag', tagId: rule.tagId, direction: rule.direction })
@@ -214,8 +220,12 @@ export function AdminReportsPage() {
   }
 
   async function handleRunReport() {
-    const report = await reportRunner.mutateAsync(buildRunInput(filters))
-    setLastReport(report)
+    try {
+      const report = await reportRunner.mutateAsync(buildRunInput(filters))
+      setLastReport(report)
+    } catch {
+      // The mutation stores the API error; keep the page mounted so ReportPreview can show it.
+    }
   }
 
   function handlePrint() {
@@ -572,6 +582,7 @@ const DAILY_PRESENCE_FIELD_OPTIONS: Array<{
   value: Extract<DailyPresenceSortCriterion, { type: 'field' }>['field']
   label: string
 }> = [
+  { value: 'rank', label: 'Rank' },
   { value: 'last_name', label: 'Last name' },
   { value: 'first_name', label: 'First name' },
   { value: 'department', label: 'Department' },
@@ -589,6 +600,20 @@ function DailyPresenceSortBuilder({
   tags: Array<{ id: string; name: string }>
   onChange: (rules: DailyPresenceSortRule[]) => void
 }) {
+  const primaryRules = rules.filter((rule) => rule.sortGroup === 'primary')
+  const secondaryRules = rules.filter((rule) => rule.sortGroup === 'secondary')
+
+  function updateGroupRules(
+    group: DailyPresenceSortGroup,
+    nextGroupRules: DailyPresenceSortRule[]
+  ) {
+    onChange(
+      group === 'primary'
+        ? [...nextGroupRules, ...secondaryRules]
+        : [...primaryRules, ...nextGroupRules]
+    )
+  }
+
   function replaceRule(ruleId: string, nextRule: DailyPresenceSortRule) {
     onChange(rules.map((rule) => (rule.id === ruleId ? nextRule : rule)))
   }
@@ -638,27 +663,28 @@ function DailyPresenceSortBuilder({
     )
   }
 
-  function moveRule(ruleId: string, direction: -1 | 1) {
-    const currentIndex = rules.findIndex((rule) => rule.id === ruleId)
+  function moveRule(group: DailyPresenceSortGroup, ruleId: string, direction: -1 | 1) {
+    const groupRules = group === 'primary' ? primaryRules : secondaryRules
+    const currentIndex = groupRules.findIndex((rule) => rule.id === ruleId)
     const nextIndex = currentIndex + direction
-    if (currentIndex < 0 || nextIndex < 0 || nextIndex >= rules.length) {
+    if (currentIndex < 0 || nextIndex < 0 || nextIndex >= groupRules.length) {
       return
     }
 
-    const nextRules = [...rules]
+    const nextRules = [...groupRules]
     const [rule] = nextRules.splice(currentIndex, 1)
     if (!rule) {
       return
     }
     nextRules.splice(nextIndex, 0, rule)
-    onChange(nextRules)
+    updateGroupRules(group, nextRules)
   }
 
   function removeRule(ruleId: string) {
     onChange(rules.filter((rule) => rule.id !== ruleId))
   }
 
-  function addTagRule() {
+  function addTagRule(group: DailyPresenceSortGroup) {
     const tag = tags[0]
     if (!tag) {
       return
@@ -666,223 +692,267 @@ function DailyPresenceSortBuilder({
 
     const nextRule: DailyPresenceSortRule = {
       id: createDailyPresenceSortRuleId(),
+      sortGroup: group,
       type: 'tag',
       tagId: tag.id,
       direction: 'asc',
     }
-    const firstFieldIndex = rules.findIndex((rule) => rule.type === 'field')
-
-    if (firstFieldIndex === -1) {
-      onChange([...rules, nextRule])
-      return
-    }
-
-    onChange([...rules.slice(0, firstFieldIndex), nextRule, ...rules.slice(firstFieldIndex)])
+    updateGroupRules(group, [...(group === 'primary' ? primaryRules : secondaryRules), nextRule])
   }
 
-  function addTagPriorityRule() {
+  function addTagPriorityRule(group: DailyPresenceSortGroup) {
     const nextRule: DailyPresenceSortRule = {
       id: createDailyPresenceSortRuleId(),
+      sortGroup: group,
       type: 'tag_priority',
       direction: 'asc',
     }
-    const firstFieldIndex = rules.findIndex((rule) => rule.type === 'field')
-
-    if (firstFieldIndex === -1) {
-      onChange([...rules, nextRule])
-      return
-    }
-
-    onChange([...rules.slice(0, firstFieldIndex), nextRule, ...rules.slice(firstFieldIndex)])
+    updateGroupRules(group, [...(group === 'primary' ? primaryRules : secondaryRules), nextRule])
   }
 
-  function addFieldRule() {
-    onChange([
-      ...rules,
+  function addFieldRule(group: DailyPresenceSortGroup) {
+    updateGroupRules(group, [
+      ...(group === 'primary' ? primaryRules : secondaryRules),
       {
         id: createDailyPresenceSortRuleId(),
+        sortGroup: group,
         type: 'field',
-        field: 'last_name',
+        field: group === 'secondary' ? 'last_name' : 'department',
         direction: 'asc',
       },
     ])
   }
 
-  return (
-    <fieldset className="rounded-box border border-base-300 bg-base-200/45 p-(--space-3)">
-      <div className="flex flex-wrap items-start justify-between gap-(--space-3)">
-        <div>
-          <legend className="font-semibold">Sort order</legend>
-          <p className="mt-(--space-1) text-sm text-base-content/65">
-            Rules run from top to bottom. Add tag priorities first, then a name or time field.
-          </p>
-        </div>
-        <div className="flex flex-wrap gap-(--space-2)">
+  function renderRule(
+    rule: DailyPresenceSortRule,
+    index: number,
+    groupRules: DailyPresenceSortRule[]
+  ) {
+    return (
+      <div
+        key={rule.id}
+        className="grid items-center gap-(--space-2) rounded-box border border-base-300 bg-base-100 p-(--space-2) md:grid-cols-[2rem_8rem_minmax(0,1fr)_8rem_auto]"
+      >
+        <span className="text-center text-xs font-semibold text-base-content/55">{index + 1}</span>
+        <select
+          className="select select-bordered select-sm w-full"
+          value={rule.type}
+          onChange={(event) => {
+            if (event.target.value === 'tag') {
+              const tag = tags[0]
+              if (!tag) return
+              replaceRule(rule.id, {
+                id: rule.id,
+                sortGroup: rule.sortGroup,
+                type: 'tag',
+                tagId: tag.id,
+                direction: 'asc',
+              })
+              return
+            }
+
+            if (event.target.value === 'tag_priority') {
+              replaceRule(rule.id, {
+                id: rule.id,
+                sortGroup: rule.sortGroup,
+                type: 'tag_priority',
+                direction: 'asc',
+              })
+              return
+            }
+
+            replaceRule(rule.id, {
+              id: rule.id,
+              sortGroup: rule.sortGroup,
+              type: 'field',
+              field: rule.sortGroup === 'secondary' ? 'last_name' : 'department',
+              direction: 'asc',
+            })
+          }}
+        >
+          <option value="tag">Specific tag</option>
+          <option value="tag_priority">Tag priority</option>
+          <option value="field">Field</option>
+        </select>
+
+        {rule.type === 'tag' ? (
+          <select
+            className="select select-bordered select-sm w-full"
+            value={rule.tagId}
+            onChange={(event) => updateTagRule(rule.id, { tagId: event.target.value })}
+          >
+            {tags.map((tag) => (
+              <option key={tag.id} value={tag.id}>
+                {tag.name}
+              </option>
+            ))}
+          </select>
+        ) : rule.type === 'tag_priority' ? (
+          <div className="rounded-box border border-base-300 bg-base-200 px-(--space-3) py-(--space-2) text-sm font-medium text-base-content/70">
+            Configured tag order
+          </div>
+        ) : (
+          <select
+            className="select select-bordered select-sm w-full"
+            value={rule.field}
+            onChange={(event) =>
+              updateFieldRule(rule.id, {
+                field: event.target.value as Extract<
+                  DailyPresenceSortCriterion,
+                  { type: 'field' }
+                >['field'],
+              })
+            }
+          >
+            {DAILY_PRESENCE_FIELD_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        )}
+
+        <select
+          className="select select-bordered select-sm w-full"
+          value={rule.direction}
+          onChange={(event) =>
+            rule.type === 'tag'
+              ? updateTagRule(rule.id, {
+                  direction: event.target.value as DailyPresenceSortCriterion['direction'],
+                })
+              : rule.type === 'tag_priority'
+                ? updateTagPriorityRule(rule.id, {
+                    direction: event.target.value as DailyPresenceSortCriterion['direction'],
+                  })
+                : updateFieldRule(rule.id, {
+                    direction: event.target.value as DailyPresenceSortCriterion['direction'],
+                  })
+          }
+        >
+          <option value="asc">
+            {rule.type === 'tag' || rule.type === 'tag_priority' ? 'First' : 'A to Z'}
+          </option>
+          <option value="desc">
+            {rule.type === 'tag' || rule.type === 'tag_priority' ? 'Last' : 'Z to A'}
+          </option>
+        </select>
+
+        <div className="flex items-center justify-end gap-(--space-1)">
           <button
             type="button"
-            className="btn btn-outline btn-sm"
-            onClick={addTagRule}
-            disabled={tags.length === 0}
+            className="btn btn-ghost btn-square btn-sm"
+            onClick={() => moveRule(rule.sortGroup, rule.id, -1)}
+            disabled={index === 0}
+            aria-label="Move sort rule up"
           >
-            <Plus className="h-4 w-4" aria-hidden="true" />
-            Specific tag
+            <ArrowUp className="h-4 w-4" aria-hidden="true" />
           </button>
-          <button type="button" className="btn btn-outline btn-sm" onClick={addTagPriorityRule}>
-            <Plus className="h-4 w-4" aria-hidden="true" />
-            Tag priority
+          <button
+            type="button"
+            className="btn btn-ghost btn-square btn-sm"
+            onClick={() => moveRule(rule.sortGroup, rule.id, 1)}
+            disabled={index === groupRules.length - 1}
+            aria-label="Move sort rule down"
+          >
+            <ArrowDown className="h-4 w-4" aria-hidden="true" />
           </button>
-          <button type="button" className="btn btn-outline btn-sm" onClick={addFieldRule}>
-            <Plus className="h-4 w-4" aria-hidden="true" />
-            Field sort
+          <button
+            type="button"
+            className="btn btn-ghost btn-square btn-sm text-error"
+            onClick={() => removeRule(rule.id)}
+            aria-label="Remove sort rule"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
           </button>
         </div>
       </div>
+    )
+  }
 
-      <div className="mt-(--space-3) space-y-(--space-2)">
-        {rules.length === 0 ? (
-          <p className="rounded-box border border-dashed border-base-300 bg-base-100 p-(--space-3) text-sm text-base-content/60">
-            No custom sort rules. The report will use the backend default order.
-          </p>
-        ) : (
-          rules.map((rule, index) => (
-            <div
-              key={rule.id}
-              className="grid items-center gap-(--space-2) rounded-box border border-base-300 bg-base-100 p-(--space-2) md:grid-cols-[2rem_8rem_minmax(0,1fr)_8rem_auto]"
+  function renderSortSection(params: {
+    group: DailyPresenceSortGroup
+    title: string
+    description: string
+    rules: DailyPresenceSortRule[]
+    emptyText: string
+  }) {
+    return (
+      <div className="rounded-box border border-base-300 bg-base-100 p-(--space-3)">
+        <div className="flex flex-wrap items-start justify-between gap-(--space-3)">
+          <div>
+            <h3 className="text-sm font-semibold">{params.title}</h3>
+            <p className="mt-(--space-1) text-xs text-base-content/65">{params.description}</p>
+          </div>
+          <div className="flex flex-wrap gap-(--space-2)">
+            <button
+              type="button"
+              className="btn btn-outline btn-sm"
+              onClick={() => addTagRule(params.group)}
+              disabled={tags.length === 0}
             >
-              <span className="text-center text-xs font-semibold text-base-content/55">
-                {index + 1}
-              </span>
-              <select
-                className="select select-bordered select-sm w-full"
-                value={rule.type}
-                onChange={(event) => {
-                  if (event.target.value === 'tag') {
-                    const tag = tags[0]
-                    if (!tag) return
-                    replaceRule(rule.id, {
-                      id: rule.id,
-                      type: 'tag',
-                      tagId: tag.id,
-                      direction: 'asc',
-                    })
-                    return
-                  }
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              Specific tag
+            </button>
+            <button
+              type="button"
+              className="btn btn-outline btn-sm"
+              onClick={() => addTagPriorityRule(params.group)}
+            >
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              Tag priority
+            </button>
+            <button
+              type="button"
+              className="btn btn-outline btn-sm"
+              onClick={() => addFieldRule(params.group)}
+            >
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              Field sort
+            </button>
+          </div>
+        </div>
 
-                  if (event.target.value === 'tag_priority') {
-                    replaceRule(rule.id, {
-                      id: rule.id,
-                      type: 'tag_priority',
-                      direction: 'asc',
-                    })
-                    return
-                  }
+        <div className="mt-(--space-3) space-y-(--space-2)">
+          {params.rules.length === 0 ? (
+            <p className="rounded-box border border-dashed border-base-300 bg-base-200 p-(--space-3) text-sm text-base-content/60">
+              {params.emptyText}
+            </p>
+          ) : (
+            params.rules.map((rule, index) => renderRule(rule, index, params.rules))
+          )}
+        </div>
+      </div>
+    )
+  }
 
-                  replaceRule(rule.id, {
-                    id: rule.id,
-                    type: 'field',
-                    field: 'last_name',
-                    direction: 'asc',
-                  })
-                }}
-              >
-                <option value="tag">Specific tag</option>
-                <option value="tag_priority">Tag priority</option>
-                <option value="field">Field</option>
-              </select>
+  return (
+    <fieldset className="rounded-box border border-base-300 bg-base-200/45 p-(--space-3)">
+      <div>
+        <legend className="font-semibold">Sort order</legend>
+        <p className="mt-(--space-1) text-sm text-base-content/65">
+          Primary rules create the report groups. Secondary rules sort members inside each primary
+          group.
+        </p>
+      </div>
 
-              {rule.type === 'tag' ? (
-                <select
-                  className="select select-bordered select-sm w-full"
-                  value={rule.tagId}
-                  onChange={(event) => updateTagRule(rule.id, { tagId: event.target.value })}
-                >
-                  {tags.map((tag) => (
-                    <option key={tag.id} value={tag.id}>
-                      {tag.name}
-                    </option>
-                  ))}
-                </select>
-              ) : rule.type === 'tag_priority' ? (
-                <div className="rounded-box border border-base-300 bg-base-200 px-(--space-3) py-(--space-2) text-sm font-medium text-base-content/70">
-                  Configured tag order
-                </div>
-              ) : (
-                <select
-                  className="select select-bordered select-sm w-full"
-                  value={rule.field}
-                  onChange={(event) =>
-                    updateFieldRule(rule.id, {
-                      field: event.target.value as Extract<
-                        DailyPresenceSortCriterion,
-                        { type: 'field' }
-                      >['field'],
-                    })
-                  }
-                >
-                  {DAILY_PRESENCE_FIELD_OPTIONS.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              )}
-
-              <select
-                className="select select-bordered select-sm w-full"
-                value={rule.direction}
-                onChange={(event) =>
-                  rule.type === 'tag'
-                    ? updateTagRule(rule.id, {
-                        direction: event.target.value as DailyPresenceSortCriterion['direction'],
-                      })
-                    : rule.type === 'tag_priority'
-                      ? updateTagPriorityRule(rule.id, {
-                          direction: event.target.value as DailyPresenceSortCriterion['direction'],
-                        })
-                      : updateFieldRule(rule.id, {
-                          direction: event.target.value as DailyPresenceSortCriterion['direction'],
-                        })
-                }
-              >
-                <option value="asc">
-                  {rule.type === 'tag' || rule.type === 'tag_priority' ? 'First' : 'A to Z'}
-                </option>
-                <option value="desc">
-                  {rule.type === 'tag' || rule.type === 'tag_priority' ? 'Last' : 'Z to A'}
-                </option>
-              </select>
-
-              <div className="flex items-center justify-end gap-(--space-1)">
-                <button
-                  type="button"
-                  className="btn btn-ghost btn-square btn-sm"
-                  onClick={() => moveRule(rule.id, -1)}
-                  disabled={index === 0}
-                  aria-label="Move sort rule up"
-                >
-                  <ArrowUp className="h-4 w-4" aria-hidden="true" />
-                </button>
-                <button
-                  type="button"
-                  className="btn btn-ghost btn-square btn-sm"
-                  onClick={() => moveRule(rule.id, 1)}
-                  disabled={index === rules.length - 1}
-                  aria-label="Move sort rule down"
-                >
-                  <ArrowDown className="h-4 w-4" aria-hidden="true" />
-                </button>
-                <button
-                  type="button"
-                  className="btn btn-ghost btn-square btn-sm text-error"
-                  onClick={() => removeRule(rule.id)}
-                  aria-label="Remove sort rule"
-                >
-                  <X className="h-4 w-4" aria-hidden="true" />
-                </button>
-              </div>
-            </div>
-          ))
-        )}
+      <div className="mt-(--space-3) grid gap-(--space-3)">
+        {renderSortSection({
+          group: 'primary',
+          title: 'Primary sort order',
+          description:
+            'Use tag priority, specific tags, departments, or other fields to build the main buckets.',
+          rules: primaryRules,
+          emptyText: 'No primary grouping. The secondary sort will apply to the full report.',
+        })}
+        {renderSortSection({
+          group: 'secondary',
+          title: 'Secondary sort order',
+          description:
+            'Use rank, last name, or time fields to order members within each primary bucket.',
+          rules: secondaryRules,
+          emptyText:
+            'No secondary sorting. Members inside each primary group will use backend fallback order.',
+        })}
       </div>
     </fieldset>
   )

--- a/apps/frontend-admin/src/components/admin/reports/report-definitions.ts
+++ b/apps/frontend-admin/src/components/admin/reports/report-definitions.ts
@@ -11,6 +11,8 @@ export type AdminReportType =
 
 export type ReportScopeType = 'everyone' | 'department' | 'tag' | 'fts' | 'geo'
 
+export type DailyPresenceSortGroup = 'primary' | 'secondary'
+
 export type ReportFilterKey =
   | 'date'
   | 'weekStartDate'
@@ -29,6 +31,7 @@ export type ReportFilterKey =
 
 export type DailyPresenceTagSortRule = Extract<DailyPresenceSortCriterion, { type: 'tag' }> & {
   id: string
+  sortGroup: DailyPresenceSortGroup
 }
 
 export type DailyPresenceTagPrioritySortRule = Extract<
@@ -36,10 +39,12 @@ export type DailyPresenceTagPrioritySortRule = Extract<
   { type: 'tag_priority' }
 > & {
   id: string
+  sortGroup: DailyPresenceSortGroup
 }
 
 export type DailyPresenceFieldSortRule = Extract<DailyPresenceSortCriterion, { type: 'field' }> & {
   id: string
+  sortGroup: DailyPresenceSortGroup
 }
 
 export type DailyPresenceSortRule =
@@ -123,7 +128,8 @@ export function getBaseReportFilters(reportType: AdminReportType): ReportFilters
     organization: '',
     dailyPresenceSort: [
       {
-        id: 'daily-sort-last-name',
+        id: 'daily-sort-secondary-last-name',
+        sortGroup: 'secondary',
         type: 'field',
         field: 'last_name',
         direction: 'asc',

--- a/apps/frontend-admin/src/components/admin/reports/report-preview.tsx
+++ b/apps/frontend-admin/src/components/admin/reports/report-preview.tsx
@@ -21,7 +21,6 @@ import { sortTagsByDisplayOrder } from '@/lib/tag-priority'
 import { cn } from '@/lib/utils'
 import {
   formatBooleanPresence,
-  formatDuration,
   formatPercent,
   formatReportDateTime,
   formatReportTime,
@@ -78,18 +77,20 @@ export function ReportPreview({ report, isLoading, errorMessage }: ReportPreview
     )
   }
 
-  if (errorMessage && !report) {
-    return (
-      <section className="rounded-box border border-error/35 bg-error-fadded p-(--space-6) text-error-fadded-content shadow-[var(--shadow-1)]">
-        <div className="flex items-start gap-(--space-3)" role="alert">
-          <AlertTriangle className="mt-1 h-5 w-5 shrink-0" aria-hidden="true" />
-          <div>
-            <h2 className="font-semibold">Report could not be generated</h2>
-            <p className="mt-(--space-1) text-sm">{errorMessage}</p>
-          </div>
+  const errorBanner = errorMessage ? (
+    <section className="rounded-box border border-error/35 bg-error-fadded p-(--space-4) text-error-fadded-content shadow-[var(--shadow-1)]">
+      <div className="flex items-start gap-(--space-3)" role="alert">
+        <AlertTriangle className="mt-1 h-5 w-5 shrink-0" aria-hidden="true" />
+        <div>
+          <h2 className="font-semibold">Report could not be generated</h2>
+          <p className="mt-(--space-1) text-sm">{errorMessage}</p>
         </div>
-      </section>
-    )
+      </div>
+    </section>
+  ) : null
+
+  if (errorMessage && !report) {
+    return errorBanner
   }
 
   if (!report) {
@@ -105,18 +106,21 @@ export function ReportPreview({ report, isLoading, errorMessage }: ReportPreview
   }
 
   return (
-    <ReportDocumentFrame report={report} isRefreshing={isLoading}>
-      {report.reportType === 'daily_presence' && <DailyPresenceReport report={report} />}
-      {report.reportType === 'weekly_presence' && <WeeklyPresenceReport report={report} />}
-      {report.reportType === 'monthly_presence' && <MonthlyPresenceReport report={report} />}
-      {report.reportType === 'training_night_monthly' && (
-        <TrainingNightMonthlyReport report={report} />
-      )}
-      {report.reportType === 'visitor_activity' && <VisitorActivityReport report={report} />}
-      {report.reportType === 'operational_exceptions' && (
-        <OperationalExceptionsReport report={report} />
-      )}
-    </ReportDocumentFrame>
+    <div className="space-y-(--space-3)">
+      {errorBanner}
+      <ReportDocumentFrame report={report} isRefreshing={isLoading}>
+        {report.reportType === 'daily_presence' && <DailyPresenceReport report={report} />}
+        {report.reportType === 'weekly_presence' && <WeeklyPresenceReport report={report} />}
+        {report.reportType === 'monthly_presence' && <MonthlyPresenceReport report={report} />}
+        {report.reportType === 'training_night_monthly' && (
+          <TrainingNightMonthlyReport report={report} />
+        )}
+        {report.reportType === 'visitor_activity' && <VisitorActivityReport report={report} />}
+        {report.reportType === 'operational_exceptions' && (
+          <OperationalExceptionsReport report={report} />
+        )}
+      </ReportDocumentFrame>
+    </div>
   )
 }
 
@@ -129,6 +133,9 @@ function ReportDocumentFrame({
   isRefreshing: boolean
   children: ReactNode
 }) {
+  const warningDetails = report.warningDetails ?? []
+  const detailedWarningMessages = new Set(warningDetails.map((detail) => detail.message))
+
   const isMatrixReport =
     report.reportType === 'weekly_presence' ||
     report.reportType === 'monthly_presence' ||
@@ -169,9 +176,6 @@ function ReportDocumentFrame({
         </div>
 
         <div className="mt-(--space-4) flex flex-wrap gap-(--space-2) text-xs text-base-content/65">
-          <span className="rounded-box bg-base-200 px-(--space-2) py-(--space-1)">
-            {report.dateRange.startDate} to {report.dateRange.endDate}
-          </span>
           {report.filters.divisionId && (
             <span className="rounded-box bg-base-200 px-(--space-2) py-(--space-1)">
               Department filter
@@ -210,9 +214,21 @@ function ReportDocumentFrame({
             <div>
               <p className="font-semibold">Report warnings</p>
               <ul className="mt-(--space-1) list-disc space-y-1 pl-(--space-4)">
-                {report.warnings.map((warning) => (
-                  <li key={warning}>{warning}</li>
+                {warningDetails.map((detail) => (
+                  <li key={detail.message}>
+                    <span>{detail.message}</span>
+                    {detail.accounts.length > 0 && (
+                      <span className="mt-(--space-1) block text-xs">
+                        Accounts: {detail.accounts.map((account) => account.displayName).join(', ')}
+                      </span>
+                    )}
+                  </li>
                 ))}
+                {report.warnings
+                  .filter((warning) => !detailedWarningMessages.has(warning))
+                  .map((warning) => (
+                    <li key={warning}>{warning}</li>
+                  ))}
               </ul>
             </div>
           </div>
@@ -267,72 +283,70 @@ function DailyPresenceReport({ report }: { report: DailyPresenceReportResponse }
               <col className="reports-daily-tags-col" />
               <col className="reports-daily-time-col" />
               <col className="reports-daily-last-out-col" />
-              <col className="reports-daily-returned-col" />
-              <col className="reports-daily-session-col" />
+              <col className="reports-daily-presence-col" />
             </colgroup>
             <thead>
               <tr>
                 <th>Member</th>
                 <th>Department</th>
                 <th>Tags</th>
-                <th>First in</th>
-                <th>Last out</th>
-                <th>Returned</th>
-                <th className="text-right">Sessions</th>
+                <th>Check-In</th>
+                <th>Check-Out</th>
+                <th>Presence</th>
               </tr>
             </thead>
             <tbody>
-              {rows.map((row) => (
-                <tr key={row.member.id}>
-                  <td className="reports-member-cell">
-                    <MemberName member={row.member} />
-                  </td>
-                  <td className="reports-department-cell">
-                    {row.member.division?.code ?? row.member.division?.name ?? 'Unassigned'}
-                  </td>
-                  <td className="reports-tags-cell">
-                    <TagList tags={row.member.tags} />
-                  </td>
-                  <td className="reports-time-cell font-mono">{formatReportTime(row.firstIn)}</td>
-                  <td className="reports-time-cell font-mono">
-                    {row.lastOut ? (
-                      formatReportTime(row.lastOut)
-                    ) : (
-                      <>
-                        <span className="reports-screen-only">Still present</span>
-                        <span className="hidden reports-print-inline">Present</span>
-                      </>
-                    )}
-                  </td>
-                  <td>
-                    <span className="reports-screen-only">
-                      <AppBadge status={row.leftAndReturned ? 'warning' : 'neutral'} size="sm">
-                        {row.leftAndReturned ? `Yes — ${row.sessionCount} sessions` : 'No'}
-                      </AppBadge>
-                    </span>
-                    <span className="hidden reports-print-inline font-mono">
-                      {row.leftAndReturned ? 'Yes' : 'No'}
-                    </span>
-                  </td>
-                  <td className="reports-session-cell text-right font-mono">
-                    <details className="reports-screen-only">
-                      <summary className="cursor-pointer text-sm font-semibold text-info">
-                        {row.sessionCount}
-                      </summary>
-                      <div className="mt-(--space-2) space-y-(--space-1) text-xs text-base-content/70">
-                        {row.sessions.map((session) => (
-                          <p key={`${row.member.id}-${session.inAt}`}>
-                            {formatReportTime(session.inAt)} -{' '}
-                            {session.outAt ? formatReportTime(session.outAt) : 'Open'} ·{' '}
-                            {formatDuration(session.durationMinutes)}
-                          </p>
+              {rows.map((row) => {
+                const isPresent = row.sessions.some((session) => session.status === 'open')
+
+                return (
+                  <tr key={row.member.id}>
+                    <td className="reports-member-cell">
+                      <MemberName member={row.member} />
+                    </td>
+                    <td className="reports-department-cell">
+                      {row.member.division?.code ?? row.member.division?.name ?? 'Unassigned'}
+                    </td>
+                    <td className="reports-tags-cell">
+                      <TagList tags={row.member.tags} />
+                    </td>
+                    <td className="reports-time-cell font-mono">
+                      <div className="grid gap-(--space-1)">
+                        {row.sessions.map((session, sessionIndex) => (
+                          <span key={`${row.member.id}-in-${session.inAt}-${sessionIndex}`}>
+                            {formatReportTime(session.inAt)}
+                          </span>
                         ))}
                       </div>
-                    </details>
-                    <span className="hidden reports-print-inline">{row.sessionCount}</span>
-                  </td>
-                </tr>
-              ))}
+                    </td>
+                    <td className="reports-time-cell font-mono">
+                      <div className="grid gap-(--space-1)">
+                        {row.sessions.map((session, sessionIndex) => (
+                          <span key={`${row.member.id}-out-${session.inAt}-${sessionIndex}`}>
+                            {session.outAt ? (
+                              formatReportTime(session.outAt)
+                            ) : session.status === 'degraded' ? (
+                              <span className="text-warning-fadded-content">Missing</span>
+                            ) : (
+                              <span className="text-base-content/45">—</span>
+                            )}
+                          </span>
+                        ))}
+                      </div>
+                    </td>
+                    <td>
+                      <span className="reports-screen-only">
+                        <AppBadge status={isPresent ? 'success' : 'neutral'} size="sm">
+                          {isPresent ? 'Present' : 'Out'}
+                        </AppBadge>
+                      </span>
+                      <span className="hidden reports-print-inline font-mono">
+                        {isPresent ? 'Present' : 'Out'}
+                      </span>
+                    </td>
+                  </tr>
+                )
+              })}
             </tbody>
           </table>
         </div>
@@ -776,9 +790,7 @@ function MemberName({ member }: { member: ReportMemberSummary }) {
   return (
     <div>
       <p className="font-semibold leading-tight">{member.displayName}</p>
-      <p className="text-xs text-base-content/55">
-        {member.memberType ?? 'Member'} · {member.status}
-      </p>
+      <p className="text-xs text-base-content/55">{member.memberType ?? 'Member'}</p>
     </div>
   )
 }

--- a/apps/frontend-admin/src/components/dashboard/status-stats.tsx
+++ b/apps/frontend-admin/src/components/dashboard/status-stats.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useMemo, useState, useSyncExternalStore } from 'react'
 import type { ReactNode } from 'react'
 import {
   Users,
@@ -36,6 +36,24 @@ const DUTY_WATCH_POSITION_ORDER = ['SWK', 'DSWK', 'QM', 'BM', 'APS'] as const
 const DUTY_WATCH_POSITION_ORDER_INDEX = new Map<string, number>(
   DUTY_WATCH_POSITION_ORDER.map((code, index) => [code, index])
 )
+
+function subscribeToAuthHydration(onStoreChange: () => void): () => void {
+  const unsubscribe = useAuthStore.persist.onFinishHydration(onStoreChange)
+
+  if (useAuthStore.persist.hasHydrated()) {
+    globalThis.queueMicrotask(onStoreChange)
+  }
+
+  return unsubscribe
+}
+
+function getAuthHydrationSnapshot(): boolean {
+  return useAuthStore.persist.hasHydrated()
+}
+
+function getServerAuthHydrationSnapshot(): boolean {
+  return false
+}
 
 function getDutyWatchPositionSortIndex(assignment: DutyWatchTeamResponse['team'][number]): number {
   const code = assignment.position?.code
@@ -699,6 +717,11 @@ function StatusActionsStat({
 
 export function StatusStats() {
   const member = useAuthStore((state) => state.member)
+  const hasHydrated = useSyncExternalStore(
+    subscribeToAuthHydration,
+    getAuthHydrationSnapshot,
+    getServerAuthHydrationSnapshot
+  )
   const [isTransferScanModalOpen, setIsTransferScanModalOpen] = useState(false)
   const [isSetTodayDdsOpen, setIsSetTodayDdsOpen] = useState(false)
   const [isOpenBuildingOpen, setIsOpenBuildingOpen] = useState(false)
@@ -708,7 +731,7 @@ export function StatusStats() {
   const currentHolder = lockupStatus?.currentHolder
   const buildingStatus = lockupStatus?.buildingStatus
   const { data: checkoutOptions } = useCheckoutOptions(currentHolder?.id ?? '')
-  const isAdmin = (member?.accountLevel ?? 0) >= AccountLevel.ADMIN
+  const isAdmin = hasHydrated && (member?.accountLevel ?? 0) >= AccountLevel.ADMIN
   const isSecured = buildingStatus === 'secured'
   const isOpenWithHolder = buildingStatus === 'open' && !!currentHolder
   const isOpenNoHolder = buildingStatus === 'open' && !currentHolder

--- a/apps/frontend-admin/src/components/kiosk/use-kiosk-screen.ts
+++ b/apps/frontend-admin/src/components/kiosk/use-kiosk-screen.ts
@@ -6,11 +6,20 @@ import { startTransition, useEffect, useMemo, useRef, useState } from 'react'
 import { useReducedMotion } from 'motion/react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useAcceptDds, useDdsStatus, useKioskResponsibilityState } from '@/hooks/use-dds'
+import { useKioskSoundSettings } from '@/hooks/use-kiosk-sound-settings'
 import { useCheckoutOptions, useLockupStatus, useOpenBuilding } from '@/hooks/use-lockup'
 import { useCurrentDds, useTonightDutyWatch } from '@/hooks/use-schedules'
 import { useSystemStatus } from '@/hooks/use-system-status'
 import { apiClient } from '@/lib/api-client'
 import { invalidateDashboardQueries } from '@/lib/dashboard-query-invalidation'
+import {
+  getDefaultKioskSoundSettings,
+  playKioskSound,
+  preloadKioskSounds,
+  unlockKioskSoundPlayback,
+  type KioskSoundEvent,
+  type KioskSoundSettings,
+} from '@/lib/kiosk-sound-settings'
 import {
   ASSIGNMENT_SUMMARY_CACHE_MS,
   BADGE_FOCUS_REQUEST_EVENT,
@@ -75,11 +84,13 @@ export function useKioskScreen() {
     lastError: null,
   })
   const replayInFlightRef = useRef(false)
+  const kioskSoundSettingsRef = useRef<KioskSoundSettings>(getDefaultKioskSoundSettings())
 
   const { data: checkoutOptions, isLoading: loadingCheckoutOptions } = useCheckoutOptions(
     pendingLockup?.memberId ?? ''
   )
   const systemStatusQuery = useSystemStatus()
+  const kioskSoundSettingsQuery = useKioskSoundSettings()
   const ddsStatusQuery = useDdsStatus()
   const lockupStatusQuery = useLockupStatus()
   const scheduledDdsQuery = useCurrentDds()
@@ -198,10 +209,23 @@ export function useKioskScreen() {
     ])
   }
 
+  const playScanFeedback = (event: KioskSoundEvent) => {
+    void playKioskSound(kioskSoundSettingsRef.current, event).catch(() => undefined)
+  }
+
   useEffect(() => {
     const timer = window.setInterval(() => setNow(new Date()), 1000)
     return () => window.clearInterval(timer)
   }, [])
+
+  useEffect(() => {
+    if (!kioskSoundSettingsQuery.data) {
+      return
+    }
+
+    kioskSoundSettingsRef.current = kioskSoundSettingsQuery.data
+    preloadKioskSounds(kioskSoundSettingsQuery.data)
+  }, [kioskSoundSettingsQuery.data])
 
   useEffect(() => {
     const currentQueue = loadQueuedScans()
@@ -410,6 +434,7 @@ export function useKioskScreen() {
       setResponsibilityContext(null)
 
       if (scanResult.type === 'visitor') {
+        playScanFeedback('warning')
         setPendingLockup(null)
         setShowLockupOptions(false)
         setResult({
@@ -425,6 +450,7 @@ export function useKioskScreen() {
       }
 
       if (scanResult.type === 'lockup') {
+        playScanFeedback('warning')
         setPendingLockup({
           memberId: scanResult.memberId,
           memberName: scanResult.memberName,
@@ -448,6 +474,7 @@ export function useKioskScreen() {
       }
 
       if (scanResult.type === 'queued') {
+        playScanFeedback('warning')
         setPendingLockup(null)
         setShowLockupOptions(false)
         setResult({
@@ -466,6 +493,7 @@ export function useKioskScreen() {
       }
 
       if (scanResult.type === 'temporary_personnel') {
+        playScanFeedback(scanResult.direction === 'in' ? 'scan_in' : 'scan_out')
         setPendingLockup(null)
         setShowLockupOptions(false)
         setResult({
@@ -495,6 +523,7 @@ export function useKioskScreen() {
       }
 
       setPendingLockup(null)
+      playScanFeedback(scanResult.direction === 'in' ? 'scan_in' : 'scan_out')
       setShowLockupOptions(false)
       setResult({
         tone: toneForDirection(scanResult.direction),
@@ -511,6 +540,7 @@ export function useKioskScreen() {
       refocusBadgeInput()
     },
     onError: (error) => {
+      playScanFeedback('error')
       setSerial('')
       setPendingLockup(null)
       setShowLockupOptions(false)
@@ -675,6 +705,7 @@ export function useKioskScreen() {
 
     setPendingLockup(null)
     setShowLockupOptions(false)
+    void unlockKioskSoundPlayback(kioskSoundSettingsRef.current)
     scanMutation.mutate(liveSerial)
   }
 
@@ -684,6 +715,7 @@ export function useKioskScreen() {
     const checkoutContext = pendingLockup
 
     if (action === 'execute') {
+      playScanFeedback('scan_out')
       setPendingLockup(null)
       setShowLockupOptions(false)
       setResult({
@@ -713,6 +745,7 @@ export function useKioskScreen() {
       })
 
       if (createResult.kind === 'lockup') {
+        playScanFeedback('warning')
         setShowLockupOptions(true)
         setResult({
           tone: 'warning',
@@ -728,6 +761,7 @@ export function useKioskScreen() {
         return
       }
 
+      playScanFeedback('scan_out')
       setPendingLockup(null)
       setShowLockupOptions(false)
       setResult({
@@ -744,6 +778,7 @@ export function useKioskScreen() {
       invalidateKioskQueries()
       refocusBadgeInput()
     } catch (error) {
+      playScanFeedback('error')
       setPendingLockup(null)
       setShowLockupOptions(false)
       setResult({

--- a/apps/frontend-admin/src/components/settings/kiosk-sound-settings-panel.tsx
+++ b/apps/frontend-admin/src/components/settings/kiosk-sound-settings-panel.tsx
@@ -1,0 +1,435 @@
+'use client'
+
+/* global File, FileReader */
+
+import { useMemo, useState } from 'react'
+import { FileAudio, Play, RotateCcw, Save, Volume2, VolumeX } from 'lucide-react'
+import { toast } from 'sonner'
+import type { KioskSystemSoundId } from '@sentinel/contracts'
+import {
+  AppCard,
+  AppCardContent,
+  AppCardDescription,
+  AppCardHeader,
+  AppCardTitle,
+} from '@/components/ui/AppCard'
+import { AppBadge } from '@/components/ui/AppBadge'
+import { ButtonSpinner } from '@/components/ui/loading-spinner'
+import {
+  getDefaultKioskSoundSettings,
+  KIOSK_SOUND_EVENTS,
+  KIOSK_SYSTEM_SOUND_OPTIONS,
+  playKioskSound,
+  type CustomKioskSoundSource,
+  type KioskSoundEvent,
+  type KioskSoundSettings,
+  type KioskSoundSource,
+} from '@/lib/kiosk-sound-settings'
+import { useKioskSoundSettings, useSaveKioskSoundSettings } from '@/hooks/use-kiosk-sound-settings'
+
+const CUSTOM_SOUND_MAX_BYTES = 1024 * 1024
+const ACCEPTED_AUDIO_TYPES = ['audio/mpeg', 'audio/mp3', 'audio/wav', 'audio/x-wav', 'audio/ogg']
+
+function cloneSettings(settings: KioskSoundSettings): KioskSoundSettings {
+  return JSON.parse(JSON.stringify(settings)) as KioskSoundSettings
+}
+
+function formatPercent(value: number): string {
+  return `${Math.round(value * 100)}%`
+}
+
+function formatBytes(value: number): string {
+  if (value < 1024) {
+    return `${value} B`
+  }
+
+  if (value < 1024 * 1024) {
+    return `${Math.round(value / 1024)} KB`
+  }
+
+  return `${(value / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function getSourceSelectValue(source: KioskSoundSource): string {
+  if (source.type === 'none') {
+    return 'none'
+  }
+
+  if (source.type === 'custom') {
+    return 'custom'
+  }
+
+  return `system:${source.id}`
+}
+
+function getSourceLabel(source: KioskSoundSource): string {
+  if (source.type === 'none') {
+    return 'No sound'
+  }
+
+  if (source.type === 'custom') {
+    return `${source.name} · ${formatBytes(source.size)}`
+  }
+
+  const option = KIOSK_SYSTEM_SOUND_OPTIONS.find((candidate) => candidate.id === source.id)
+  return option ? `${option.theme} · ${option.label}` : source.id
+}
+
+function createCustomSoundSource(file: File, dataUrl: string): CustomKioskSoundSource {
+  return {
+    type: 'custom',
+    name: file.name,
+    mimeType: file.type,
+    size: file.size,
+    dataUrl,
+  }
+}
+
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+
+    reader.addEventListener('load', () => {
+      if (typeof reader.result === 'string') {
+        resolve(reader.result)
+        return
+      }
+
+      reject(new Error('Selected file could not be read.'))
+    })
+
+    reader.addEventListener('error', () => reject(new Error('Selected file could not be read.')))
+    reader.readAsDataURL(file)
+  })
+}
+
+async function fileToCustomSoundSource(file: File): Promise<CustomKioskSoundSource> {
+  if (!ACCEPTED_AUDIO_TYPES.includes(file.type)) {
+    throw new Error('Use an MP3, WAV, or OGG audio file.')
+  }
+
+  if (file.size > CUSTOM_SOUND_MAX_BYTES) {
+    throw new Error('Use a sound file that is 1 MB or smaller.')
+  }
+
+  const dataUrl = await readFileAsDataUrl(file)
+  if (!dataUrl.startsWith('data:audio/')) {
+    throw new Error('The selected file was not recognized as audio.')
+  }
+
+  return createCustomSoundSource(file, dataUrl)
+}
+
+export function KioskSoundSettingsPanel() {
+  const { data: settings, isLoading, isError, error } = useKioskSoundSettings()
+
+  if (isLoading) {
+    return (
+      <AppCard>
+        <AppCardContent className="py-(--space-10) text-center text-base-content/60">
+          Loading kiosk sound settings...
+        </AppCardContent>
+      </AppCard>
+    )
+  }
+
+  if (isError) {
+    return (
+      <AppCard status="error">
+        <AppCardHeader>
+          <AppCardTitle>Kiosk scan sounds</AppCardTitle>
+          <AppCardDescription>
+            {error instanceof Error ? error.message : 'Failed to load kiosk sound settings.'}
+          </AppCardDescription>
+        </AppCardHeader>
+      </AppCard>
+    )
+  }
+
+  return <KioskSoundSettingsEditor settings={settings ?? getDefaultKioskSoundSettings()} />
+}
+
+function KioskSoundSettingsEditor({ settings }: { settings: KioskSoundSettings }) {
+  const saveSettings = useSaveKioskSoundSettings()
+  const [draft, setDraft] = useState<KioskSoundSettings>(() => cloneSettings(settings))
+  const [customEvent, setCustomEvent] = useState<KioskSoundEvent | null>(null)
+
+  const isDirty = useMemo(
+    () => JSON.stringify(draft) !== JSON.stringify(settings),
+    [draft, settings]
+  )
+
+  const setEventSource = (eventId: KioskSoundEvent, source: KioskSoundSource) => {
+    setDraft((current) => ({
+      ...current,
+      events: {
+        ...current.events,
+        [eventId]: source,
+      },
+    }))
+  }
+
+  const handleSelectSource = (eventId: KioskSoundEvent, value: string) => {
+    if (value === 'none') {
+      setCustomEvent(null)
+      setEventSource(eventId, { type: 'none' })
+      return
+    }
+
+    if (value === 'custom') {
+      setCustomEvent(eventId)
+      return
+    }
+
+    const systemId = value.replace(/^system:/, '') as KioskSystemSoundId
+    setCustomEvent(null)
+    setEventSource(eventId, { type: 'system', id: systemId })
+  }
+
+  const handleCustomFile = async (eventId: KioskSoundEvent, file: File | null) => {
+    if (!file) {
+      return
+    }
+
+    try {
+      const source = await fileToCustomSoundSource(file)
+      setEventSource(eventId, source)
+      setCustomEvent(null)
+      toast.success(
+        `Custom sound added for ${KIOSK_SOUND_EVENTS.find((item) => item.id === eventId)?.label}`
+      )
+    } catch (fileError) {
+      toast.error(fileError instanceof Error ? fileError.message : 'Failed to read sound file')
+    }
+  }
+
+  const handleTest = async (eventId: KioskSoundEvent) => {
+    try {
+      const played = await playKioskSound(draft, eventId)
+      if (!played) {
+        toast.message('No sound selected for this event')
+        return
+      }
+      toast.success('Sound test played')
+    } catch {
+      toast.error('Browser blocked playback. Click the page once and try again.')
+    }
+  }
+
+  const handleSave = async () => {
+    try {
+      await saveSettings.mutateAsync(draft)
+      toast.success('Kiosk sound settings saved')
+    } catch (saveError) {
+      toast.error(saveError instanceof Error ? saveError.message : 'Failed to save sound settings')
+    }
+  }
+
+  return (
+    <div className="grid gap-(--space-4) xl:grid-cols-[minmax(0,1fr)_20rem]">
+      <AppCard>
+        <AppCardHeader>
+          <div className="flex flex-wrap items-start justify-between gap-(--space-3)">
+            <div>
+              <AppCardTitle>Kiosk scan sounds</AppCardTitle>
+              <AppCardDescription>
+                Pick the audio feedback used after badge scans on the kiosk.
+              </AppCardDescription>
+            </div>
+            <AppBadge status={draft.enabled ? 'success' : 'neutral'}>
+              {draft.enabled ? 'Enabled' : 'Muted'}
+            </AppBadge>
+          </div>
+        </AppCardHeader>
+        <AppCardContent className="space-y-(--space-4)">
+          <div className="grid gap-(--space-3) border-b border-base-300 pb-(--space-4) lg:grid-cols-[minmax(0,1fr)_16rem]">
+            <label className="flex items-center gap-(--space-3)">
+              <input
+                type="checkbox"
+                className="toggle toggle-primary"
+                checked={draft.enabled}
+                onChange={(event) =>
+                  setDraft((current) => ({ ...current, enabled: event.target.checked }))
+                }
+              />
+              <span className="min-w-0">
+                <span className="block text-sm font-semibold">Play kiosk scan sounds</span>
+                <span className="block text-xs text-base-content/60">
+                  Turns all configured scan sounds on or off.
+                </span>
+              </span>
+            </label>
+
+            <label className="grid gap-(--space-1)">
+              <span className="flex items-center justify-between gap-(--space-2) text-sm font-semibold">
+                <span>Volume</span>
+                <span className="font-mono text-xs text-base-content/60">
+                  {formatPercent(draft.volume)}
+                </span>
+              </span>
+              <input
+                type="range"
+                min={0}
+                max={100}
+                value={Math.round(draft.volume * 100)}
+                className="range range-primary range-sm"
+                onChange={(event) =>
+                  setDraft((current) => ({
+                    ...current,
+                    volume: Number(event.target.value) / 100,
+                  }))
+                }
+              />
+            </label>
+          </div>
+
+          <div className="grid gap-(--space-3)">
+            {KIOSK_SOUND_EVENTS.map((eventDefinition) => {
+              const source = draft.events[eventDefinition.id]
+              const showCustomInput = customEvent === eventDefinition.id || source.type === 'custom'
+
+              return (
+                <section
+                  key={eventDefinition.id}
+                  className="grid gap-(--space-3) border border-base-300 bg-base-200/50 p-(--space-3) lg:grid-cols-[minmax(0,1fr)_minmax(18rem,24rem)_auto]"
+                >
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold">{eventDefinition.label}</p>
+                    <p className="mt-(--space-1) text-xs leading-snug text-base-content/60">
+                      {eventDefinition.description}
+                    </p>
+                    <p className="mt-(--space-2) truncate text-xs text-base-content/55">
+                      {getSourceLabel(source)}
+                    </p>
+                  </div>
+
+                  <div className="grid gap-(--space-2)">
+                    <select
+                      className="select select-bordered select-sm w-full"
+                      value={
+                        customEvent === eventDefinition.id ? 'custom' : getSourceSelectValue(source)
+                      }
+                      onChange={(selectEvent) =>
+                        handleSelectSource(eventDefinition.id, selectEvent.target.value)
+                      }
+                    >
+                      <option value="none">No sound</option>
+                      <option value="custom">Select custom sound file...</option>
+                      {KIOSK_SYSTEM_SOUND_OPTIONS.map((option) => (
+                        <option key={option.id} value={`system:${option.id}`}>
+                          {option.theme} - {option.label} ({option.fileName})
+                        </option>
+                      ))}
+                    </select>
+
+                    {showCustomInput ? (
+                      <input
+                        type="file"
+                        className="file-input file-input-bordered file-input-sm w-full"
+                        accept=".mp3,.wav,.ogg,audio/mpeg,audio/wav,audio/ogg"
+                        onChange={(fileEvent) => {
+                          void handleCustomFile(
+                            eventDefinition.id,
+                            fileEvent.target.files?.[0] ?? null
+                          )
+                          fileEvent.target.value = ''
+                        }}
+                      />
+                    ) : null}
+                  </div>
+
+                  <button
+                    type="button"
+                    className="btn btn-outline btn-sm self-start"
+                    onClick={() => void handleTest(eventDefinition.id)}
+                    disabled={!draft.enabled || source.type === 'none'}
+                  >
+                    <Play className="h-4 w-4" />
+                    Test
+                  </button>
+                </section>
+              )
+            })}
+          </div>
+
+          <div className="flex flex-wrap items-center justify-end gap-(--space-2) border-t border-base-300 pt-(--space-4)">
+            <button
+              type="button"
+              className="btn btn-outline btn-sm"
+              onClick={() => {
+                setDraft(getDefaultKioskSoundSettings())
+                setCustomEvent(null)
+              }}
+            >
+              <RotateCcw className="h-4 w-4" />
+              Defaults
+            </button>
+            <button
+              type="button"
+              className="btn btn-ghost btn-sm"
+              onClick={() => {
+                setDraft(cloneSettings(settings))
+                setCustomEvent(null)
+              }}
+              disabled={!isDirty || saveSettings.isPending}
+            >
+              Discard
+            </button>
+            <button
+              type="button"
+              className="btn btn-primary btn-sm"
+              onClick={() => void handleSave()}
+              disabled={!isDirty || saveSettings.isPending}
+            >
+              {saveSettings.isPending ? <ButtonSpinner /> : <Save className="h-4 w-4" />}
+              Save
+            </button>
+          </div>
+        </AppCardContent>
+      </AppCard>
+
+      <AppCard className="self-start">
+        <AppCardHeader>
+          <AppCardTitle>Current setup</AppCardTitle>
+          <AppCardDescription>
+            Saved sounds apply to the kiosk after the next scan.
+          </AppCardDescription>
+        </AppCardHeader>
+        <AppCardContent className="grid gap-(--space-3)">
+          <div className="flex items-center gap-(--space-3) bg-base-200 p-(--space-3)">
+            {draft.enabled ? (
+              <Volume2 className="h-5 w-5 text-success" aria-hidden="true" />
+            ) : (
+              <VolumeX className="h-5 w-5 text-base-content/50" aria-hidden="true" />
+            )}
+            <div className="min-w-0">
+              <p className="text-sm font-semibold">
+                {draft.enabled ? `${formatPercent(draft.volume)} volume` : 'Muted'}
+              </p>
+              <p className="text-xs text-base-content/60">
+                {draft.enabled ? 'Kiosk scan feedback is active.' : 'No scan sounds will play.'}
+              </p>
+            </div>
+          </div>
+
+          <div className="grid gap-(--space-2)">
+            {KIOSK_SOUND_EVENTS.map((eventDefinition) => (
+              <div
+                key={eventDefinition.id}
+                className="grid grid-cols-[1rem_minmax(0,1fr)] gap-(--space-2) text-sm"
+              >
+                <FileAudio className="mt-0.5 h-4 w-4 text-base-content/50" aria-hidden="true" />
+                <div className="min-w-0">
+                  <p className="font-medium">{eventDefinition.label}</p>
+                  <p className="truncate text-xs text-base-content/60">
+                    {getSourceLabel(draft.events[eventDefinition.id])}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </AppCardContent>
+      </AppCard>
+    </div>
+  )
+}

--- a/apps/frontend-admin/src/components/ui/motion-button.tsx
+++ b/apps/frontend-admin/src/components/ui/motion-button.tsx
@@ -1,41 +1,61 @@
 'use client'
 
-import type { HTMLMotionProps } from 'motion/react'
+import type { ComponentPropsWithoutRef, ReactNode } from 'react'
 import { motion, useReducedMotion } from 'motion/react'
 
-interface MotionButtonProps extends HTMLMotionProps<'button'> {
+interface MotionButtonProps extends Omit<ComponentPropsWithoutRef<'button'>, 'children'> {
+  children?: ReactNode
   hoverPreset?: 'lift' | 'micro'
 }
 
 export function MotionButton({
   children,
+  className,
   disabled,
   hoverPreset = 'lift',
+  onClick,
+  tabIndex,
   type = 'button',
   ...props
 }: MotionButtonProps) {
   const shouldReduceMotion = useReducedMotion()
+  const isDisabled = Boolean(disabled)
+  const disabledClassName = isDisabled ? 'pointer-events-none opacity-40' : ''
+  const resolvedClassName = [className, disabledClassName].filter(Boolean).join(' ')
+
+  const handleClick: NonNullable<ComponentPropsWithoutRef<'button'>['onClick']> = (event) => {
+    if (isDisabled) {
+      event.preventDefault()
+      event.stopPropagation()
+      return
+    }
+
+    onClick?.(event)
+  }
 
   const whileHover =
-    shouldReduceMotion || disabled
+    shouldReduceMotion || isDisabled
       ? undefined
       : hoverPreset === 'micro'
         ? { y: -1, scale: 1.015 }
         : { y: -2, scale: 1.02 }
 
-  const whileTap = shouldReduceMotion || disabled ? undefined : { y: 0, scale: 0.985 }
+  const whileTap = shouldReduceMotion || isDisabled ? undefined : { y: 0, scale: 0.985 }
   const transition = shouldReduceMotion
     ? { duration: 0 }
     : { duration: 0.16, ease: 'easeOut' as const }
 
   return (
     <motion.button
+      {...(props as ComponentPropsWithoutRef<typeof motion.button>)}
       type={type}
-      disabled={disabled}
+      aria-disabled={isDisabled || undefined}
+      className={resolvedClassName}
+      onClick={handleClick}
+      tabIndex={isDisabled ? -1 : tabIndex}
       whileHover={whileHover}
       whileTap={whileTap}
       transition={transition}
-      {...props}
     >
       {children}
     </motion.button>

--- a/apps/frontend-admin/src/hooks/use-admin-reports.ts
+++ b/apps/frontend-admin/src/hooks/use-admin-reports.ts
@@ -52,16 +52,68 @@ export type RunAdminReportInput =
     }
 
 function getApiErrorMessage(body: unknown, fallback: string): string {
-  if (
+  const message =
     typeof body === 'object' &&
     body !== null &&
     'message' in body &&
     typeof (body as { message?: unknown }).message === 'string'
+      ? (body as { message: string }).message
+      : fallback
+
+  if (
+    typeof body === 'object' &&
+    body !== null &&
+    'issues' in body &&
+    Array.isArray((body as { issues?: unknown }).issues)
   ) {
-    return (body as { message: string }).message
+    const issueMessages = (body as { issues: unknown[] }).issues
+      .map((issue) => formatValidationIssue(issue))
+      .filter((issueMessage): issueMessage is string => Boolean(issueMessage))
+
+    if (issueMessages.length > 0) {
+      return `${message}: ${issueMessages.join('; ')}`
+    }
   }
 
-  return fallback
+  return message
+}
+
+function formatValidationIssue(issue: unknown): string | null {
+  if (typeof issue !== 'object' || issue === null) {
+    return null
+  }
+
+  const issueRecord = issue as { input?: unknown; message?: unknown; path?: unknown }
+  const message = typeof issueRecord.message === 'string' ? issueRecord.message : null
+  if (!message) {
+    return null
+  }
+
+  if (message === 'Invalid daily presence sort field' && issueRecord.input === 'rank') {
+    return 'Rank sorting requires the updated reports API. Restart or rebuild the backend with the latest report contract, or remove Rank from the sort order.'
+  }
+
+  const path = formatValidationIssuePath(issueRecord.path)
+  return path ? `${path}: ${message}` : message
+}
+
+function formatValidationIssuePath(path: unknown): string | null {
+  if (!Array.isArray(path)) {
+    return null
+  }
+
+  const keys = path
+    .map((segment) => {
+      if (typeof segment !== 'object' || segment === null || !('key' in segment)) {
+        return null
+      }
+
+      const key = (segment as { key?: unknown }).key
+      return typeof key === 'string' || typeof key === 'number' ? String(key) : null
+    })
+    .filter((key): key is string => key !== null)
+
+  return keys.length > 0 ? keys.join('.') : null
 }
 
 export function useAdminReportRunner() {

--- a/apps/frontend-admin/src/hooks/use-kiosk-sound-settings.ts
+++ b/apps/frontend-admin/src/hooks/use-kiosk-sound-settings.ts
@@ -1,0 +1,103 @@
+'use client'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { apiClient } from '@/lib/api-client'
+import {
+  getDefaultKioskSoundSettings,
+  KIOSK_SOUND_SETTING_CATEGORY,
+  KIOSK_SOUND_SETTING_DESCRIPTION,
+  KIOSK_SOUND_SETTING_KEY,
+  parseKioskSoundSettings,
+  type KioskSoundSettings,
+} from '@/lib/kiosk-sound-settings'
+
+const kioskSoundSettingsQueryKey = ['kiosk-sound-settings'] as const
+
+function extractErrorMessage(body: unknown, fallback: string): string {
+  if (
+    body &&
+    typeof body === 'object' &&
+    'message' in body &&
+    typeof body.message === 'string' &&
+    body.message.trim().length > 0
+  ) {
+    return body.message
+  }
+
+  return fallback
+}
+
+async function fetchKioskSoundSettings(): Promise<KioskSoundSettings> {
+  const response = await apiClient.settings.getSettingByKey({
+    params: { key: KIOSK_SOUND_SETTING_KEY },
+  })
+
+  if (response.status === 404) {
+    return getDefaultKioskSoundSettings()
+  }
+
+  if (response.status !== 200) {
+    throw new Error(extractErrorMessage(response.body, 'Failed to load kiosk sound settings'))
+  }
+
+  return parseKioskSoundSettings(response.body.value) ?? getDefaultKioskSoundSettings()
+}
+
+async function upsertKioskSoundSettings(settings: KioskSoundSettings): Promise<KioskSoundSettings> {
+  const existing = await apiClient.settings.getSettingByKey({
+    params: { key: KIOSK_SOUND_SETTING_KEY },
+  })
+
+  if (existing.status === 200) {
+    const updated = await apiClient.settings.updateSetting({
+      params: { key: KIOSK_SOUND_SETTING_KEY },
+      body: {
+        value: settings,
+        description: KIOSK_SOUND_SETTING_DESCRIPTION,
+      },
+    })
+
+    if (updated.status !== 200) {
+      throw new Error(extractErrorMessage(updated.body, 'Failed to save kiosk sound settings'))
+    }
+
+    return parseKioskSoundSettings(updated.body.value) ?? getDefaultKioskSoundSettings()
+  }
+
+  if (existing.status === 404) {
+    const created = await apiClient.settings.createSetting({
+      body: {
+        key: KIOSK_SOUND_SETTING_KEY,
+        value: settings,
+        category: KIOSK_SOUND_SETTING_CATEGORY,
+        description: KIOSK_SOUND_SETTING_DESCRIPTION,
+      },
+    })
+
+    if (created.status !== 201) {
+      throw new Error(extractErrorMessage(created.body, 'Failed to create kiosk sound settings'))
+    }
+
+    return parseKioskSoundSettings(created.body.value) ?? getDefaultKioskSoundSettings()
+  }
+
+  throw new Error(extractErrorMessage(existing.body, 'Failed to resolve kiosk sound settings'))
+}
+
+export function useKioskSoundSettings() {
+  return useQuery({
+    queryKey: kioskSoundSettingsQueryKey,
+    queryFn: fetchKioskSoundSettings,
+  })
+}
+
+export function useSaveKioskSoundSettings() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: upsertKioskSoundSettings,
+    onSuccess: (settings) => {
+      queryClient.setQueryData(kioskSoundSettingsQueryKey, settings)
+    },
+  })
+}

--- a/apps/frontend-admin/src/lib/admin-routes.test.ts
+++ b/apps/frontend-admin/src/lib/admin-routes.test.ts
@@ -105,6 +105,9 @@ describe('ADMIN_NAV_ROUTES', () => {
     expect(resolveLegacyAdminPath('/settings', new URLSearchParams('tab=dashboard-sorting'))).toBe(
       '/admin/dashboard-sorting'
     )
+    expect(resolveLegacyAdminPath('/settings', new URLSearchParams('tab=kiosk-sounds'))).toBe(
+      '/admin/kiosk-sounds'
+    )
     expect(resolveLegacyAdminPath('/settings', new URLSearchParams('tab=tags'))).toBe(
       '/admin/config?tab=tags'
     )

--- a/apps/frontend-admin/src/lib/admin-routes.ts
+++ b/apps/frontend-admin/src/lib/admin-routes.ts
@@ -22,6 +22,7 @@ export type AdminRouteId =
   | 'temporary-personnel'
   | 'config'
   | 'timings'
+  | 'kiosk-sounds'
   | 'account-levels'
   | 'dashboard-sorting'
 
@@ -50,6 +51,7 @@ export type AdminIconKey =
   | 'logs'
   | 'network'
   | 'shield'
+  | 'volume'
   | 'terminal'
   | 'user-plus'
 
@@ -248,6 +250,22 @@ export const ADMIN_NAV_ROUTES = [
     aliases: ['operational timings', 'working hours', 'cutoffs', 'alert limits'],
     keywords: ['timings', 'schedule', 'cutoffs', 'working hours', 'alerts'],
     searchWeight: 79,
+    requiredRole: ADMIN_ROLE_LEVEL.ADMIN,
+    requiredCapabilities: ['admin:view', 'config:manage'],
+    navVisibility: 'sidebar',
+    featureStatus: 'available',
+  },
+  {
+    id: 'kiosk-sounds',
+    label: 'Kiosk Sounds',
+    href: '/admin/kiosk-sounds',
+    group: 'Settings',
+    tier: 1,
+    icon: 'volume',
+    description: 'Choose audio feedback for kiosk badge scan results.',
+    aliases: ['scan sounds', 'audio feedback', 'badge sounds', 'kiosk audio'],
+    keywords: ['kiosk', 'sounds', 'audio', 'scan', 'badge', 'feedback'],
+    searchWeight: 78,
     requiredRole: ADMIN_ROLE_LEVEL.ADMIN,
     requiredCapabilities: ['admin:view', 'config:manage'],
     navVisibility: 'sidebar',
@@ -540,6 +558,11 @@ export function resolveLegacyAdminPath(
   if (requestedTab === 'dashboard-sorting') {
     query.delete('tab')
     return withQuery('/admin/dashboard-sorting', query)
+  }
+
+  if (requestedTab === 'kiosk-sounds') {
+    query.delete('tab')
+    return withQuery('/admin/kiosk-sounds', query)
   }
 
   return withQuery('/admin/config', query)

--- a/apps/frontend-admin/src/lib/kiosk-sound-settings.test.ts
+++ b/apps/frontend-admin/src/lib/kiosk-sound-settings.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_KIOSK_SOUND_SETTINGS,
+  getKioskSystemSoundUrl,
+  parseKioskSoundSettings,
+  resolveKioskSoundUrl,
+  type KioskSoundSettings,
+} from './kiosk-sound-settings'
+
+describe('kiosk sound settings', () => {
+  it('parses valid settings and clamps volume', () => {
+    const parsed = parseKioskSoundSettings({
+      version: 1,
+      enabled: true,
+      volume: 2,
+      events: {
+        scan_in: { type: 'system', id: 'yaru-complete' },
+        scan_out: { type: 'none' },
+        warning: {
+          type: 'custom',
+          name: 'warning.ogg',
+          mimeType: 'audio/ogg',
+          size: 123,
+          dataUrl: 'data:audio/ogg;base64,c291bmQ=',
+        },
+        error: { type: 'system', id: 'yaru-error' },
+      },
+    })
+
+    expect(parsed).toEqual({
+      version: 1,
+      enabled: true,
+      volume: 1,
+      events: {
+        scan_in: { type: 'system', id: 'yaru-complete' },
+        scan_out: { type: 'none' },
+        warning: {
+          type: 'custom',
+          name: 'warning.ogg',
+          mimeType: 'audio/ogg',
+          size: 123,
+          dataUrl: 'data:audio/ogg;base64,c291bmQ=',
+        },
+        error: { type: 'system', id: 'yaru-error' },
+      },
+    })
+  })
+
+  it('falls back to defaults for invalid event sources', () => {
+    const parsed = parseKioskSoundSettings({
+      version: 1,
+      enabled: false,
+      volume: 0.25,
+      events: {
+        scan_in: { type: 'system', id: 'not-allowlisted' },
+        scan_out: { type: 'custom', dataUrl: 'data:text/plain;base64,nope' },
+        warning: { type: 'none' },
+        error: { type: 'system', id: 'yaru-error' },
+      },
+    })
+
+    expect(parsed?.events.scan_in).toEqual(DEFAULT_KIOSK_SOUND_SETTINGS.events.scan_in)
+    expect(parsed?.events.scan_out).toEqual(DEFAULT_KIOSK_SOUND_SETTINGS.events.scan_out)
+    expect(parsed?.events.warning).toEqual({ type: 'none' })
+  })
+
+  it('resolves system and custom playback URLs', () => {
+    const settings: KioskSoundSettings = {
+      version: 1,
+      enabled: true,
+      volume: 0.5,
+      events: {
+        scan_in: { type: 'system', id: 'yaru-device-added' },
+        scan_out: {
+          type: 'custom',
+          name: 'out.ogg',
+          mimeType: 'audio/ogg',
+          size: 4,
+          dataUrl: 'data:audio/ogg;base64,b3V0',
+        },
+        warning: { type: 'none' },
+        error: { type: 'system', id: 'yaru-error' },
+      },
+    }
+
+    expect(resolveKioskSoundUrl(settings, 'scan_in')).toBe(
+      getKioskSystemSoundUrl('yaru-device-added')
+    )
+    expect(resolveKioskSoundUrl(settings, 'scan_out')).toBe('data:audio/ogg;base64,b3V0')
+    expect(resolveKioskSoundUrl(settings, 'warning')).toBeNull()
+  })
+
+  it('uses the frontend media route for built-in system sounds', () => {
+    expect(getKioskSystemSoundUrl('yaru-device-added')).toBe(
+      '/media/kiosk-sounds/system/yaru-device-added'
+    )
+  })
+})

--- a/apps/frontend-admin/src/lib/kiosk-sound-settings.ts
+++ b/apps/frontend-admin/src/lib/kiosk-sound-settings.ts
@@ -1,0 +1,289 @@
+'use client'
+
+/* global Audio, HTMLAudioElement */
+
+import {
+  KIOSK_SOUND_SETTING_CATEGORY,
+  KIOSK_SOUND_SETTING_DESCRIPTION,
+  KIOSK_SOUND_SETTING_KEY,
+  KIOSK_SYSTEM_SOUND_OPTIONS,
+  type KioskSystemSoundId,
+} from '@sentinel/contracts'
+
+export {
+  KIOSK_SOUND_SETTING_CATEGORY,
+  KIOSK_SOUND_SETTING_DESCRIPTION,
+  KIOSK_SOUND_SETTING_KEY,
+  KIOSK_SYSTEM_SOUND_OPTIONS,
+}
+
+export type KioskSoundEvent = 'scan_in' | 'scan_out' | 'warning' | 'error'
+
+export interface KioskSoundEventDefinition {
+  id: KioskSoundEvent
+  label: string
+  description: string
+}
+
+export interface DisabledKioskSoundSource {
+  type: 'none'
+}
+
+export interface SystemKioskSoundSource {
+  type: 'system'
+  id: KioskSystemSoundId
+}
+
+export interface CustomKioskSoundSource {
+  type: 'custom'
+  name: string
+  mimeType: string
+  size: number
+  dataUrl: string
+}
+
+export type KioskSoundSource =
+  | DisabledKioskSoundSource
+  | SystemKioskSoundSource
+  | CustomKioskSoundSource
+
+export interface KioskSoundSettings {
+  version: 1
+  enabled: boolean
+  volume: number
+  events: Record<KioskSoundEvent, KioskSoundSource>
+}
+
+export const KIOSK_SOUND_EVENTS: readonly KioskSoundEventDefinition[] = [
+  {
+    id: 'scan_in',
+    label: 'Scan in',
+    description: 'Member or temporary personnel arrival confirmed.',
+  },
+  {
+    id: 'scan_out',
+    label: 'Scan out',
+    description: 'Member or temporary personnel departure confirmed.',
+  },
+  {
+    id: 'warning',
+    label: 'Warning',
+    description: 'Visitor badge, lockup hold, or offline queued scan.',
+  },
+  {
+    id: 'error',
+    label: 'Rejected scan',
+    description: 'Badge lookup or scan was rejected.',
+  },
+] as const
+
+export const DEFAULT_KIOSK_SOUND_SETTINGS: KioskSoundSettings = {
+  version: 1,
+  enabled: true,
+  volume: 0.75,
+  events: {
+    scan_in: { type: 'system', id: 'yaru-device-added' },
+    scan_out: { type: 'system', id: 'yaru-device-removed' },
+    warning: { type: 'system', id: 'yaru-warning' },
+    error: { type: 'system', id: 'yaru-error' },
+  },
+}
+
+const kioskSystemSoundIds = new Set<string>(KIOSK_SYSTEM_SOUND_OPTIONS.map((option) => option.id))
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function cloneSettings(settings: KioskSoundSettings): KioskSoundSettings {
+  return JSON.parse(JSON.stringify(settings)) as KioskSoundSettings
+}
+
+function clampVolume(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return DEFAULT_KIOSK_SOUND_SETTINGS.volume
+  }
+
+  return Math.min(1, Math.max(0, value))
+}
+
+function parseSoundSource(value: unknown, fallback: KioskSoundSource): KioskSoundSource {
+  if (!isRecord(value) || typeof value.type !== 'string') {
+    return fallback
+  }
+
+  if (value.type === 'none') {
+    return { type: 'none' }
+  }
+
+  if (
+    value.type === 'system' &&
+    typeof value.id === 'string' &&
+    kioskSystemSoundIds.has(value.id)
+  ) {
+    return {
+      type: 'system',
+      id: value.id as KioskSystemSoundId,
+    }
+  }
+
+  if (
+    value.type === 'custom' &&
+    typeof value.name === 'string' &&
+    typeof value.mimeType === 'string' &&
+    typeof value.size === 'number' &&
+    typeof value.dataUrl === 'string' &&
+    value.dataUrl.startsWith('data:audio/')
+  ) {
+    return {
+      type: 'custom',
+      name: value.name,
+      mimeType: value.mimeType,
+      size: value.size,
+      dataUrl: value.dataUrl,
+    }
+  }
+
+  return fallback
+}
+
+export function parseKioskSoundSettings(value: unknown): KioskSoundSettings | null {
+  if (!isRecord(value) || value.version !== 1 || !isRecord(value.events)) {
+    return null
+  }
+
+  const defaults = DEFAULT_KIOSK_SOUND_SETTINGS
+
+  return {
+    version: 1,
+    enabled: typeof value.enabled === 'boolean' ? value.enabled : defaults.enabled,
+    volume: clampVolume(value.volume),
+    events: {
+      scan_in: parseSoundSource(value.events.scan_in, defaults.events.scan_in),
+      scan_out: parseSoundSource(value.events.scan_out, defaults.events.scan_out),
+      warning: parseSoundSource(value.events.warning, defaults.events.warning),
+      error: parseSoundSource(value.events.error, defaults.events.error),
+    },
+  }
+}
+
+export function getDefaultKioskSoundSettings(): KioskSoundSettings {
+  return cloneSettings(DEFAULT_KIOSK_SOUND_SETTINGS)
+}
+
+export function getKioskSystemSoundUrl(id: KioskSystemSoundId): string {
+  return `/media/kiosk-sounds/system/${encodeURIComponent(id)}`
+}
+
+export function resolveKioskSoundUrl(
+  settings: KioskSoundSettings,
+  event: KioskSoundEvent
+): string | null {
+  if (!settings.enabled) {
+    return null
+  }
+
+  const source = settings.events[event]
+
+  if (source.type === 'none') {
+    return null
+  }
+
+  if (source.type === 'system') {
+    return getKioskSystemSoundUrl(source.id)
+  }
+
+  return source.dataUrl
+}
+
+const kioskAudioByUrl = new Map<string, HTMLAudioElement>()
+
+function getKioskAudio(url: string): HTMLAudioElement {
+  const cachedAudio = kioskAudioByUrl.get(url)
+  if (cachedAudio) {
+    return cachedAudio
+  }
+
+  const audio = new Audio(url)
+  audio.preload = 'auto'
+  kioskAudioByUrl.set(url, audio)
+  return audio
+}
+
+function getConfiguredSoundUrls(settings: KioskSoundSettings): string[] {
+  return Array.from(
+    new Set(
+      (['scan_in', 'scan_out', 'warning', 'error'] satisfies KioskSoundEvent[])
+        .map((event) => resolveKioskSoundUrl(settings, event))
+        .filter((url): url is string => Boolean(url))
+    )
+  )
+}
+
+export function preloadKioskSounds(settings: KioskSoundSettings): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  for (const url of getConfiguredSoundUrls(settings)) {
+    getKioskAudio(url).load()
+  }
+}
+
+export async function unlockKioskSoundPlayback(settings: KioskSoundSettings): Promise<boolean> {
+  if (typeof window === 'undefined') {
+    return false
+  }
+
+  const urls = getConfiguredSoundUrls(settings)
+  if (urls.length === 0) {
+    return false
+  }
+
+  const unlockAttempts = urls.map(async (url) => {
+    const audio = getKioskAudio(url)
+    const previousMuted = audio.muted
+    const previousVolume = audio.volume
+
+    audio.muted = true
+    audio.volume = 0
+
+    try {
+      audio.currentTime = 0
+      await audio.play()
+      audio.pause()
+      audio.currentTime = 0
+      return true
+    } catch {
+      return false
+    } finally {
+      audio.muted = previousMuted
+      audio.volume = previousVolume
+    }
+  })
+
+  const results = await Promise.allSettled(unlockAttempts)
+  return results.some((result) => result.status === 'fulfilled' && result.value)
+}
+
+export async function playKioskSound(
+  settings: KioskSoundSettings,
+  event: KioskSoundEvent
+): Promise<boolean> {
+  if (typeof window === 'undefined') {
+    return false
+  }
+
+  const url = resolveKioskSoundUrl(settings, event)
+  if (!url) {
+    return false
+  }
+
+  const audio = getKioskAudio(url)
+  audio.pause()
+  audio.currentTime = 0
+  audio.muted = false
+  audio.volume = settings.volume
+  await audio.play()
+  return true
+}

--- a/apps/frontend-admin/src/lib/kiosk-system-sound-response.server.ts
+++ b/apps/frontend-admin/src/lib/kiosk-system-sound-response.server.ts
@@ -1,0 +1,35 @@
+import { readFile } from 'node:fs/promises'
+import { NextResponse } from 'next/server'
+import { KIOSK_SYSTEM_SOUND_OPTIONS } from '@sentinel/contracts'
+
+function soundNotFound() {
+  return NextResponse.json(
+    {
+      error: 'NOT_FOUND',
+      message: 'Kiosk sound file not found',
+    },
+    { status: 404 }
+  )
+}
+
+export async function createKioskSystemSoundResponse(id: string): Promise<globalThis.Response> {
+  const sound = KIOSK_SYSTEM_SOUND_OPTIONS.find((candidate) => candidate.id === id)
+
+  if (!sound) {
+    return soundNotFound()
+  }
+
+  try {
+    const bytes = await readFile(sound.path)
+
+    return new globalThis.Response(bytes, {
+      status: 200,
+      headers: {
+        'Cache-Control': 'public, max-age=86400',
+        'Content-Type': sound.contentType,
+      },
+    })
+  } catch {
+    return soundNotFound()
+  }
+}

--- a/apps/frontend-admin/src/proxy.ts
+++ b/apps/frontend-admin/src/proxy.ts
@@ -38,5 +38,7 @@ export function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/((?!login|_next/static|_next/image|favicon\\.ico|.*\\.png$|.*\\.jpg$|.*\\.svg$).*)'],
+  matcher: [
+    '/((?!api|media/kiosk-sounds|login|_next/static|_next/image|favicon\\.ico|.*\\.png$|.*\\.jpg$|.*\\.svg$).*)',
+  ],
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -4,4 +4,5 @@
 export * from './schemas/index.js'
 export * from './contracts/index.js'
 export * from './duty-watch-recurrence.js'
+export * from './kiosk-sounds.js'
 export * from './operational-night-recurrence.js'

--- a/packages/contracts/src/kiosk-sounds.ts
+++ b/packages/contracts/src/kiosk-sounds.ts
@@ -1,0 +1,81 @@
+export const KIOSK_SOUND_SETTING_KEY = 'kiosk.scan_sounds'
+export const KIOSK_SOUND_SETTING_CATEGORY = 'notifications'
+export const KIOSK_SOUND_SETTING_DESCRIPTION =
+  'Controls kiosk audio feedback for badge scan outcomes.'
+
+export const KIOSK_SYSTEM_SOUND_OPTIONS = [
+  {
+    id: 'yaru-device-added',
+    label: 'Device added',
+    theme: 'Yaru',
+    fileName: 'device-added.oga',
+    path: '/usr/share/sounds/Yaru/stereo/device-added.oga',
+    contentType: 'audio/ogg',
+  },
+  {
+    id: 'yaru-device-removed',
+    label: 'Device removed',
+    theme: 'Yaru',
+    fileName: 'device-removed.oga',
+    path: '/usr/share/sounds/Yaru/stereo/device-removed.oga',
+    contentType: 'audio/ogg',
+  },
+  {
+    id: 'yaru-complete',
+    label: 'Complete',
+    theme: 'Yaru',
+    fileName: 'complete.oga',
+    path: '/usr/share/sounds/Yaru/stereo/complete.oga',
+    contentType: 'audio/ogg',
+  },
+  {
+    id: 'yaru-message',
+    label: 'Message',
+    theme: 'Yaru',
+    fileName: 'message.oga',
+    path: '/usr/share/sounds/Yaru/stereo/message.oga',
+    contentType: 'audio/ogg',
+  },
+  {
+    id: 'yaru-warning',
+    label: 'Warning',
+    theme: 'Yaru',
+    fileName: 'dialog-warning.oga',
+    path: '/usr/share/sounds/Yaru/stereo/dialog-warning.oga',
+    contentType: 'audio/ogg',
+  },
+  {
+    id: 'yaru-error',
+    label: 'Error',
+    theme: 'Yaru',
+    fileName: 'dialog-error.oga',
+    path: '/usr/share/sounds/Yaru/stereo/dialog-error.oga',
+    contentType: 'audio/ogg',
+  },
+  {
+    id: 'freedesktop-complete',
+    label: 'Complete',
+    theme: 'freedesktop',
+    fileName: 'complete.oga',
+    path: '/usr/share/sounds/freedesktop/stereo/complete.oga',
+    contentType: 'audio/ogg',
+  },
+  {
+    id: 'freedesktop-bell',
+    label: 'Bell',
+    theme: 'freedesktop',
+    fileName: 'bell.oga',
+    path: '/usr/share/sounds/freedesktop/stereo/bell.oga',
+    contentType: 'audio/ogg',
+  },
+  {
+    id: 'freedesktop-warning',
+    label: 'Warning',
+    theme: 'freedesktop',
+    fileName: 'dialog-warning.oga',
+    path: '/usr/share/sounds/freedesktop/stereo/dialog-warning.oga',
+    contentType: 'audio/ogg',
+  },
+] as const
+
+export type KioskSystemSoundId = (typeof KIOSK_SYSTEM_SOUND_OPTIONS)[number]['id']

--- a/packages/contracts/src/schemas/admin-navigation.schema.ts
+++ b/packages/contracts/src/schemas/admin-navigation.schema.ts
@@ -19,6 +19,7 @@ export const AdminNavigationRouteIdValues = [
   'temporary-personnel',
   'config',
   'timings',
+  'kiosk-sounds',
   'account-levels',
   'dashboard-sorting',
   'legacy',

--- a/packages/contracts/src/schemas/report.schema.ts
+++ b/packages/contracts/src/schemas/report.schema.ts
@@ -62,7 +62,7 @@ export const DailyPresenceSortDirectionEnum = v.picklist(
 )
 
 export const DailyPresenceSortFieldEnum = v.picklist(
-  ['last_name', 'first_name', 'department', 'first_in', 'last_out', 'sessions'],
+  ['last_name', 'first_name', 'rank', 'department', 'first_in', 'last_out', 'sessions'],
   'Invalid daily presence sort field'
 )
 
@@ -339,6 +339,30 @@ export const ReportFilterSummarySchema = v.object({
 
 export type ReportFilterSummary = v.InferOutput<typeof ReportFilterSummarySchema>
 
+export const ReportDivisionSummarySchema = v.object({
+  id: v.nullable(v.string()),
+  code: v.nullable(v.string()),
+  name: v.string(),
+})
+
+export type ReportDivisionSummary = v.InferOutput<typeof ReportDivisionSummarySchema>
+
+export const ReportWarningAccountSummarySchema = v.object({
+  id: v.string(),
+  displayName: v.string(),
+  division: v.nullable(ReportDivisionSummarySchema),
+  memberType: v.nullable(v.string()),
+})
+
+export type ReportWarningAccountSummary = v.InferOutput<typeof ReportWarningAccountSummarySchema>
+
+export const ReportWarningDetailSchema = v.object({
+  message: v.string(),
+  accounts: v.array(ReportWarningAccountSummarySchema),
+})
+
+export type ReportWarningDetail = v.InferOutput<typeof ReportWarningDetailSchema>
+
 const ReportEnvelopeBaseEntries = {
   reportType: OperationalReportTypeEnum,
   title: v.string(),
@@ -348,15 +372,8 @@ const ReportEnvelopeBaseEntries = {
   dateRange: ReportDateRangeSchema,
   filters: ReportFilterSummarySchema,
   warnings: v.array(v.string()),
+  warningDetails: v.optional(v.array(ReportWarningDetailSchema), []),
 }
-
-export const ReportDivisionSummarySchema = v.object({
-  id: v.nullable(v.string()),
-  code: v.nullable(v.string()),
-  name: v.string(),
-})
-
-export type ReportDivisionSummary = v.InferOutput<typeof ReportDivisionSummarySchema>
 
 export const ReportTagSummarySchema = v.object({
   id: v.string(),

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Prepares Sentinel v3.4.7 as the next patch release after v3.4.6.
- Adds richer Daily Presence report warnings with affected member account details.
- Updates Daily Presence report layout to show multiple check-in/check-out sessions within one member row.
- Adds primary and secondary report sorting, including rank sorting support when the updated backend API is deployed.
- Improves report validation errors so stale API contracts are easier to diagnose.

## Why this change was needed

Daily Presence reports needed clearer session detail, clearer warning detail, and a better way to combine grouping rules with member ordering. The prior UI also surfaced report request validation failures as generic runtime errors, which made stale backend/frontend contract mismatches hard to understand.

## What changed

### User-facing

- Daily Presence report rows keep one entry per member while showing each session on its own line inside the Check-In and Check-Out columns.
- The report removes member account status, Returned, and Sessions count columns from the detail table.
- The report keeps Last Out semantics through session check-out lines while separately showing Presence.
- Report warnings can include affected account names when the updated backend provides warning details.

### Admin/operator-facing

- Report sorting now has separate Primary sort order and Secondary sort order sections.
- Secondary sorting can order members inside the primary grouping.
- Validation failures now show specific issue details in-page instead of crashing the dev build.
- If Rank sorting is used against a stale backend, the UI explains that the updated reports API is required.

### Backend/API

- Adds `warningDetails` metadata to report responses.
- Tracks affected member IDs for presence pairing warnings.
- Adds `rank` as a Daily Presence sort field and sorts ranks by configured rank display order.

### Database

- No database migration required.

### Tests

- Adds backend coverage for warning account details and rank sorting behavior.

## User impact

Report readers get a more accurate view of members who leave and return during the day, without duplicate member rows.

## Operator impact

Operators should rebuild/redeploy both backend and frontend for v3.4.7 so Rank sorting and warning account details use the updated shared report contract.

## Upgrade or migration notes

No database migration is required. Deploy the v3.4.7 backend and frontend together to avoid stale API validation for Rank sorting.

## Risk and rollback notes

Main risk is report layout or sort behavior regression. Rollback to v3.4.6 is safe; v3.4.7 does not introduce schema changes.

## Testing performed

- `pnpm --filter frontend-admin typecheck`
- `pnpm --filter frontend-admin lint`
- `pnpm --filter @sentinel/backend typecheck`
- `pnpm --filter @sentinel/contracts build`
- `pnpm build`
- `deploy/deb/build-deb.sh --version v3.4.7 --output-dir dist`
- Playwright visual sanity check on `/admin/reports` at 1920x1080

## Changelog candidates

- Improved Daily Presence reports with per-session check-in/check-out lines in a single member row.
- Added affected account details to report warnings.
- Added primary and secondary sort controls for Daily Presence reports.
- Added Rank sorting support for Daily Presence reports.
- Improved report validation errors when frontend and backend report contracts are out of sync.