### PR TITLE
feat(reports): expand attendance report filtering and sorting

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.4.7",
+  "version": "3.4.8",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/repositories/operational-report-repository.ts
+++ b/apps/backend/src/repositories/operational-report-repository.ts
@@ -199,7 +199,9 @@ export interface OperationalReportScheduledDutyAssignmentRecord {
 
 export interface OperationalReportMemberFilters {
   divisionId?: string
+  divisionIds?: string[]
   tagId?: string
+  tagIds?: string[]
 }
 
 export interface OperationalReportVisitorFilters {
@@ -275,30 +277,50 @@ export class OperationalReportRepository {
       },
     }
 
-    if (filters.divisionId) {
-      where.divisionId = filters.divisionId
+    const divisionIds = filters.divisionIds ?? (filters.divisionId ? [filters.divisionId] : [])
+    const tagIds = filters.tagIds ?? (filters.tagId ? [filters.tagId] : [])
+    const scopeClauses: Prisma.MemberWhereInput[] = []
+
+    if (divisionIds.length > 0) {
+      scopeClauses.push({
+        divisionId: {
+          in: divisionIds,
+        },
+      })
     }
 
-    if (filters.tagId) {
-      where.OR = [
-        {
-          memberTags: {
-            some: {
-              tagId: filters.tagId,
-            },
-          },
-        },
-        {
-          qualifications: {
-            some: {
-              status: 'active',
-              qualificationType: {
-                tagId: filters.tagId,
+    if (tagIds.length > 0) {
+      scopeClauses.push({
+        OR: [
+          {
+            memberTags: {
+              some: {
+                tagId: {
+                  in: tagIds,
+                },
               },
             },
           },
-        },
-      ]
+          {
+            qualifications: {
+              some: {
+                status: 'active',
+                qualificationType: {
+                  tagId: {
+                    in: tagIds,
+                  },
+                },
+              },
+            },
+          },
+        ],
+      })
+    }
+
+    if (scopeClauses.length === 1) {
+      Object.assign(where, scopeClauses[0])
+    } else if (scopeClauses.length > 1) {
+      where.OR = scopeClauses
     }
 
     return this.prisma.member.findMany({

--- a/apps/backend/src/services/operational-report-service.test.ts
+++ b/apps/backend/src/services/operational-report-service.test.ts
@@ -8,12 +8,15 @@ import {
   pairOperationalPresenceSessions,
   presenceSessionOverlapsRange,
   sortDailyPresenceRows,
+  sortMemberReportRows,
   type DailyPresenceSortableRow,
+  type MemberReportSortableRow,
   type PresenceSessionInternal,
   OperationalReportService,
 } from './operational-report-service.js'
 import type {
   OperationalReportCheckinRecord,
+  OperationalReportMemberFilters,
   OperationalReportMemberRecord,
   OperationalReportRepository,
 } from '../repositories/operational-report-repository.js'
@@ -142,6 +145,81 @@ function sortableDailyPresenceRow(input: {
   }
 }
 
+function sortableWeeklyPresenceRow(input: {
+  id: string
+  firstName: string
+  lastName: string
+  totalDaysPresent: number
+  totalSessions?: number
+}): MemberReportSortableRow {
+  return {
+    memberRecord: {
+      id: input.id,
+      rank: 'S1',
+      firstName: input.firstName,
+      lastName: input.lastName,
+      displayName: `S1 ${input.lastName}, ${input.firstName}`,
+      rankRef: { displayOrder: 3 },
+      division: null,
+      memberTags: [],
+      qualifications: [],
+    },
+    row: {
+      member: {
+        id: input.id,
+        displayName: `S1 ${input.lastName}, ${input.firstName}`,
+        rank: 'S1',
+        status: 'Active',
+        division: null,
+        memberType: 'Class A',
+        tags: [],
+      },
+      days: [],
+      trainingNightPresent: null,
+      adminNightPresent: null,
+      keyNights: [],
+      totalDaysPresent: input.totalDaysPresent,
+      totalSessions: input.totalSessions ?? input.totalDaysPresent,
+    },
+  }
+}
+
+function sortableTrainingNightMonthlyRow(input: {
+  id: string
+  firstName: string
+  lastName: string
+  percentage: number
+}): MemberReportSortableRow {
+  return {
+    memberRecord: {
+      id: input.id,
+      rank: 'S1',
+      firstName: input.firstName,
+      lastName: input.lastName,
+      displayName: `S1 ${input.lastName}, ${input.firstName}`,
+      rankRef: { displayOrder: 3 },
+      division: null,
+      memberTags: [],
+      qualifications: [],
+    },
+    row: {
+      member: {
+        id: input.id,
+        displayName: `S1 ${input.lastName}, ${input.firstName}`,
+        rank: 'S1',
+        status: 'Active',
+        division: null,
+        memberType: 'Class A',
+        tags: [],
+      },
+      nights: [],
+      attended: input.percentage,
+      possible: 100,
+      percentage: input.percentage,
+    },
+  }
+}
+
 describe('pairOperationalPresenceSessions', () => {
   it('pairs each check-in with the next valid checkout for the same member', () => {
     const warnings = new Set<string>()
@@ -230,6 +308,31 @@ describe('pairOperationalPresenceSessions', () => {
       )
     ).toEqual(['member-1', 'member-2'])
   })
+
+  it('suppresses unmatched checkout warnings outside the selected warning range', () => {
+    const warnings = new Set<string>()
+    const warningMemberIds = new Map<string, Set<string>>()
+    const sessionsByMember = pairOperationalPresenceSessions(
+      [
+        checkin('1', 'member-1', 'out', '2026-06-11T08:00:00.000Z'),
+        checkin('2', 'member-1', 'in', '2026-06-12T13:00:00.000Z'),
+      ],
+      warnings,
+      {
+        warningMemberIds,
+        warningRange: {
+          start: new Date('2026-06-12T08:00:00.000Z'),
+          end: new Date('2026-06-13T08:00:00.000Z'),
+        },
+      }
+    )
+
+    expect(getSessions(sessionsByMember, 'member-1')).toHaveLength(1)
+    expect(Array.from(warnings)).not.toContain(
+      'Some checkout records could not be paired with a prior check-in and were ignored.'
+    )
+    expect(warningMemberIds.size).toBe(0)
+  })
 })
 
 describe('generateDailyPresence', () => {
@@ -252,6 +355,8 @@ describe('generateDailyPresence', () => {
         ),
       ],
       findScheduledDutyAssignmentsForMembers: async () => [],
+      findDdsAssignmentsForMembers: async () => [],
+      findLiveDutyAssignmentsForMembers: async () => [],
     } as unknown as OperationalReportRepository
     const service = new OperationalReportService(undefined, repository)
 
@@ -277,6 +382,90 @@ describe('generateDailyPresence', () => {
         ],
       },
     ])
+  })
+
+  it('does not warn about unmatched checkouts that only belong to the report lookback', async () => {
+    const member = operationalReportMember({
+      id: '11111111-1111-4111-8111-111111111111',
+      displayName: 'S1 Example, A',
+      rank: 'S1',
+      firstName: 'Alex',
+      lastName: 'Example',
+    })
+    const repository = {
+      findActiveMembers: async () => [member],
+      findCheckinsForMembers: async () => [
+        checkin(
+          'checkin-1',
+          '11111111-1111-4111-8111-111111111111',
+          'out',
+          '2026-06-11T08:00:00.000Z',
+          'SYSTEM'
+        ),
+      ],
+      findScheduledDutyAssignmentsForMembers: async () => [],
+      findDdsAssignmentsForMembers: async () => [],
+      findLiveDutyAssignmentsForMembers: async () => [],
+    } as unknown as OperationalReportRepository
+    const service = new OperationalReportService(undefined, repository)
+
+    const report = await service.generateDailyPresence(
+      { date: '2026-06-12', scopeType: 'everyone' },
+      { id: 'actor-1', rank: 'MS', firstName: 'Report', lastName: 'Runner' }
+    )
+
+    expect(report.warnings).not.toContain(
+      'Some checkout records could not be paired with a prior check-in and were ignored.'
+    )
+    expect(report.warningDetails).toEqual([])
+  })
+})
+
+describe('generateTrainingNightMonthly', () => {
+  it('runs against all selected departments', async () => {
+    const adminDivision = {
+      id: '11111111-1111-4111-8111-111111111111',
+      code: 'ADMIN',
+      name: 'Administration',
+    }
+    const bandDivision = {
+      id: '22222222-2222-4222-8222-222222222222',
+      code: 'BAND',
+      name: 'Band',
+    }
+    const divisions = new Map([
+      [adminDivision.id, adminDivision],
+      [bandDivision.id, bandDivision],
+    ])
+    let activeMemberFilters: OperationalReportMemberFilters | null = null
+    const repository = {
+      findDivisionById: async (divisionId: string) => divisions.get(divisionId) ?? null,
+      findActiveMembers: async (filters: OperationalReportMemberFilters) => {
+        activeMemberFilters = filters
+        return []
+      },
+      findCheckinsForMembers: async () => [],
+      findUnitEvents: async () => [],
+      findAppSettingValue: async () => null,
+      findReportSettingValue: async () => null,
+    } as unknown as OperationalReportRepository
+    const service = new OperationalReportService(undefined, repository)
+
+    const report = await service.generateTrainingNightMonthly(
+      {
+        month: '2026-06',
+        divisionIds: [adminDivision.id, bandDivision.id],
+      },
+      { id: 'actor-1', rank: 'MS', firstName: 'Report', lastName: 'Runner' }
+    )
+
+    expect(activeMemberFilters).toEqual({
+      divisionIds: [adminDivision.id, bandDivision.id],
+    })
+    expect(report.filters.scopeLabel).toBe('Administration, Band')
+    expect(report.filters.divisionId).toBe(adminDivision.id)
+    expect(report.filters.divisionIds).toEqual([adminDivision.id, bandDivision.id])
+    expect(report.data.department).toBeNull()
   })
 })
 
@@ -530,6 +719,65 @@ describe('sortDailyPresenceRows', () => {
       'admin-carter',
       'untagged-able',
     ])
+  })
+})
+
+describe('sortMemberReportRows', () => {
+  it('sorts weekly-style attendance rows by days present before last name', () => {
+    const sorted = sortMemberReportRows(
+      [
+        sortableWeeklyPresenceRow({
+          id: 'low-zulu',
+          firstName: 'Zed',
+          lastName: 'Zulu',
+          totalDaysPresent: 1,
+        }),
+        sortableWeeklyPresenceRow({
+          id: 'high-baker',
+          firstName: 'Bill',
+          lastName: 'Baker',
+          totalDaysPresent: 4,
+        }),
+        sortableWeeklyPresenceRow({
+          id: 'high-alpha',
+          firstName: 'Amy',
+          lastName: 'Alpha',
+          totalDaysPresent: 4,
+        }),
+      ],
+      [
+        { type: 'field', field: 'total_days_present', direction: 'desc' },
+        { type: 'field', field: 'last_name', direction: 'asc' },
+      ]
+    )
+
+    expect(sorted.map((row) => row.memberRecord.id)).toEqual([
+      'high-alpha',
+      'high-baker',
+      'low-zulu',
+    ])
+  })
+
+  it('sorts training night monthly rows by attendance percentage', () => {
+    const sorted = sortMemberReportRows(
+      [
+        sortableTrainingNightMonthlyRow({
+          id: 'half',
+          firstName: 'Hal',
+          lastName: 'Half',
+          percentage: 50,
+        }),
+        sortableTrainingNightMonthlyRow({
+          id: 'full',
+          firstName: 'Faye',
+          lastName: 'Full',
+          percentage: 100,
+        }),
+      ],
+      [{ type: 'field', field: 'percentage', direction: 'desc' }]
+    )
+
+    expect(sorted.map((row) => row.memberRecord.id)).toEqual(['full', 'half'])
   })
 })
 

