### PR TITLE
fix(reports): reconcile quick checkout report sessions

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.4.8",
+  "version": "3.4.9",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/services/operational-report-service.test.ts
+++ b/apps/backend/src/services/operational-report-service.test.ts
@@ -288,6 +288,64 @@ describe('pairOperationalPresenceSessions', () => {
     )
   })
 
+  it('ignores an unmatched checkout without warning when a check-in follows within five minutes', () => {
+    const warnings = new Set<string>()
+    const sessionsByMember = pairOperationalPresenceSessions(
+      [
+        checkin('1', 'member-1', 'out', '2026-05-05T08:00:00.000Z'),
+        checkin('2', 'member-1', 'in', '2026-05-05T08:04:00.000Z'),
+        checkin('3', 'member-1', 'out', '2026-05-05T12:00:00.000Z'),
+      ],
+      warnings
+    )
+
+    const sessions = getSessions(sessionsByMember, 'member-1')
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]?.inAt.toISOString()).toBe('2026-05-05T08:04:00.000Z')
+    expect(sessions[0]?.outAt?.toISOString()).toBe('2026-05-05T12:00:00.000Z')
+    expect(Array.from(warnings)).not.toContain(
+      'Some checkout records could not be paired with a prior check-in and were ignored.'
+    )
+  })
+
+  it('treats a checkout followed by a check-in within five minutes as continuous presence', () => {
+    const warnings = new Set<string>()
+    const sessionsByMember = pairOperationalPresenceSessions(
+      [
+        checkin('1', 'member-1', 'in', '2026-05-05T08:00:00.000Z'),
+        checkin('2', 'member-1', 'out', '2026-05-05T10:00:00.000Z'),
+        checkin('3', 'member-1', 'in', '2026-05-05T10:03:00.000Z'),
+        checkin('4', 'member-1', 'out', '2026-05-05T16:00:00.000Z'),
+      ],
+      warnings
+    )
+
+    const sessions = getSessions(sessionsByMember, 'member-1')
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]?.inAt.toISOString()).toBe('2026-05-05T08:00:00.000Z')
+    expect(sessions[0]?.outAt?.toISOString()).toBe('2026-05-05T16:00:00.000Z')
+    expect(sessions[0]?.status).toBe('complete')
+    expect(warnings.size).toBe(0)
+  })
+
+  it('keeps warning for an unmatched checkout when the next check-in is outside five minutes', () => {
+    const warnings = new Set<string>()
+    const sessionsByMember = pairOperationalPresenceSessions(
+      [
+        checkin('1', 'member-1', 'out', '2026-05-05T08:00:00.000Z'),
+        checkin('2', 'member-1', 'in', '2026-05-05T08:06:00.000Z'),
+      ],
+      warnings
+    )
+
+    const sessions = getSessions(sessionsByMember, 'member-1')
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]?.inAt.toISOString()).toBe('2026-05-05T08:06:00.000Z')
+    expect(Array.from(warnings)).toContain(
+      'Some checkout records could not be paired with a prior check-in and were ignored.'
+    )
+  })
+
   it('tracks affected member IDs for unmatched checkout warnings', () => {
     const warnings = new Set<string>()
     const warningMemberIds = new Map<string, Set<string>>()
@@ -673,6 +731,90 @@ describe('sortDailyPresenceRows', () => {
     expect(sorted.map((row) => row.memberRecord.id)).toEqual(['s1-able', 's1-zulu', 'ms-baker'])
   })
 
+  it('lets last name direction control equal-rank members when rank is descending', () => {
+    const sorted = sortDailyPresenceRows(
+      [
+        sortableDailyPresenceRow({
+          id: 's1-zulu',
+          firstName: 'Zed',
+          lastName: 'Zulu',
+          rank: 'S1',
+          rankOrder: 3,
+        }),
+        sortableDailyPresenceRow({
+          id: 'ms-baker',
+          firstName: 'Bill',
+          lastName: 'Baker',
+          rank: 'MS',
+          rankOrder: 5,
+        }),
+        sortableDailyPresenceRow({
+          id: 's1-able',
+          firstName: 'Ann',
+          lastName: 'Able',
+          rank: 'S1',
+          rankOrder: 3,
+        }),
+      ],
+      [
+        { type: 'field', field: 'rank', direction: 'desc' },
+        { type: 'field', field: 'last_name', direction: 'asc' },
+      ]
+    )
+
+    expect(sorted.map((row) => row.memberRecord.id)).toEqual(['ms-baker', 's1-able', 's1-zulu'])
+  })
+
+  it('honors descending last name sort direction', () => {
+    const sorted = sortDailyPresenceRows(
+      [
+        sortableDailyPresenceRow({
+          id: 'able',
+          firstName: 'Ann',
+          lastName: 'Able',
+        }),
+        sortableDailyPresenceRow({
+          id: 'baker',
+          firstName: 'Bill',
+          lastName: 'Baker',
+        }),
+        sortableDailyPresenceRow({
+          id: 'zulu',
+          firstName: 'Zed',
+          lastName: 'Zulu',
+        }),
+      ],
+      [{ type: 'field', field: 'last_name', direction: 'desc' }]
+    )
+
+    expect(sorted.map((row) => row.memberRecord.id)).toEqual(['zulu', 'baker', 'able'])
+  })
+
+  it('honors descending first name sort direction', () => {
+    const sorted = sortDailyPresenceRows(
+      [
+        sortableDailyPresenceRow({
+          id: 'amy',
+          firstName: 'Amy',
+          lastName: 'Zulu',
+        }),
+        sortableDailyPresenceRow({
+          id: 'bill',
+          firstName: 'Bill',
+          lastName: 'Baker',
+        }),
+        sortableDailyPresenceRow({
+          id: 'zed',
+          firstName: 'Zed',
+          lastName: 'Able',
+        }),
+      ],
+      [{ type: 'field', field: 'first_name', direction: 'desc' }]
+    )
+
+    expect(sorted.map((row) => row.memberRecord.id)).toEqual(['zed', 'bill', 'amy'])
+  })
+
   it('sorts by configured tag priority before last name', () => {
     const sorted = sortDailyPresenceRows(
       [
@@ -756,6 +898,40 @@ describe('sortMemberReportRows', () => {
       'high-baker',
       'low-zulu',
     ])
+  })
+
+  it('lets last name direction control equal-rank weekly rows when rank is descending', () => {
+    const sorted = sortMemberReportRows(
+      [
+        sortableWeeklyPresenceRow({
+          id: 's1-zulu',
+          firstName: 'Zed',
+          lastName: 'Zulu',
+          rank: 'S1',
+          rankOrder: 3,
+        }),
+        sortableWeeklyPresenceRow({
+          id: 'ms-baker',
+          firstName: 'Bill',
+          lastName: 'Baker',
+          rank: 'MS',
+          rankOrder: 5,
+        }),
+        sortableWeeklyPresenceRow({
+          id: 's1-able',
+          firstName: 'Ann',
+          lastName: 'Able',
+          rank: 'S1',
+          rankOrder: 3,
+        }),
+      ],
+      [
+        { type: 'field', field: 'rank', direction: 'desc' },
+        { type: 'field', field: 'last_name', direction: 'asc' },
+      ]
+    )
+
+    expect(sorted.map((row) => row.memberRecord.id)).toEqual(['ms-baker', 's1-able', 's1-zulu'])
   })
 
   it('sorts training night monthly rows by attendance percentage', () => {

--- a/apps/backend/src/services/operational-report-service.ts
+++ b/apps/backend/src/services/operational-report-service.ts
@@ -52,6 +52,8 @@ import { isSentinelBootstrapMember } from '../lib/system-bootstrap.js'
 
 const UNIT_NAME = 'HMCS Chippawa'
 const REPORT_LOOKBACK_DAYS = 1
+const MISTAKEN_CHECKOUT_GRACE_MINUTES = 5
+const MISTAKEN_CHECKOUT_GRACE_MS = MISTAKEN_CHECKOUT_GRACE_MINUTES * 60 * 1000
 const OPERATIONAL_TIMINGS_SETTING_KEY_V3 = 'operational.timings.v3'
 const REPEATED_CHECKIN_WARNING =
   'Some members have multiple check-ins without an intervening checkout; affected sessions are marked as degraded.'
@@ -330,10 +332,7 @@ function compareMemberReportField(
 ): number {
   switch (field) {
     case 'first_name':
-      return (
-        compareNullableString(left.memberRecord.firstName, right.memberRecord.firstName) ||
-        compareNullableString(left.memberRecord.lastName, right.memberRecord.lastName)
-      )
+      return compareNullableString(left.memberRecord.firstName, right.memberRecord.firstName)
     case 'rank': {
       const leftRankOrder = left.memberRecord.rankRef?.displayOrder ?? null
       const rightRankOrder = right.memberRecord.rankRef?.displayOrder ?? null
@@ -342,17 +341,12 @@ function compareMemberReportField(
         return leftRankOrder - rightRankOrder
       }
 
-      return (
-        compareNullableString(left.memberRecord.rank, right.memberRecord.rank) ||
-        compareNullableString(left.memberRecord.lastName, right.memberRecord.lastName)
-      )
+      return compareNullableString(left.memberRecord.rank, right.memberRecord.rank)
     }
     case 'department':
-      return (
-        compareNullableString(
-          left.memberRecord.division?.code,
-          right.memberRecord.division?.code
-        ) || compareNullableString(left.memberRecord.lastName, right.memberRecord.lastName)
+      return compareNullableString(
+        left.memberRecord.division?.code,
+        right.memberRecord.division?.code
       )
     case 'first_in':
       return compareNullableString(getDailyFirstIn(left.row), getDailyFirstIn(right.row))
@@ -523,7 +517,11 @@ export function pairOperationalPresenceSessions(
     const sessions: PresenceSessionInternal[] = []
     let openIn: OperationalReportCheckinRecord | null = null
 
-    for (const record of sorted) {
+    for (let index = 0; index < sorted.length; index += 1) {
+      const record = sorted[index]
+      if (!record) {
+        continue
+      }
       const direction = record.direction.toLowerCase()
 
       if (direction === 'in') {
@@ -547,7 +545,13 @@ export function pairOperationalPresenceSessions(
       }
 
       if (direction === 'out') {
+        const nextRecord = sorted[index + 1]
+
         if (!openIn) {
+          if (isMistakenCheckoutBeforeNearbyCheckin(record, nextRecord)) {
+            continue
+          }
+
           addPresenceWarning(
             warnings,
             UNMATCHED_CHECKOUT_WARNING,
@@ -555,6 +559,11 @@ export function pairOperationalPresenceSessions(
             memberId,
             record.timestamp
           )
+          continue
+        }
+
+        if (isMistakenCheckoutBeforeNearbyCheckin(record, nextRecord)) {
+          index += 1
           continue
         }
 
@@ -591,6 +600,18 @@ export function pairOperationalPresenceSessions(
   }
 
   return sessionsByMember
+}
+
+function isMistakenCheckoutBeforeNearbyCheckin(
+  checkout: OperationalReportCheckinRecord,
+  nextRecord: OperationalReportCheckinRecord | undefined
+): boolean {
+  if (!nextRecord || nextRecord.direction.toLowerCase() !== 'in') {
+    return false
+  }
+
+  const elapsedMs = nextRecord.timestamp.getTime() - checkout.timestamp.getTime()
+  return elapsedMs >= 0 && elapsedMs <= MISTAKEN_CHECKOUT_GRACE_MS
 }
 
 function addPresenceWarning(

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.4.8",
+  "version": "3.4.9",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.4.8",
+  "version": "3.4.9",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.4.8",
+  "version": "3.4.9",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.4.8",
+  "version": "3.4.9",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.4.8",
+  "version": "3.4.9",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Treat rapid check-out/check-in pairs within five minutes as continuous presence in reports.
- Suppress unmatched checkout report warnings when an unmatched check-out is immediately followed by a check-in within five minutes.
- Fix report sorting so Rank descending plus Last name A-Z keeps names ascending within equal-rank groups.
- Bump Sentinel workspace packages to 3.4.9 for the patch release.

## Why this change was needed

Operators reported Daily Presence warnings for check-out records that were likely either accidental first scans or quick returns after someone was pulled back into work. Reports should preserve the raw scan history but avoid interpreting those quick pairs as real departures, repeated sessions, or actionable warning conditions.

## What changed

### User-facing

- Presence reports now treat an out/in pair within five minutes as continuous attendance.
- Rank-first report sorting now respects the configured Last name A-Z or Z-A rule inside equal-rank groups.

### Admin/operator-facing

- Raw check-in data is unchanged. The reconciliation applies only while building report sessions.
- Existing unmatched checkout warnings still appear when the next check-in is outside the five-minute window.

### Backend/API

- Updated report session pairing in `operational-report-service`.
- Added regression coverage for quick return scans, unmatched checkout grace handling, and rank plus last-name sort ordering.

### Database

- No database changes.

### Deployment/update

- Workspace package versions are bumped to 3.4.9.

### Tests

- Added focused service tests for report pairing and sorting behavior.

## User impact

Report readers should see fewer false checkout warnings and fewer artificial “left and returned” sessions when a member checked out and came back within five minutes.

## Operator impact

No manual cleanup of raw check-in rows is required for this case. Operators can still inspect the raw history if needed.

## Upgrade or migration notes

No upgrade action required beyond deploying v3.4.9. No database migration is required.

## Risk and rollback notes

Main risk: a real departure and return inside five minutes will be reported as continuous presence. That matches the chosen reporting rule and leaves raw scan history intact for audit review. Rollback is safe because no stored data shape changes.

## Testing performed

- `pnpm version:check`
- `pnpm --filter @sentinel/backend typecheck`
- `pnpm --filter @sentinel/backend lint` (passes with existing warnings only)
- Direct `tsx` probes for quick return and unmatched checkout grace behavior during implementation

## Changelog candidates

- Reports now treat check-out/check-in pairs within five minutes as continuous presence without changing raw scan records.
- Fixed Rank plus Last Name report sorting so equal-rank members follow the selected last-name direction.