--- a/apps/backend/src/services/operational-report-service.ts
+++ b/apps/backend/src/services/operational-report-service.ts
@@ -6,6 +6,7 @@ import type {
   DailyPresenceReportResponse,
   DailyPresenceSortCriterion,
   KeyNight,
+  MonthlyPresenceRow,
   MonthlyPresenceReportConfig,
   MonthlyPresenceReportResponse,
   OperationalNightAudienceTarget,
@@ -21,9 +22,11 @@ import type {
   ReportWarningDetail,
   ReportWarningAccountSummary,
   TrainingNightMonthlyReportConfig,
+  TrainingNightMonthlyRow,
   TrainingNightMonthlyReportResponse,
   VisitorActivityReportConfig,
   VisitorActivityReportResponse,
+  WeeklyPresenceRow,
   WeeklyPresenceReportConfig,
   WeeklyPresenceReportResponse,
 } from '@sentinel/contracts'
@@ -80,7 +83,9 @@ interface DateRange {
 
 interface EffectiveScope {
   divisionId?: string
+  divisionIds?: string[]
   tagId?: string
+  tagIds?: string[]
   scopeLabel: string
   warnings: string[]
   noResults: boolean
@@ -121,9 +126,13 @@ interface LockupCheckedOutMember {
 
 interface PairPresenceSessionsOptions {
   warningMemberIds?: Map<string, Set<string>>
+  warningRange?: {
+    start: Date
+    end: Date
+  }
 }
 
-export interface DailyPresenceSortableMember {
+export interface MemberReportSortableMember {
   id: string
   rank: string
   firstName: string
@@ -135,8 +144,20 @@ export interface DailyPresenceSortableMember {
   qualifications: Array<{ qualificationType: { tagId: string | null } }>
 }
 
-export interface DailyPresenceSortableRow {
-  memberRecord: DailyPresenceSortableMember
+type MemberReportSortableRowData =
+  | DailyPresenceRow
+  | WeeklyPresenceRow
+  | MonthlyPresenceRow
+  | TrainingNightMonthlyRow
+
+export interface MemberReportSortableRow {
+  memberRecord: MemberReportSortableMember
+  row: MemberReportSortableRowData
+}
+
+export type DailyPresenceSortableMember = MemberReportSortableMember
+
+export interface DailyPresenceSortableRow extends MemberReportSortableRow {
   row: DailyPresenceRow
 }
 
@@ -214,7 +235,7 @@ export function compareReportTagsByPriority(
 }
 
 export function dailyPresenceSortableMemberHasTag(
-  member: DailyPresenceSortableMember,
+  member: MemberReportSortableMember,
   tagId: string
 ): boolean {
   return (
@@ -236,9 +257,75 @@ function compareNullableString(left: string | null | undefined, right: string | 
   })
 }
 
-function compareDailyPresenceField(
-  left: DailyPresenceSortableRow,
-  right: DailyPresenceSortableRow,
+function compareBoolean(left: boolean | null | undefined, right: boolean | null | undefined) {
+  const leftValue = left === true ? 1 : left === false ? 0 : -1
+  const rightValue = right === true ? 1 : right === false ? 0 : -1
+  return leftValue - rightValue
+}
+
+function compareNumber(left: number | null | undefined, right: number | null | undefined) {
+  if (left === undefined || left === null) {
+    return right === undefined || right === null ? 0 : 1
+  }
+
+  if (right === undefined || right === null) {
+    return -1
+  }
+
+  return left - right
+}
+
+function getDailyFirstIn(row: MemberReportSortableRowData): string | null | undefined {
+  return 'firstIn' in row ? row.firstIn : undefined
+}
+
+function getDailyLastOut(row: MemberReportSortableRowData): string | null | undefined {
+  return 'lastOut' in row ? row.lastOut : undefined
+}
+
+function getDailySessionCount(row: MemberReportSortableRowData): number | undefined {
+  return 'sessionCount' in row ? row.sessionCount : undefined
+}
+
+function getTotalDaysPresent(row: MemberReportSortableRowData): number | undefined {
+  return 'totalDaysPresent' in row ? row.totalDaysPresent : undefined
+}
+
+function getTotalSessions(row: MemberReportSortableRowData): number | undefined {
+  return 'totalSessions' in row ? row.totalSessions : undefined
+}
+
+function getTrainingNightPresent(row: MemberReportSortableRowData): boolean | null | undefined {
+  return 'trainingNightPresent' in row ? row.trainingNightPresent : undefined
+}
+
+function getAdminNightPresent(row: MemberReportSortableRowData): boolean | null | undefined {
+  return 'adminNightPresent' in row ? row.adminNightPresent : undefined
+}
+
+function getTrainingNightsPresent(row: MemberReportSortableRowData): number | undefined {
+  return 'trainingNightsPresent' in row ? row.trainingNightsPresent : undefined
+}
+
+function getAdminNightsPresent(row: MemberReportSortableRowData): number | undefined {
+  return 'adminNightsPresent' in row ? row.adminNightsPresent : undefined
+}
+
+function getAttended(row: MemberReportSortableRowData): number | undefined {
+  return 'attended' in row ? row.attended : undefined
+}
+
+function getPossible(row: MemberReportSortableRowData): number | undefined {
+  return 'possible' in row ? row.possible : undefined
+}
+
+function getPercentage(row: MemberReportSortableRowData): number | undefined {
+  return 'percentage' in row ? row.percentage : undefined
+}
+
+function compareMemberReportField(
+  left: MemberReportSortableRow,
+  right: MemberReportSortableRow,
   field: Extract<DailyPresenceSortCriterion, { type: 'field' }>['field']
 ): number {
   switch (field) {
@@ -268,11 +355,29 @@ function compareDailyPresenceField(
         ) || compareNullableString(left.memberRecord.lastName, right.memberRecord.lastName)
       )
     case 'first_in':
-      return compareNullableString(left.row.firstIn, right.row.firstIn)
+      return compareNullableString(getDailyFirstIn(left.row), getDailyFirstIn(right.row))
     case 'last_out':
-      return compareNullableString(left.row.lastOut, right.row.lastOut)
+      return compareNullableString(getDailyLastOut(left.row), getDailyLastOut(right.row))
     case 'sessions':
-      return left.row.sessionCount - right.row.sessionCount
+      return compareNumber(getDailySessionCount(left.row), getDailySessionCount(right.row))
+    case 'total_days_present':
+      return compareNumber(getTotalDaysPresent(left.row), getTotalDaysPresent(right.row))
+    case 'total_sessions':
+      return compareNumber(getTotalSessions(left.row), getTotalSessions(right.row))
+    case 'training_night_present':
+      return compareBoolean(getTrainingNightPresent(left.row), getTrainingNightPresent(right.row))
+    case 'admin_night_present':
+      return compareBoolean(getAdminNightPresent(left.row), getAdminNightPresent(right.row))
+    case 'training_nights_present':
+      return compareNumber(getTrainingNightsPresent(left.row), getTrainingNightsPresent(right.row))
+    case 'admin_nights_present':
+      return compareNumber(getAdminNightsPresent(left.row), getAdminNightsPresent(right.row))
+    case 'attended':
+      return compareNumber(getAttended(left.row), getAttended(right.row))
+    case 'possible':
+      return compareNumber(getPossible(left.row), getPossible(right.row))
+    case 'percentage':
+      return compareNumber(getPercentage(left.row), getPercentage(right.row))
     case 'last_name':
       return (
         compareNullableString(left.memberRecord.lastName, right.memberRecord.lastName) ||
@@ -281,18 +386,18 @@ function compareDailyPresenceField(
   }
 }
 
-function getDailyPresenceRowTagPriority(row: DailyPresenceSortableRow): number | null {
+function getMemberReportRowTagPriority(row: MemberReportSortableRow): number | null {
   const firstTag = row.row.member.tags[0]
   return firstTag ? firstTag.displayOrder : null
 }
 
-function compareDailyPresenceTagPriority(
-  left: DailyPresenceSortableRow,
-  right: DailyPresenceSortableRow,
+function compareMemberReportTagPriority(
+  left: MemberReportSortableRow,
+  right: MemberReportSortableRow,
   direction: DailyPresenceSortCriterion['direction']
 ): number {
-  const leftPriority = getDailyPresenceRowTagPriority(left)
-  const rightPriority = getDailyPresenceRowTagPriority(right)
+  const leftPriority = getMemberReportRowTagPriority(left)
+  const rightPriority = getMemberReportRowTagPriority(right)
 
   if (leftPriority === null && rightPriority === null) {
     return 0
@@ -307,9 +412,9 @@ function compareDailyPresenceTagPriority(
   return (leftPriority - rightPriority) * (direction === 'desc' ? -1 : 1)
 }
 
-function compareDailyPresenceCriterion(
-  left: DailyPresenceSortableRow,
-  right: DailyPresenceSortableRow,
+function compareMemberReportCriterion(
+  left: MemberReportSortableRow,
+  right: MemberReportSortableRow,
   criterion: DailyPresenceSortCriterion
 ): number {
   const direction = criterion.direction === 'desc' ? -1 : 1
@@ -326,13 +431,13 @@ function compareDailyPresenceCriterion(
   }
 
   if (criterion.type === 'tag_priority') {
-    return compareDailyPresenceTagPriority(left, right, criterion.direction)
+    return compareMemberReportTagPriority(left, right, criterion.direction)
   }
 
-  return compareDailyPresenceField(left, right, criterion.field) * direction
+  return compareMemberReportField(left, right, criterion.field) * direction
 }
 
-export function sortDailyPresenceRows<T extends DailyPresenceSortableRow>(
+export function sortMemberReportRows<T extends MemberReportSortableRow>(
   rows: T[],
   sort: DailyPresenceSortCriterion[] | undefined
 ): T[] {
@@ -344,7 +449,7 @@ export function sortDailyPresenceRows<T extends DailyPresenceSortableRow>(
 
   return [...rows].sort((left, right) => {
     for (const criterion of sortCriteria) {
-      const result = compareDailyPresenceCriterion(left, right, criterion)
+      const result = compareMemberReportCriterion(left, right, criterion)
       if (result !== 0) {
         return result
       }
@@ -357,6 +462,13 @@ export function sortDailyPresenceRows<T extends DailyPresenceSortableRow>(
       left.memberRecord.id.localeCompare(right.memberRecord.id)
     )
   })
+}
+
+export function sortDailyPresenceRows<T extends DailyPresenceSortableRow>(
+  rows: T[],
+  sort: DailyPresenceSortCriterion[] | undefined
+): T[] {
+  return sortMemberReportRows(rows, sort)
 }
 
 export function presenceSessionOverlapsRange(
@@ -416,7 +528,13 @@ export function pairOperationalPresenceSessions(
 
       if (direction === 'in') {
         if (openIn) {
-          addPresenceWarning(warnings, REPEATED_CHECKIN_WARNING, options, memberId)
+          addPresenceWarning(
+            warnings,
+            REPEATED_CHECKIN_WARNING,
+            options,
+            memberId,
+            record.timestamp
+          )
           sessions.push({
             memberId,
             inAt: openIn.timestamp,
@@ -430,12 +548,18 @@ export function pairOperationalPresenceSessions(
 
       if (direction === 'out') {
         if (!openIn) {
-          addPresenceWarning(warnings, UNMATCHED_CHECKOUT_WARNING, options, memberId)
+          addPresenceWarning(
+            warnings,
+            UNMATCHED_CHECKOUT_WARNING,
+            options,
+            memberId,
+            record.timestamp
+          )
           continue
         }
 
         if (record.timestamp < openIn.timestamp) {
-          addPresenceWarning(warnings, EARLY_CHECKOUT_WARNING, options, memberId)
+          addPresenceWarning(warnings, EARLY_CHECKOUT_WARNING, options, memberId, record.timestamp)
           openIn = null
           continue
         }
@@ -451,7 +575,7 @@ export function pairOperationalPresenceSessions(
         continue
       }
 
-      addPresenceWarning(warnings, UNKNOWN_DIRECTION_WARNING, options, memberId)
+      addPresenceWarning(warnings, UNKNOWN_DIRECTION_WARNING, options, memberId, record.timestamp)
     }
 
     if (openIn) {
@@ -473,8 +597,17 @@ function addPresenceWarning(
   warnings: Set<string>,
   warning: string,
   options: PairPresenceSessionsOptions,
-  memberId?: string | null
+  memberId?: string | null,
+  timestamp?: Date
 ) {
+  if (
+    timestamp &&
+    options.warningRange &&
+    (timestamp < options.warningRange.start || timestamp >= options.warningRange.end)
+  ) {
+    return
+  }
+
   warnings.add(warning)
 
   if (!memberId || !options.warningMemberIds) {
@@ -505,7 +638,9 @@ export class OperationalReportService {
       ? []
       : await this.repository.findActiveMembers({
           divisionId: scope.divisionId,
+          divisionIds: scope.divisionIds,
           tagId: scope.tagId,
+          tagIds: scope.tagIds,
         })
     const sessionsByMember = await this.getSessionsByMember(
       members,
@@ -549,7 +684,9 @@ export class OperationalReportService {
       ...this.getEnvelopeBase('daily_presence', 'Daily Presence Report', actor, range, {
         scopeLabel: scope.scopeLabel,
         divisionId: scope.divisionId,
+        divisionIds: scope.divisionIds,
         tagId: scope.tagId,
+        tagIds: scope.tagIds,
       }),
       warnings: Array.from(warnings),
       warningDetails: this.getWarningDetails(warnings, warningMemberIds, members),
@@ -581,7 +718,9 @@ export class OperationalReportService {
       ? []
       : await this.repository.findActiveMembers({
           divisionId: scope.divisionId,
+          divisionIds: scope.divisionIds,
           tagId: scope.tagId,
+          tagIds: scope.tagIds,
         })
     const sessionsByMember = await this.getSessionsByMember(members, range, warnings)
     const scheduledDutyRolesByMember = await this.getScheduledDutyRolesByMember(members, range)
@@ -597,7 +736,7 @@ export class OperationalReportService {
       ),
     }))
 
-    const rows = members.map((member) => {
+    const sortableRows = members.map((member) => {
       const memberSessions = sessionsByMember.get(member.id) ?? []
       const dayMarkers = days.map((day) =>
         this.getPresenceMarker(day.date, memberSessions, this.formatShortDate(day.date))
@@ -607,23 +746,29 @@ export class OperationalReportService {
       )
 
       return {
-        member: this.toMemberSummary(member, scheduledDutyRolesByMember.get(member.id)),
-        days: dayMarkers,
-        trainingNightPresent: this.getCategoryPresence('training', keyNights, keyNightMarkers),
-        adminNightPresent: this.getCategoryPresence('administrative', keyNights, keyNightMarkers),
-        keyNights: keyNightMarkers,
-        totalDaysPresent: dayMarkers.filter((marker) => marker.present).length,
-        totalSessions: memberSessions.filter((session) =>
-          this.sessionOverlaps(session, range.start, range.end)
-        ).length,
+        memberRecord: member,
+        row: {
+          member: this.toMemberSummary(member, scheduledDutyRolesByMember.get(member.id)),
+          days: dayMarkers,
+          trainingNightPresent: this.getCategoryPresence('training', keyNights, keyNightMarkers),
+          adminNightPresent: this.getCategoryPresence('administrative', keyNights, keyNightMarkers),
+          keyNights: keyNightMarkers,
+          totalDaysPresent: dayMarkers.filter((marker) => marker.present).length,
+          totalSessions: memberSessions.filter((session) =>
+            this.sessionOverlaps(session, range.start, range.end)
+          ).length,
+        },
       }
     })
+    const rows = sortMemberReportRows(sortableRows, config.sort).map(({ row }) => row)
 
     return {
       ...this.getEnvelopeBase('weekly_presence', 'Weekly Presence Report', actor, range, {
         scopeLabel: scope.scopeLabel,
         divisionId: scope.divisionId,
+        divisionIds: scope.divisionIds,
         tagId: scope.tagId,
+        tagIds: scope.tagIds,
       }),
       warnings: Array.from(warnings),
       data: {
@@ -651,7 +796,9 @@ export class OperationalReportService {
       ? []
       : await this.repository.findActiveMembers({
           divisionId: scope.divisionId,
+          divisionIds: scope.divisionIds,
           tagId: scope.tagId,
+          tagIds: scope.tagIds,
         })
     const sessionsByMember = await this.getSessionsByMember(members, range, warnings)
     const keyNights = await this.getKeyNights(range, ['training', 'administrative'], warnings)
@@ -666,7 +813,7 @@ export class OperationalReportService {
       ),
     }))
 
-    const rows = members.map((member) => {
+    const sortableRows = members.map((member) => {
       const memberSessions = sessionsByMember.get(member.id) ?? []
       const dayMarkers = days.map((day) =>
         this.getPresenceMarker(day.date, memberSessions, day.label)
@@ -676,27 +823,33 @@ export class OperationalReportService {
       )
 
       return {
-        member: this.toMemberSummary(member, new Set(), { hideDutyTags: true }),
-        days: dayMarkers,
-        keyNights: keyNightMarkers,
-        totalDaysPresent: dayMarkers.filter((marker) => marker.present).length,
-        totalSessions: memberSessions.filter((session) =>
-          this.sessionOverlaps(session, range.start, range.end)
-        ).length,
-        trainingNightsPresent: this.countCategoryPresence('training', keyNights, keyNightMarkers),
-        adminNightsPresent: this.countCategoryPresence(
-          'administrative',
-          keyNights,
-          keyNightMarkers
-        ),
+        memberRecord: member,
+        row: {
+          member: this.toMemberSummary(member, new Set(), { hideDutyTags: true }),
+          days: dayMarkers,
+          keyNights: keyNightMarkers,
+          totalDaysPresent: dayMarkers.filter((marker) => marker.present).length,
+          totalSessions: memberSessions.filter((session) =>
+            this.sessionOverlaps(session, range.start, range.end)
+          ).length,
+          trainingNightsPresent: this.countCategoryPresence('training', keyNights, keyNightMarkers),
+          adminNightsPresent: this.countCategoryPresence(
+            'administrative',
+            keyNights,
+            keyNightMarkers
+          ),
+        },
       }
     })
+    const rows = sortMemberReportRows(sortableRows, config.sort).map(({ row }) => row)
 
     return {
       ...this.getEnvelopeBase('monthly_presence', 'Monthly Presence Report', actor, range, {
         scopeLabel: scope.scopeLabel,
         divisionId: scope.divisionId,
+        divisionIds: scope.divisionIds,
         tagId: scope.tagId,
+        tagIds: scope.tagIds,
       }),
       warnings: Array.from(warnings),
       data: {
@@ -720,13 +873,29 @@ export class OperationalReportService {
   ): Promise<TrainingNightMonthlyReportResponse> {
     const range = this.getMonthRange(config.month)
     const warnings = new Set<string>()
-    const division = await this.repository.findDivisionById(config.divisionId)
-    if (!division) {
-      warnings.add('Selected department was not found. The report has no department members.')
+    const selectedDivisionIds = this.uniqueIds(config.divisionIds, config.divisionId)
+    const divisions: Array<{ id: string; code: string; name: string }> = []
+
+    if (selectedDivisionIds.length === 0) {
+      warnings.add('No department was selected. The report has no department members.')
     }
-    const members = division
-      ? await this.repository.findActiveMembers({ divisionId: config.divisionId })
-      : []
+
+    for (const divisionId of selectedDivisionIds) {
+      const division = await this.repository.findDivisionById(divisionId)
+      if (!division) {
+        warnings.add('One or more selected departments were not found.')
+        continue
+      }
+
+      divisions.push(division)
+    }
+
+    const members =
+      divisions.length > 0
+        ? await this.repository.findActiveMembers({
+            divisionIds: divisions.map((division) => division.id),
+          })
+        : []
     const sessionsByMember = await this.getSessionsByMember(members, range, warnings)
     const keyNights = await this.getKeyNights(range, ['training'], warnings)
     const trainingNights = keyNights.filter((night) => night.category === 'training')
@@ -735,7 +904,7 @@ export class OperationalReportService {
       warnings.add('No Training Nights were found for the selected month.')
     }
 
-    const rows = members.map((member) => {
+    const sortableRows = members.map((member) => {
       const memberSessions = sessionsByMember.get(member.id) ?? []
       const nightMarkers = trainingNights.map((night) =>
         this.getKeyNightPresenceMarker(night, member, memberSessions)
@@ -746,13 +915,17 @@ export class OperationalReportService {
       const possible = nightMarkers.filter((marker) => marker.requirement === 'required').length
 
       return {
-        member: this.toMemberSummary(member, new Set(), { hideDutyTags: true }),
-        nights: nightMarkers,
-        attended,
-        possible,
-        percentage: possible > 0 ? Math.round((attended / possible) * 100) : 0,
+        memberRecord: member,
+        row: {
+          member: this.toMemberSummary(member, new Set(), { hideDutyTags: true }),
+          nights: nightMarkers,
+          attended,
+          possible,
+          percentage: possible > 0 ? Math.round((attended / possible) * 100) : 0,
+        },
       }
     })
+    const rows = sortMemberReportRows(sortableRows, config.sort).map(({ row }) => row)
 
     return {
       ...this.getEnvelopeBase(
@@ -761,19 +934,24 @@ export class OperationalReportService {
         actor,
         range,
         {
-          scopeLabel: division ? division.name : 'Selected department',
-          divisionId: config.divisionId,
+          scopeLabel:
+            divisions.length > 0
+              ? divisions.map((division) => division.name).join(', ')
+              : 'Selected department',
+          divisionId: divisions[0]?.id ?? config.divisionId,
+          divisionIds: selectedDivisionIds,
         }
       ),
       warnings: Array.from(warnings),
       data: {
-        department: division
-          ? {
-              id: division.id,
-              code: division.code,
-              name: division.name,
-            }
-          : null,
+        department:
+          divisions.length === 1 && divisions[0]
+            ? {
+                id: divisions[0].id,
+                code: divisions[0].code,
+                name: divisions[0].name,
+              }
+            : null,
         trainingNights: trainingNights.map(this.toApiKeyNight),
         rows,
         summary: {
@@ -973,7 +1151,9 @@ export class OperationalReportService {
     filters: {
       scopeLabel: string
       divisionId?: string
+      divisionIds?: string[]
       tagId?: string
+      tagIds?: string[]
       visitorType?: string
       visitorPurpose?: string
       eventCategory?: string
@@ -1001,95 +1181,114 @@ export class OperationalReportService {
   private async resolveScope(
     config: {
       scopeType?: ReportScopeType
+      scopeTypes?: ReportScopeType[]
       divisionId?: string
+      divisionIds?: string[]
       tagId?: string
+      tagIds?: string[]
     },
     warnings: Set<string>
   ): Promise<EffectiveScope> {
-    const scopeType = config.scopeType ?? 'everyone'
+    const scopeTypes = this.normalizeReportScopeTypes(config.scopeTypes, config.scopeType)
 
-    if (scopeType === 'department') {
-      if (!config.divisionId) {
+    if (scopeTypes.includes('everyone')) {
+      return {
+        scopeLabel: 'Everyone',
+        warnings: Array.from(warnings),
+        noResults: false,
+      }
+    }
+
+    const divisionIds = this.uniqueIds(config.divisionIds, config.divisionId)
+    const tagIds = this.uniqueIds(config.tagIds, config.tagId)
+    const resolvedDivisionIds: string[] = []
+    const resolvedTagIds: string[] = []
+    const scopeLabels: string[] = []
+
+    if (scopeTypes.includes('department')) {
+      if (divisionIds.length === 0) {
         warnings.add('Department scope was selected, but no department was provided.')
-        return {
-          scopeLabel: 'Department',
-          warnings: Array.from(warnings),
-          noResults: true,
-        }
-      }
+      } else {
+        for (const divisionId of divisionIds) {
+          const division = await this.repository.findDivisionById(divisionId)
+          if (!division) {
+            warnings.add('One or more selected departments were not found.')
+            continue
+          }
 
-      const division = await this.repository.findDivisionById(config.divisionId)
-      if (!division) {
-        warnings.add('Selected department was not found.')
-        return {
-          divisionId: config.divisionId,
-          scopeLabel: 'Selected department',
-          warnings: Array.from(warnings),
-          noResults: true,
+          resolvedDivisionIds.push(division.id)
+          scopeLabels.push(division.name)
         }
-      }
-
-      return {
-        divisionId: division.id,
-        scopeLabel: division.name,
-        warnings: Array.from(warnings),
-        noResults: false,
       }
     }
 
-    if (scopeType === 'tag') {
-      if (!config.tagId) {
+    if (scopeTypes.includes('tag')) {
+      if (tagIds.length === 0) {
         warnings.add('Tag scope was selected, but no tag was provided.')
-        return {
-          scopeLabel: 'Specific tag',
-          warnings: Array.from(warnings),
-          noResults: true,
-        }
-      }
+      } else {
+        for (const tagId of tagIds) {
+          const tag = await this.repository.findTagById(tagId)
+          if (!tag) {
+            warnings.add('One or more selected tags were not found.')
+            continue
+          }
 
-      const tag = await this.repository.findTagById(config.tagId)
-      if (!tag) {
-        warnings.add('Selected tag was not found.')
-        return {
-          tagId: config.tagId,
-          scopeLabel: 'Specific tag',
-          warnings: Array.from(warnings),
-          noResults: true,
+          resolvedTagIds.push(tag.id)
+          scopeLabels.push(tag.name)
         }
-      }
-
-      return {
-        tagId: tag.id,
-        scopeLabel: tag.name,
-        warnings: Array.from(warnings),
-        noResults: false,
       }
     }
 
-    if (scopeType === 'fts' || scopeType === 'geo') {
-      const tag = await this.repository.findTagShortcut(scopeType)
-      if (!tag) {
-        warnings.add(`${scopeType.toUpperCase()} tag was not found. No tag IDs were hardcoded.`)
-        return {
-          scopeLabel: `${scopeType.toUpperCase()} tag shortcut`,
-          warnings: Array.from(warnings),
-          noResults: true,
-        }
+    for (const shortcut of ['fts', 'geo'] as const) {
+      if (!scopeTypes.includes(shortcut)) {
+        continue
       }
 
+      const tag = await this.repository.findTagShortcut(shortcut)
+      if (!tag) {
+        warnings.add(`${shortcut.toUpperCase()} tag was not found. No tag IDs were hardcoded.`)
+        continue
+      }
+
+      resolvedTagIds.push(tag.id)
+      scopeLabels.push(tag.name)
+    }
+
+    const finalDivisionIds = this.uniqueIds(resolvedDivisionIds)
+    const finalTagIds = this.uniqueIds(resolvedTagIds)
+    const finalScopeLabels = [...new Set(scopeLabels)]
+
+    if (finalDivisionIds.length === 0 && finalTagIds.length === 0) {
       return {
-        tagId: tag.id,
-        scopeLabel: tag.name,
+        scopeLabel: finalScopeLabels.length > 0 ? finalScopeLabels.join(', ') : 'Selected scope',
         warnings: Array.from(warnings),
-        noResults: false,
+        noResults: true,
       }
     }
 
     return {
-      scopeLabel: 'Everyone',
+      divisionId: finalDivisionIds[0],
+      divisionIds: finalDivisionIds,
+      tagId: finalTagIds[0],
+      tagIds: finalTagIds,
+      scopeLabel: finalScopeLabels.join(', '),
       warnings: Array.from(warnings),
       noResults: false,
     }
+  }
+
+  private normalizeReportScopeTypes(
+    scopeTypes: ReportScopeType[] | undefined,
+    fallbackScopeType: ReportScopeType | undefined
+  ): ReportScopeType[] {
+    const selected =
+      scopeTypes && scopeTypes.length > 0 ? scopeTypes : [fallbackScopeType ?? 'everyone']
+    const unique = [...new Set(selected)]
+    return unique.includes('everyone') ? ['everyone'] : unique
+  }
+
+  private uniqueIds(ids: string[] | undefined, fallbackId?: string): string[] {
+    return [...new Set([...(ids ?? []), fallbackId].filter((id): id is string => Boolean(id)))]
   }
 
   private async getSessionsByMember(
@@ -1103,19 +1302,27 @@ export class OperationalReportService {
       .minus({ days: REPORT_LOOKBACK_DAYS })
       .toJSDate()
     const checkins = await this.repository.findCheckinsForMembers(memberIds, queryStart, range.end)
-    return this.pairSessions(checkins, warnings, warningMemberIds)
+    return this.pairSessions(checkins, range, warnings, warningMemberIds)
   }
 
   private pairSessions(
     checkins: OperationalReportCheckinRecord[],
+    range: DateRange,
     warnings: Set<string>,
     warningMemberIds?: Map<string, Set<string>>
   ): Map<string, PresenceSessionInternal[]> {
-    return pairOperationalPresenceSessions(
-      checkins,
-      warnings,
-      warningMemberIds ? { warningMemberIds } : {}
-    )
+    const options: PairPresenceSessionsOptions = {
+      warningRange: {
+        start: range.start,
+        end: range.end,
+      },
+    }
+
+    if (warningMemberIds) {
+      options.warningMemberIds = warningMemberIds
+    }
+
+    return pairOperationalPresenceSessions(checkins, warnings, options)
   }
 
   private getPresenceMarker(

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.4.7",
+  "version": "3.4.8",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/components/admin/reports/AdminReportsPage.tsx
+++ b/apps/frontend-admin/src/components/admin/reports/AdminReportsPage.tsx
@@ -1,7 +1,17 @@
 'use client'
 
 import { useMemo, useState } from 'react'
-import { ArrowDown, ArrowUp, FileText, Play, Plus, Printer, RotateCcw, X } from 'lucide-react'
+import {
+  ArrowDown,
+  ArrowUp,
+  ChevronDown,
+  FileText,
+  Play,
+  Plus,
+  Printer,
+  RotateCcw,
+  X,
+} from 'lucide-react'
 import type { DailyPresenceSortCriterion } from '@sentinel/contracts'
 import {
   AppCard,
@@ -35,17 +45,56 @@ import { ReportPreview } from './report-preview'
 
 const SENTINEL_BOOTSTRAP_SERVICE_NUMBER = 'SENTINEL-SYSTEM'
 
+const REPORT_SCOPE_OPTIONS: Array<{ value: ReportScopeType; label: string }> = [
+  { value: 'everyone', label: 'Everyone' },
+  { value: 'department', label: 'Department' },
+  { value: 'tag', label: 'Specific tag' },
+  { value: 'fts', label: 'FTS tag shortcut' },
+  { value: 'geo', label: 'GEO tag shortcut' },
+]
+
 function optionalString(value: string): string | undefined {
   const trimmed = value.trim()
   return trimmed.length > 0 ? trimmed : undefined
 }
 
-function scopeRequiresDepartment(scopeType: ReportScopeType): boolean {
-  return scopeType === 'department'
+function optionalStringArray(values: string[]): string[] | undefined {
+  const normalized = [...new Set(values.map((value) => value.trim()).filter(Boolean))]
+  return normalized.length > 0 ? normalized : undefined
 }
 
-function scopeRequiresTag(scopeType: ReportScopeType): boolean {
-  return scopeType === 'tag'
+function getSelectedScopeTypes(filters: ReportFilters): ReportScopeType[] {
+  const selected = filters.scopeTypes.length > 0 ? filters.scopeTypes : [filters.scopeType]
+  return selected.includes('everyone') ? ['everyone'] : [...new Set(selected)]
+}
+
+function scopeRequiresDepartment(scopeTypes: ReportScopeType[]): boolean {
+  return scopeTypes.includes('department')
+}
+
+function scopeRequiresTag(scopeTypes: ReportScopeType[]): boolean {
+  return scopeTypes.includes('tag')
+}
+
+function reportSupportsMultiScope(reportType: AdminReportType): boolean {
+  return reportType === 'weekly_presence' || reportType === 'monthly_presence'
+}
+
+function reportSupportsMultiDepartment(reportType: AdminReportType): boolean {
+  return (
+    reportType === 'weekly_presence' ||
+    reportType === 'monthly_presence' ||
+    reportType === 'training_night_monthly'
+  )
+}
+
+function reportSupportsMemberSort(reportType: AdminReportType): boolean {
+  return (
+    reportType === 'daily_presence' ||
+    reportType === 'weekly_presence' ||
+    reportType === 'monthly_presence' ||
+    reportType === 'training_night_monthly'
+  )
 }
 
 function createDailyPresenceSortRuleId(): string {
@@ -80,11 +129,18 @@ function toDailyPresenceSortCriteria(rules: DailyPresenceSortRule[]): DailyPrese
 }
 
 function buildRunInput(filters: ReportFilters): RunAdminReportInput {
-  const scopeType = filters.scopeType
-  const divisionId = scopeRequiresDepartment(scopeType)
+  const scopeTypes = reportSupportsMultiScope(filters.reportType)
+    ? getSelectedScopeTypes(filters)
+    : [filters.scopeType]
+  const scopeType = scopeTypes[0] ?? 'everyone'
+  const divisionIds = scopeRequiresDepartment(scopeTypes)
+    ? optionalStringArray(filters.divisionIds)
+    : undefined
+  const divisionId = scopeRequiresDepartment(scopeTypes)
     ? optionalString(filters.divisionId)
     : undefined
-  const tagId = scopeRequiresTag(scopeType) ? optionalString(filters.tagId) : undefined
+  const tagIds = scopeRequiresTag(scopeTypes) ? optionalStringArray(filters.tagIds) : undefined
+  const tagId = scopeRequiresTag(scopeTypes) ? optionalString(filters.tagId) : undefined
 
   switch (filters.reportType) {
     case 'daily_presence':
@@ -104,8 +160,12 @@ function buildRunInput(filters: ReportFilters): RunAdminReportInput {
         body: {
           weekStartDate: filters.weekStartDate,
           scopeType,
+          scopeTypes,
           divisionId,
+          divisionIds,
           tagId,
+          tagIds,
+          sort: toDailyPresenceSortCriteria(filters.dailyPresenceSort),
         },
       }
     case 'monthly_presence':
@@ -114,8 +174,12 @@ function buildRunInput(filters: ReportFilters): RunAdminReportInput {
         body: {
           month: filters.month,
           scopeType,
+          scopeTypes,
           divisionId,
+          divisionIds,
           tagId,
+          tagIds,
+          sort: toDailyPresenceSortCriteria(filters.dailyPresenceSort),
         },
       }
     case 'training_night_monthly':
@@ -123,7 +187,9 @@ function buildRunInput(filters: ReportFilters): RunAdminReportInput {
         reportType: 'training_night_monthly',
         body: {
           month: filters.month,
-          divisionId: filters.divisionId,
+          divisionId: filters.divisionId || filters.divisionIds[0],
+          divisionIds: filters.divisionIds,
+          sort: toDailyPresenceSortCriteria(filters.dailyPresenceSort),
         },
       }
     case 'visitor_activity':
@@ -167,12 +233,15 @@ export function AdminReportsPage() {
   const tags = tagsQuery.data ?? []
   const ftsTag = tags.find((tag) => tag.name.toLowerCase() === 'fts')
   const geoTag = tags.find((tag) => tag.name.toLowerCase() === 'geo')
-  const shortcutWarning =
-    filters.scopeType === 'fts' && !ftsTag
+  const selectedScopeTypes = getSelectedScopeTypes(filters)
+  const shortcutWarnings = [
+    selectedScopeTypes.includes('fts') && !ftsTag
       ? 'FTS tag was not found. The shortcut is disabled until the tag exists.'
-      : filters.scopeType === 'geo' && !geoTag
-        ? 'GEO tag was not found. The shortcut is disabled until the tag exists.'
-        : null
+      : null,
+    selectedScopeTypes.includes('geo') && !geoTag
+      ? 'GEO tag was not found. The shortcut is disabled until the tag exists.'
+      : null,
+  ].filter((message): message is string => message !== null)
 
   const validationMessages = useMemo(() => {
     const messages: string[] = []
@@ -182,27 +251,27 @@ export function AdminReportsPage() {
       }
     }
 
-    if (scopeRequiresDepartment(filters.scopeType) && !filters.divisionId) {
-      messages.push('Select a department for the department scope.')
+    if (scopeRequiresDepartment(selectedScopeTypes) && filters.divisionIds.length === 0) {
+      messages.push('Select at least one department for the department scope.')
     }
 
-    if (scopeRequiresTag(filters.scopeType) && !filters.tagId) {
-      messages.push('Select a tag for the specific tag scope.')
+    if (scopeRequiresTag(selectedScopeTypes) && filters.tagIds.length === 0) {
+      messages.push('Select at least one tag for the specific tag scope.')
     }
 
     if (
-      filters.reportType === 'daily_presence' &&
+      reportSupportsMemberSort(filters.reportType) &&
       filters.dailyPresenceSort.some((rule) => rule.type === 'tag' && !rule.tagId)
     ) {
       messages.push('Select a tag for each tag sort rule.')
     }
 
-    if (shortcutWarning) {
+    for (const shortcutWarning of shortcutWarnings) {
       messages.push(shortcutWarning)
     }
 
     return messages
-  }, [definition.requiredFilters, filters, shortcutWarning])
+  }, [definition.requiredFilters, filters, selectedScopeTypes, shortcutWarnings])
 
   const isRunDisabled = validationMessages.length > 0 || reportRunner.isPending
   const errorMessage = reportRunner.error?.message ?? null
@@ -276,7 +345,7 @@ export function AdminReportsPage() {
               tags={tags}
               visitTypes={visitTypesQuery.data ?? []}
               hostMembers={reportHostMembers}
-              shortcutWarning={shortcutWarning}
+              shortcutWarnings={shortcutWarnings}
             />
           </div>
 
@@ -352,7 +421,7 @@ function ReportsFilterPanel({
   tags,
   visitTypes,
   hostMembers,
-  shortcutWarning,
+  shortcutWarnings,
 }: {
   filters: ReportFilters
   updateFilters: (next: Partial<ReportFilters>) => void
@@ -366,16 +435,65 @@ function ReportsFilterPanel({
     firstName: string
     lastName: string
   }>
-  shortcutWarning: string | null
+  shortcutWarnings: string[]
 }) {
   const definition = getReportDefinition(filters.reportType)
   const visible = new Set(definition.visibleFilters)
   const showScope = visible.has('scopeType')
+  const useMultiScope = reportSupportsMultiScope(filters.reportType)
+  const useMultiDepartment = reportSupportsMultiDepartment(filters.reportType)
+  const selectedScopeTypes = useMultiScope ? getSelectedScopeTypes(filters) : [filters.scopeType]
   const showDepartment =
     visible.has('divisionId') &&
-    (filters.reportType === 'training_night_monthly' || filters.scopeType === 'department')
-  const showTag = visible.has('tagId') && filters.scopeType === 'tag'
+    (filters.reportType === 'training_night_monthly' || selectedScopeTypes.includes('department'))
+  const showTag = visible.has('tagId') && selectedScopeTypes.includes('tag')
   const showDailyPresenceSort = visible.has('dailyPresenceSort')
+
+  function updateScopeTypes(nextScopeTypes: ReportScopeType[]) {
+    const normalized = nextScopeTypes.includes('everyone')
+      ? (['everyone'] as ReportScopeType[])
+      : nextScopeTypes.length > 0
+        ? nextScopeTypes
+        : (['everyone'] as ReportScopeType[])
+    const includesDepartment = normalized.includes('department')
+    const includesTag = normalized.includes('tag')
+
+    updateFilters({
+      scopeType: normalized[0] ?? 'everyone',
+      scopeTypes: normalized,
+      divisionId: includesDepartment ? filters.divisionId : '',
+      divisionIds: includesDepartment ? filters.divisionIds : [],
+      tagId: includesTag ? filters.tagId : '',
+      tagIds: includesTag ? filters.tagIds : [],
+    })
+  }
+
+  function toggleScopeType(scopeType: ReportScopeType) {
+    if (scopeType === 'everyone') {
+      updateScopeTypes(['everyone'])
+      return
+    }
+
+    const withoutEveryone = selectedScopeTypes.filter((value) => value !== 'everyone')
+    const nextScopeTypes = withoutEveryone.includes(scopeType)
+      ? withoutEveryone.filter((value) => value !== scopeType)
+      : [...withoutEveryone, scopeType]
+    updateScopeTypes(nextScopeTypes)
+  }
+
+  function updateDepartmentIds(divisionIds: string[]) {
+    updateFilters({
+      divisionIds,
+      divisionId: divisionIds[0] ?? '',
+    })
+  }
+
+  function updateTagIds(tagIds: string[]) {
+    updateFilters({
+      tagIds,
+      tagId: tagIds[0] ?? '',
+    })
+  }
 
   return (
     <div className="grid gap-(--space-3) md:grid-cols-2 xl:grid-cols-3">
@@ -421,26 +539,42 @@ function ReportsFilterPanel({
           <span className="label pb-(--space-1)">
             <span className="label-text font-semibold">Scope</span>
           </span>
-          <select
-            className="select select-bordered w-full"
-            value={filters.scopeType}
-            onChange={(event) =>
-              updateFilters({
-                scopeType: event.target.value as ReportScopeType,
-                divisionId: '',
-                tagId: '',
-              })
-            }
-          >
-            <option value="everyone">Everyone</option>
-            <option value="department">Department</option>
-            <option value="tag">Specific tag</option>
-            <option value="fts">FTS tag shortcut</option>
-            <option value="geo">GEO tag shortcut</option>
-          </select>
-          {shortcutWarning && (
+          {useMultiScope ? (
+            <MultiSelectDropdown
+              ariaLabel="Scope"
+              options={REPORT_SCOPE_OPTIONS}
+              selectedValues={selectedScopeTypes}
+              emptyLabel="Select scopes"
+              summaryLabel={(count) => `${count} scopes`}
+              onToggle={(value) => toggleScopeType(value as ReportScopeType)}
+            />
+          ) : (
+            <select
+              className="select select-bordered w-full"
+              value={filters.scopeType}
+              onChange={(event) =>
+                updateFilters({
+                  scopeType: event.target.value as ReportScopeType,
+                  scopeTypes: [event.target.value as ReportScopeType],
+                  divisionId: '',
+                  divisionIds: [],
+                  tagId: '',
+                  tagIds: [],
+                })
+              }
+            >
+              {REPORT_SCOPE_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          )}
+          {shortcutWarnings.length > 0 && (
             <span className="label pt-(--space-1)">
-              <span className="label-text-alt text-warning-fadded-content">{shortcutWarning}</span>
+              <span className="label-text-alt text-warning-fadded-content">
+                {shortcutWarnings.join(' ')}
+              </span>
             </span>
           )}
         </label>
@@ -450,18 +584,43 @@ function ReportsFilterPanel({
           <span className="label pb-(--space-1)">
             <span className="label-text font-semibold">Department</span>
           </span>
-          <select
-            className="select select-bordered w-full"
-            value={filters.divisionId}
-            onChange={(event) => updateFilters({ divisionId: event.target.value })}
-          >
-            <option value="">Select department</option>
-            {divisions.map((division) => (
-              <option key={division.id} value={division.id}>
-                {division.code} — {division.name}
-              </option>
-            ))}
-          </select>
+          {useMultiDepartment ? (
+            <MultiSelectDropdown
+              ariaLabel="Department"
+              options={divisions.map((division) => ({
+                value: division.id,
+                label: `${division.code} - ${division.name}`,
+              }))}
+              selectedValues={filters.divisionIds}
+              emptyLabel="Select departments"
+              summaryLabel={(count) => `${count} departments`}
+              onToggle={(divisionId) =>
+                updateDepartmentIds(
+                  filters.divisionIds.includes(divisionId)
+                    ? filters.divisionIds.filter((value) => value !== divisionId)
+                    : [...filters.divisionIds, divisionId]
+                )
+              }
+            />
+          ) : (
+            <select
+              className="select select-bordered w-full"
+              value={filters.divisionId}
+              onChange={(event) =>
+                updateFilters({
+                  divisionId: event.target.value,
+                  divisionIds: event.target.value ? [event.target.value] : [],
+                })
+              }
+            >
+              <option value="">Select department</option>
+              {divisions.map((division) => (
+                <option key={division.id} value={division.id}>
+                  {division.code} - {division.name}
+                </option>
+              ))}
+            </select>
+          )}
         </label>
       )}
       {showTag && (
@@ -469,23 +628,46 @@ function ReportsFilterPanel({
           <span className="label pb-(--space-1)">
             <span className="label-text font-semibold">Tag</span>
           </span>
-          <select
-            className="select select-bordered w-full"
-            value={filters.tagId}
-            onChange={(event) => updateFilters({ tagId: event.target.value })}
-          >
-            <option value="">Select tag</option>
-            {tags.map((tag) => (
-              <option key={tag.id} value={tag.id}>
-                {tag.name}
-              </option>
-            ))}
-          </select>
+          {useMultiScope ? (
+            <MultiSelectDropdown
+              ariaLabel="Tag"
+              options={tags.map((tag) => ({ value: tag.id, label: tag.name }))}
+              selectedValues={filters.tagIds}
+              emptyLabel="Select tags"
+              summaryLabel={(count) => `${count} tags`}
+              onToggle={(tagId) =>
+                updateTagIds(
+                  filters.tagIds.includes(tagId)
+                    ? filters.tagIds.filter((value) => value !== tagId)
+                    : [...filters.tagIds, tagId]
+                )
+              }
+            />
+          ) : (
+            <select
+              className="select select-bordered w-full"
+              value={filters.tagId}
+              onChange={(event) =>
+                updateFilters({
+                  tagId: event.target.value,
+                  tagIds: event.target.value ? [event.target.value] : [],
+                })
+              }
+            >
+              <option value="">Select tag</option>
+              {tags.map((tag) => (
+                <option key={tag.id} value={tag.id}>
+                  {tag.name}
+                </option>
+              ))}
+            </select>
+          )}
         </label>
       )}
       {showDailyPresenceSort && (
         <div className="md:col-span-2 xl:col-span-3">
-          <DailyPresenceSortBuilder
+          <MemberReportSortBuilder
+            reportType={filters.reportType}
             rules={filters.dailyPresenceSort}
             tags={tags}
             onChange={(dailyPresenceSort) => updateFilters({ dailyPresenceSort })}
@@ -578,10 +760,65 @@ function ReportsFilterPanel({
   )
 }
 
-const DAILY_PRESENCE_FIELD_OPTIONS: Array<{
-  value: Extract<DailyPresenceSortCriterion, { type: 'field' }>['field']
-  label: string
-}> = [
+function MultiSelectDropdown({
+  ariaLabel,
+  options,
+  selectedValues,
+  emptyLabel,
+  summaryLabel,
+  onToggle,
+}: {
+  ariaLabel: string
+  options: Array<{ value: string; label: string }>
+  selectedValues: string[]
+  emptyLabel: string
+  summaryLabel: (count: number) => string
+  onToggle: (value: string) => void
+}) {
+  const selectedOptions = options.filter((option) => selectedValues.includes(option.value))
+  const buttonLabel =
+    selectedOptions.length === 0
+      ? emptyLabel
+      : selectedOptions.length === 1
+        ? selectedOptions[0]?.label
+        : summaryLabel(selectedOptions.length)
+
+  return (
+    <details className="dropdown w-full">
+      <summary
+        className="btn btn-outline h-12 w-full justify-between px-(--space-4) font-normal"
+        aria-label={ariaLabel}
+      >
+        <span className="truncate">{buttonLabel}</span>
+        <ChevronDown className="h-4 w-4 shrink-0" aria-hidden="true" />
+      </summary>
+      <div className="dropdown-content z-20 mt-(--space-1) max-h-80 w-full overflow-y-auto rounded-box border border-base-300 bg-base-100 p-(--space-2) shadow-[var(--shadow-2)]">
+        {options.map((option) => {
+          const checked = selectedValues.includes(option.value)
+          return (
+            <label
+              key={option.value}
+              className="flex cursor-pointer items-center gap-(--space-2) rounded-box px-(--space-2) py-(--space-2) text-sm hover:bg-base-200"
+            >
+              <input
+                type="checkbox"
+                className="checkbox checkbox-sm"
+                aria-label={option.label}
+                checked={checked}
+                onChange={() => onToggle(option.value)}
+              />
+              <span className="min-w-0 flex-1 truncate">{option.label}</span>
+            </label>
+          )
+        })}
+      </div>
+    </details>
+  )
+}
+
+type MemberReportSortField = Extract<DailyPresenceSortCriterion, { type: 'field' }>['field']
+
+const DAILY_PRESENCE_FIELD_OPTIONS: Array<{ value: MemberReportSortField; label: string }> = [
   { value: 'rank', label: 'Rank' },
   { value: 'last_name', label: 'Last name' },
   { value: 'first_name', label: 'First name' },
@@ -591,17 +828,149 @@ const DAILY_PRESENCE_FIELD_OPTIONS: Array<{
   { value: 'sessions', label: 'Sessions' },
 ]
 
-function DailyPresenceSortBuilder({
+const WEEKLY_PRESENCE_FIELD_OPTIONS: Array<{ value: MemberReportSortField; label: string }> = [
+  { value: 'rank', label: 'Rank' },
+  { value: 'last_name', label: 'Last name' },
+  { value: 'first_name', label: 'First name' },
+  { value: 'department', label: 'Department' },
+  { value: 'total_days_present', label: 'Days present' },
+  { value: 'total_sessions', label: 'Sessions' },
+  { value: 'training_night_present', label: 'Training night' },
+  { value: 'admin_night_present', label: 'Admin night' },
+]
+
+const MONTHLY_PRESENCE_FIELD_OPTIONS: Array<{ value: MemberReportSortField; label: string }> = [
+  { value: 'rank', label: 'Rank' },
+  { value: 'last_name', label: 'Last name' },
+  { value: 'first_name', label: 'First name' },
+  { value: 'department', label: 'Department' },
+  { value: 'total_days_present', label: 'Days present' },
+  { value: 'total_sessions', label: 'Sessions' },
+  { value: 'training_nights_present', label: 'Training nights' },
+  { value: 'admin_nights_present', label: 'Admin nights' },
+]
+
+const TRAINING_NIGHT_MONTHLY_FIELD_OPTIONS: Array<{
+  value: MemberReportSortField
+  label: string
+}> = [
+  { value: 'rank', label: 'Rank' },
+  { value: 'last_name', label: 'Last name' },
+  { value: 'first_name', label: 'First name' },
+  { value: 'department', label: 'Department' },
+  { value: 'attended', label: 'Attended' },
+  { value: 'possible', label: 'Possible' },
+  { value: 'percentage', label: 'Percentage' },
+]
+
+function getMemberReportFieldOptions(
+  reportType: AdminReportType
+): Array<{ value: MemberReportSortField; label: string }> {
+  switch (reportType) {
+    case 'weekly_presence':
+      return WEEKLY_PRESENCE_FIELD_OPTIONS
+    case 'monthly_presence':
+      return MONTHLY_PRESENCE_FIELD_OPTIONS
+    case 'training_night_monthly':
+      return TRAINING_NIGHT_MONTHLY_FIELD_OPTIONS
+    case 'daily_presence':
+    case 'visitor_activity':
+    case 'operational_exceptions':
+      return DAILY_PRESENCE_FIELD_OPTIONS
+  }
+}
+
+function getDefaultMemberReportSortField(
+  reportType: AdminReportType,
+  group: DailyPresenceSortGroup
+): MemberReportSortField {
+  if (group === 'secondary') {
+    return 'last_name'
+  }
+
+  return getMemberReportFieldOptions(reportType).some((option) => option.value === 'department')
+    ? 'department'
+    : 'rank'
+}
+
+function getDefaultMemberReportFieldDirection(field: MemberReportSortField) {
+  if (
+    field === 'rank' ||
+    field === 'sessions' ||
+    field === 'total_days_present' ||
+    field === 'total_sessions' ||
+    field === 'training_nights_present' ||
+    field === 'admin_nights_present' ||
+    field === 'attended' ||
+    field === 'possible' ||
+    field === 'percentage' ||
+    field === 'training_night_present' ||
+    field === 'admin_night_present'
+  ) {
+    return 'desc'
+  }
+
+  return 'asc'
+}
+
+function getDailyPresenceFieldDirectionLabels(field: MemberReportSortField) {
+  if (field === 'rank') {
+    return {
+      asc: 'Lowest rank first',
+      desc: 'Highest rank first',
+    }
+  }
+
+  if (field === 'first_in' || field === 'last_out') {
+    return {
+      asc: 'Earliest first',
+      desc: 'Latest first',
+    }
+  }
+
+  if (field === 'training_night_present' || field === 'admin_night_present') {
+    return {
+      asc: 'Not present first',
+      desc: 'Present first',
+    }
+  }
+
+  if (
+    field === 'sessions' ||
+    field === 'total_days_present' ||
+    field === 'total_sessions' ||
+    field === 'training_nights_present' ||
+    field === 'admin_nights_present' ||
+    field === 'attended' ||
+    field === 'possible' ||
+    field === 'percentage'
+  ) {
+    return {
+      asc: 'Low to high',
+      desc: 'High to low',
+    }
+  }
+
+  return {
+    asc: 'A to Z',
+    desc: 'Z to A',
+  }
+}
+
+function MemberReportSortBuilder({
+  reportType,
   rules,
   tags,
   onChange,
 }: {
+  reportType: AdminReportType
   rules: DailyPresenceSortRule[]
   tags: Array<{ id: string; name: string }>
   onChange: (rules: DailyPresenceSortRule[]) => void
 }) {
   const primaryRules = rules.filter((rule) => rule.sortGroup === 'primary')
   const secondaryRules = rules.filter((rule) => rule.sortGroup === 'secondary')
+  const fieldOptions = getMemberReportFieldOptions(reportType)
 
   function updateGroupRules(
     group: DailyPresenceSortGroup,
@@ -711,14 +1080,15 @@ function DailyPresenceSortBuilder({
   }
 
   function addFieldRule(group: DailyPresenceSortGroup) {
+    const field = getDefaultMemberReportSortField(reportType, group)
     updateGroupRules(group, [
       ...(group === 'primary' ? primaryRules : secondaryRules),
       {
         id: createDailyPresenceSortRuleId(),
         sortGroup: group,
         type: 'field',
-        field: group === 'secondary' ? 'last_name' : 'department',
-        direction: 'asc',
+        field,
+        direction: getDefaultMemberReportFieldDirection(field),
       },
     ])
   }
@@ -765,8 +1135,10 @@ function DailyPresenceSortBuilder({
               id: rule.id,
               sortGroup: rule.sortGroup,
               type: 'field',
-              field: rule.sortGroup === 'secondary' ? 'last_name' : 'department',
-              direction: 'asc',
+              field: getDefaultMemberReportSortField(reportType, rule.sortGroup),
+              direction: getDefaultMemberReportFieldDirection(
+                getDefaultMemberReportSortField(reportType, rule.sortGroup)
+              ),
             })
           }}
         >
@@ -795,16 +1167,15 @@ function DailyPresenceSortBuilder({
           <select
             className="select select-bordered select-sm w-full"
             value={rule.field}
-            onChange={(event) =>
+            onChange={(event) => {
+              const field = event.target.value as MemberReportSortField
               updateFieldRule(rule.id, {
-                field: event.target.value as Extract<
-                  DailyPresenceSortCriterion,
-                  { type: 'field' }
-                >['field'],
+                field,
+                direction: getDefaultMemberReportFieldDirection(field),
               })
-            }
+            }}
           >
-            {DAILY_PRESENCE_FIELD_OPTIONS.map((option) => (
+            {fieldOptions.map((option) => (
               <option key={option.value} value={option.value}>
                 {option.label}
               </option>
@@ -812,30 +1183,35 @@ function DailyPresenceSortBuilder({
           </select>
         )}
 
-        <select
-          className="select select-bordered select-sm w-full"
-          value={rule.direction}
-          onChange={(event) =>
-            rule.type === 'tag'
-              ? updateTagRule(rule.id, {
-                  direction: event.target.value as DailyPresenceSortCriterion['direction'],
-                })
-              : rule.type === 'tag_priority'
-                ? updateTagPriorityRule(rule.id, {
-                    direction: event.target.value as DailyPresenceSortCriterion['direction'],
-                  })
-                : updateFieldRule(rule.id, {
-                    direction: event.target.value as DailyPresenceSortCriterion['direction'],
-                  })
-          }
-        >
-          <option value="asc">
-            {rule.type === 'tag' || rule.type === 'tag_priority' ? 'First' : 'A to Z'}
-          </option>
-          <option value="desc">
-            {rule.type === 'tag' || rule.type === 'tag_priority' ? 'Last' : 'Z to A'}
-          </option>
-        </select>
+        {(() => {
+          const directionLabels =
+            rule.type === 'field'
+              ? getDailyPresenceFieldDirectionLabels(rule.field)
+              : { asc: 'First', desc: 'Last' }
+
+          return (
+            <select
+              className="select select-bordered select-sm w-full"
+              value={rule.direction}
+              onChange={(event) =>
+                rule.type === 'tag'
+                  ? updateTagRule(rule.id, {
+                      direction: event.target.value as DailyPresenceSortCriterion['direction'],
+                    })
+                  : rule.type === 'tag_priority'
+                    ? updateTagPriorityRule(rule.id, {
+                        direction: event.target.value as DailyPresenceSortCriterion['direction'],
+                      })
+                    : updateFieldRule(rule.id, {
+                        direction: event.target.value as DailyPresenceSortCriterion['direction'],
+                      })
+              }
+            >
+              <option value="asc">{directionLabels.asc}</option>
+              <option value="desc">{directionLabels.desc}</option>
+            </select>
+          )
+        })()}
 
         <div className="flex items-center justify-end gap-(--space-1)">
           <button

--- a/apps/frontend-admin/src/components/admin/reports/report-definitions.ts
+++ b/apps/frontend-admin/src/components/admin/reports/report-definitions.ts
@@ -60,8 +60,11 @@ export interface ReportFilters {
   startDate: string
   endDate: string
   scopeType: ReportScopeType
+  scopeTypes: ReportScopeType[]
   divisionId: string
+  divisionIds: string[]
   tagId: string
+  tagIds: string[]
   visitType: string
   visitorPurpose: string
   eventLinked: 'all' | 'linked' | 'unlinked'
@@ -120,12 +123,15 @@ export function getBaseReportFilters(reportType: AdminReportType): ReportFilters
     endDate: toDateInput(monthEnd < now ? monthEnd : now),
     scopeType: 'everyone',
     divisionId: '',
+    divisionIds: [],
     tagId: '',
+    tagIds: [],
     visitType: '',
     visitorPurpose: '',
     eventLinked: 'all',
     hostMemberId: '',
     organization: '',
+    scopeTypes: ['everyone'],
     dailyPresenceSort: [
       {
         id: 'daily-sort-secondary-last-name',
@@ -155,7 +161,7 @@ export const REPORT_DEFINITIONS = [
     description: 'Presence across a Monday-Sunday week with key night attendance markers.',
     defaultFilters: () => getBaseReportFilters('weekly_presence'),
     requiredFilters: ['weekStartDate'],
-    visibleFilters: ['weekStartDate', 'scopeType', 'divisionId', 'tagId'],
+    visibleFilters: ['weekStartDate', 'scopeType', 'divisionId', 'tagId', 'dailyPresenceSort'],
     runMutation: 'generateWeeklyPresence',
     previewComponent: 'WeeklyPresenceReport',
   },
@@ -165,7 +171,7 @@ export const REPORT_DEFINITIONS = [
     description: 'Monthly attendance overview by member, department, or tag-backed group.',
     defaultFilters: () => getBaseReportFilters('monthly_presence'),
     requiredFilters: ['month'],
-    visibleFilters: ['month', 'scopeType', 'divisionId', 'tagId'],
+    visibleFilters: ['month', 'scopeType', 'divisionId', 'tagId', 'dailyPresenceSort'],
     runMutation: 'generateMonthlyPresence',
     previewComponent: 'MonthlyPresenceReport',
   },
@@ -176,9 +182,10 @@ export const REPORT_DEFINITIONS = [
     defaultFilters: () => ({
       ...getBaseReportFilters('training_night_monthly'),
       scopeType: 'department',
+      scopeTypes: ['department'],
     }),
-    requiredFilters: ['month', 'divisionId'],
-    visibleFilters: ['month', 'divisionId'],
+    requiredFilters: ['month'],
+    visibleFilters: ['month', 'divisionId', 'dailyPresenceSort'],
     runMutation: 'generateTrainingNightMonthly',
     previewComponent: 'TrainingNightMonthlyReport',
   },

--- a/apps/frontend-admin/src/components/admin/reports/report-preview.tsx
+++ b/apps/frontend-admin/src/components/admin/reports/report-preview.tsx
@@ -176,14 +176,18 @@ function ReportDocumentFrame({
         </div>
 
         <div className="mt-(--space-4) flex flex-wrap gap-(--space-2) text-xs text-base-content/65">
-          {report.filters.divisionId && (
+          {(report.filters.divisionId || report.filters.divisionIds?.length) && (
             <span className="rounded-box bg-base-200 px-(--space-2) py-(--space-1)">
-              Department filter
+              {report.filters.divisionIds && report.filters.divisionIds.length > 1
+                ? `${report.filters.divisionIds.length} department filters`
+                : 'Department filter'}
             </span>
           )}
-          {report.filters.tagId && (
+          {(report.filters.tagId || report.filters.tagIds?.length) && (
             <span className="rounded-box bg-base-200 px-(--space-2) py-(--space-1)">
-              Tag filter
+              {report.filters.tagIds && report.filters.tagIds.length > 1
+                ? `${report.filters.tagIds.length} tag filters`
+                : 'Tag filter'}
             </span>
           )}
           {report.filters.visitorType && (

--- a/apps/frontend-admin/src/hooks/use-admin-reports.ts
+++ b/apps/frontend-admin/src/hooks/use-admin-reports.ts
@@ -89,7 +89,11 @@ function formatValidationIssue(issue: unknown): string | null {
     return null
   }
 
-  if (message === 'Invalid daily presence sort field' && issueRecord.input === 'rank') {
+  if (
+    (message === 'Invalid daily presence sort field' ||
+      message === 'Invalid attendance report sort field') &&
+    issueRecord.input === 'rank'
+  ) {
     return 'Rank sorting requires the updated reports API. Restart or rebuild the backend with the latest report contract, or remove Rank from the sort order.'
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.4.7",
+  "version": "3.4.8",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.4.7",
+  "version": "3.4.8",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/contracts/src/schemas/report.schema.ts
+++ b/packages/contracts/src/schemas/report.schema.ts
@@ -62,8 +62,25 @@ export const DailyPresenceSortDirectionEnum = v.picklist(
 )
 
 export const DailyPresenceSortFieldEnum = v.picklist(
-  ['last_name', 'first_name', 'rank', 'department', 'first_in', 'last_out', 'sessions'],
-  'Invalid daily presence sort field'
+  [
+    'last_name',
+    'first_name',
+    'rank',
+    'department',
+    'first_in',
+    'last_out',
+    'sessions',
+    'total_days_present',
+    'total_sessions',
+    'training_night_present',
+    'admin_night_present',
+    'training_nights_present',
+    'admin_nights_present',
+    'attended',
+    'possible',
+    'percentage',
+  ],
+  'Invalid attendance report sort field'
 )
 
 const LocalDateSchema = v.pipe(
@@ -77,6 +94,7 @@ const LocalMonthSchema = v.pipe(
 )
 
 const UuidSchema = v.pipe(v.string(), v.uuid('Invalid ID format'))
+const UuidArraySchema = v.array(UuidSchema)
 
 // ============================================================================
 // Request Schemas
@@ -161,8 +179,11 @@ export type VisitorSummaryConfig = v.InferOutput<typeof VisitorSummaryConfigSche
  */
 export const PresenceReportConfigSchema = v.object({
   scopeType: v.optional(OperationalReportScopeEnum, 'everyone'),
+  scopeTypes: v.optional(v.array(OperationalReportScopeEnum)),
   divisionId: v.optional(UuidSchema),
+  divisionIds: v.optional(UuidArraySchema),
   tagId: v.optional(UuidSchema),
+  tagIds: v.optional(UuidArraySchema),
 })
 
 export type PresenceReportConfig = v.InferOutput<typeof PresenceReportConfigSchema>
@@ -194,7 +215,7 @@ export type DailyPresenceSortCriterion = v.InferOutput<typeof DailyPresenceSortC
 
 export const DailyPresenceSortSchema = v.pipe(
   v.array(DailyPresenceSortCriterionSchema),
-  v.maxLength(8, 'Daily presence reports support up to 8 sort rules')
+  v.maxLength(8, 'Attendance reports support up to 8 sort rules')
 )
 
 export const DailyPresenceReportConfigSchema = v.object({
@@ -210,8 +231,12 @@ export type DailyPresenceReportConfig = v.InferOutput<typeof DailyPresenceReport
 export const WeeklyPresenceReportConfigSchema = v.object({
   weekStartDate: LocalDateSchema,
   scopeType: v.optional(OperationalReportScopeEnum, 'everyone'),
+  scopeTypes: v.optional(v.array(OperationalReportScopeEnum)),
   divisionId: v.optional(UuidSchema),
+  divisionIds: v.optional(UuidArraySchema),
   tagId: v.optional(UuidSchema),
+  tagIds: v.optional(UuidArraySchema),
+  sort: v.optional(DailyPresenceSortSchema),
 })
 
 export type WeeklyPresenceReportConfig = v.InferOutput<typeof WeeklyPresenceReportConfigSchema>
@@ -219,15 +244,21 @@ export type WeeklyPresenceReportConfig = v.InferOutput<typeof WeeklyPresenceRepo
 export const MonthlyPresenceReportConfigSchema = v.object({
   month: LocalMonthSchema,
   scopeType: v.optional(OperationalReportScopeEnum, 'everyone'),
+  scopeTypes: v.optional(v.array(OperationalReportScopeEnum)),
   divisionId: v.optional(UuidSchema),
+  divisionIds: v.optional(UuidArraySchema),
   tagId: v.optional(UuidSchema),
+  tagIds: v.optional(UuidArraySchema),
+  sort: v.optional(DailyPresenceSortSchema),
 })
 
 export type MonthlyPresenceReportConfig = v.InferOutput<typeof MonthlyPresenceReportConfigSchema>
 
 export const TrainingNightMonthlyReportConfigSchema = v.object({
   month: LocalMonthSchema,
-  divisionId: UuidSchema,
+  divisionId: v.optional(UuidSchema),
+  divisionIds: v.optional(UuidArraySchema),
+  sort: v.optional(DailyPresenceSortSchema),
 })
 
 export type TrainingNightMonthlyReportConfig = v.InferOutput<
@@ -331,7 +362,9 @@ export type ReportDateRange = v.InferOutput<typeof ReportDateRangeSchema>
 export const ReportFilterSummarySchema = v.object({
   scopeLabel: v.string(),
   divisionId: v.optional(v.string()),
+  divisionIds: v.optional(v.array(v.string())),
   tagId: v.optional(v.string()),
+  tagIds: v.optional(v.array(v.string())),
   visitorType: v.optional(v.string()),
   visitorPurpose: v.optional(v.string()),
   eventCategory: v.optional(v.string()),

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.4.7",
+  "version": "3.4.8",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.4.7",
+  "version": "3.4.8",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Adds multi-select Scope, Department, and Tag filtering for Weekly and Monthly Presence reports where those filters apply.
- Adds multi-department selection for Training Night Monthly reports.
- Extends the Primary and Secondary sort builder to Weekly Presence, Monthly Presence, and Training Night Monthly reports with report-specific field choices.
- Keeps Visitor Activity and Operational Exceptions on their existing timeline-style ordering because they are not member attendance reports.
- Prepares Sentinel v3.4.8 as the next patch release.

## Why this change was needed

Report users needed more flexible attendance audiences and consistent member sorting beyond Daily Presence. Weekly, Monthly, and Training Night Monthly reports now support the same primary/secondary sorting workflow where the underlying rows are member attendance rows.

## What changed

### User-facing

- Weekly and Monthly Presence reports can filter by multiple scopes and multiple departments or tags.
- Training Night Monthly can include multiple departments in one report.
- Weekly, Monthly, and Training Night Monthly reports now show the same Primary and Secondary sort controls used by Daily Presence.
- Sort field choices are constrained per report so users only see fields that make sense for that report.

### Admin/operator-facing

- Report setup remains in the existing Admin Reports workflow.
- Training Night Monthly now labels multi-department reports by the selected department names.
- The report preview filter badges summarize multi-department and multi-tag filters.

### Backend/API

- Attendance report request schemas now accept multi-value `scopeTypes`, `divisionIds`, and `tagIds` where applicable.
- Weekly, Monthly, and Training Night Monthly report configs now accept `sort` criteria.
- The backend now applies one shared member-report sorter across Daily, Weekly, Monthly, and Training Night Monthly rows.
- Existing single-value `scopeType`, `divisionId`, and `tagId` request fields remain supported for compatibility.

### Database

- No database changes.

### Deployment/update

- Package versions were synchronized to `3.4.8` for the patch release.

### Tests

- Added backend regression coverage for multi-department Training Night Monthly filtering.
- Added backend regression coverage for shared member-report sorting by attendance count and percentage.

## User impact

Report users can generate broader attendance reports without running separate exports per department or tag, and can order member rows consistently across attendance report types.

## Operator impact

No manual operator action is required beyond deploying the patch release. Existing report requests remain compatible.

## Upgrade or migration notes

No upgrade action required. No database migration is required. No configuration change is required.

## Risk and rollback notes

Main risk is incorrect report row ordering or overly broad filtering in attendance reports. Verification covered the backend sort/filter paths and the Admin Reports UI. Rollback is safe by redeploying the previous release because no database or configuration migration is included.

## Testing performed

- `pnpm --filter @sentinel/backend typecheck`
- `pnpm --filter frontend-admin typecheck`
- `node_modules/.pnpm/node_modules/.bin/vitest run apps/backend/src/services/operational-report-service.test.ts`
- `pnpm --filter frontend-admin lint` with existing warnings only
- `pnpm --filter @sentinel/backend lint` with existing warnings only
- `git diff --check`
- Playwright visual check at `1920x1080` on `/admin/reports` for Daily, Weekly, Monthly, Training Night Monthly, and Visitor Activity report setup states
- `pnpm version:check`

## Changelog candidates

- Added multi-select audience filtering for Weekly, Monthly, and Training Night Monthly attendance reports.
- Added Primary and Secondary member sorting to Weekly, Monthly, and Training Night Monthly reports.
- Fixed Daily Presence report warning noise from unmatched checkout records that only belonged to the lookback window.
- Prepared Sentinel v3.4.8 as a patch release with no database migration required.