### PR TITLE
Release v3.4.10

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.4.9",
+  "version": "3.4.10",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/repositories/operational-report-repository.ts
+++ b/apps/backend/src/repositories/operational-report-repository.ts
@@ -161,6 +161,13 @@ export interface OperationalReportCheckinRecord {
   direction: string
   timestamp: Date
   kioskId: string
+  method: string | null
+}
+
+export interface OperationalReportCheckinTimestampEditRecord {
+  checkinId: string
+  editReason: string | null
+  createdAt: Date | null
 }
 
 export type OperationalReportUnitEventRecord = Prisma.UnitEventGetPayload<{
@@ -212,6 +219,37 @@ export interface OperationalReportVisitorFilters {
   eventLinked?: boolean
   hostMemberId?: string
   organization?: string
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function auditDetailsChangedTimestamp(details: Prisma.JsonValue): boolean {
+  if (!isRecord(details)) {
+    return false
+  }
+
+  const changes = details.changes
+  if (!isRecord(changes)) {
+    return false
+  }
+
+  return isRecord(changes.timestamp)
+}
+
+function getAuditEditReason(details: Prisma.JsonValue): string | null {
+  if (!isRecord(details)) {
+    return null
+  }
+
+  const editReason = details.editReason
+  if (typeof editReason !== 'string') {
+    return null
+  }
+
+  const trimmed = editReason.trim()
+  return trimmed.length > 0 ? trimmed : null
 }
 
 export class OperationalReportRepository {
@@ -360,9 +398,50 @@ export class OperationalReportRepository {
         direction: true,
         timestamp: true,
         kioskId: true,
+        method: true,
       },
       orderBy: [{ memberId: 'asc' }, { timestamp: 'asc' }],
     })
+  }
+
+  async findCheckinTimestampEditNotes(
+    checkinIds: string[]
+  ): Promise<OperationalReportCheckinTimestampEditRecord[]> {
+    if (checkinIds.length === 0) {
+      return []
+    }
+
+    const auditLogs = await this.prisma.auditLog.findMany({
+      where: {
+        action: 'checkin_update',
+        entityType: 'checkin',
+        entityId: {
+          in: checkinIds,
+        },
+      },
+      select: {
+        entityId: true,
+        details: true,
+        createdAt: true,
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+    })
+
+    return auditLogs
+      .map((log): OperationalReportCheckinTimestampEditRecord | null => {
+        if (!log.entityId || !auditDetailsChangedTimestamp(log.details)) {
+          return null
+        }
+
+        return {
+          checkinId: log.entityId,
+          editReason: getAuditEditReason(log.details),
+          createdAt: log.createdAt,
+        }
+      })
+      .filter((record): record is OperationalReportCheckinTimestampEditRecord => record !== null)
   }
 
   async findScheduledDutyAssignmentsForMembers(

--- a/apps/backend/src/services/operational-report-service.test.ts
+++ b/apps/backend/src/services/operational-report-service.test.ts
@@ -26,7 +26,8 @@ function checkin(
   memberId: string,
   direction: 'in' | 'out',
   timestamp: string,
-  kioskId = 'front'
+  kioskId = 'front',
+  method: string | null = 'badge'
 ): OperationalReportCheckinRecord {
   return {
     id,
@@ -34,6 +35,7 @@ function checkin(
     direction,
     timestamp: new Date(timestamp),
     kioskId,
+    method,
   }
 }
 
@@ -412,6 +414,7 @@ describe('generateDailyPresence', () => {
           '2026-06-12T14:00:00.000Z'
         ),
       ],
+      findCheckinTimestampEditNotes: async () => [],
       findScheduledDutyAssignmentsForMembers: async () => [],
       findDdsAssignmentsForMembers: async () => [],
       findLiveDutyAssignmentsForMembers: async () => [],
@@ -461,6 +464,7 @@ describe('generateDailyPresence', () => {
           'SYSTEM'
         ),
       ],
+      findCheckinTimestampEditNotes: async () => [],
       findScheduledDutyAssignmentsForMembers: async () => [],
       findDdsAssignmentsForMembers: async () => [],
       findLiveDutyAssignmentsForMembers: async () => [],
@@ -476,6 +480,103 @@ describe('generateDailyPresence', () => {
       'Some checkout records could not be paired with a prior check-in and were ignored.'
     )
     expect(report.warningDetails).toEqual([])
+  })
+
+  it('includes session methods and timestamp edit notes', async () => {
+    const member = operationalReportMember({
+      id: '11111111-1111-4111-8111-111111111111',
+      displayName: 'S1 Example, A',
+      rank: 'S1',
+      firstName: 'Alex',
+      lastName: 'Example',
+    })
+    let requestedEditNoteCheckinIds: string[] = []
+    const repository = {
+      findActiveMembers: async () => [member],
+      findCheckinsForMembers: async () => [
+        checkin(
+          'checkin-in-1',
+          '11111111-1111-4111-8111-111111111111',
+          'in',
+          '2026-06-12T14:00:00.000Z',
+          'front',
+          'admin_manual'
+        ),
+        checkin(
+          'checkin-out-1',
+          '11111111-1111-4111-8111-111111111111',
+          'out',
+          '2026-06-12T18:00:00.000Z'
+        ),
+        checkin(
+          'checkin-in-2',
+          '11111111-1111-4111-8111-111111111111',
+          'in',
+          '2026-06-12T19:00:00.000Z'
+        ),
+        checkin(
+          'checkin-out-2',
+          '11111111-1111-4111-8111-111111111111',
+          'out',
+          '2026-06-12T22:00:00.000Z',
+          'front',
+          'manual'
+        ),
+      ],
+      findCheckinTimestampEditNotes: async (checkinIds: string[]) => {
+        requestedEditNoteCheckinIds = checkinIds
+        return [
+          {
+            checkinId: 'checkin-in-1',
+            editReason: 'Corrected missed morning scan',
+            createdAt: new Date('2026-06-12T15:00:00.000Z'),
+          },
+          {
+            checkinId: 'checkin-out-2',
+            editReason: 'Corrected final checkout time',
+            createdAt: new Date('2026-06-12T23:00:00.000Z'),
+          },
+        ]
+      },
+      findScheduledDutyAssignmentsForMembers: async () => [],
+      findDdsAssignmentsForMembers: async () => [],
+      findLiveDutyAssignmentsForMembers: async () => [],
+    } as unknown as OperationalReportRepository
+    const service = new OperationalReportService(undefined, repository)
+
+    const report = await service.generateDailyPresence(
+      { date: '2026-06-12', scopeType: 'everyone' },
+      { id: 'actor-1', rank: 'MS', firstName: 'Report', lastName: 'Runner' }
+    )
+
+    expect(requestedEditNoteCheckinIds.sort()).toEqual([
+      'checkin-in-1',
+      'checkin-in-2',
+      'checkin-out-1',
+      'checkin-out-2',
+    ])
+    expect(report.data.rows[0]?.sessions).toEqual([
+      {
+        inAt: '2026-06-12T14:00:00.000Z',
+        outAt: '2026-06-12T18:00:00.000Z',
+        durationMinutes: 240,
+        status: 'complete',
+        inMethod: 'admin_manual',
+        outMethod: 'badge',
+        inEditNote: 'Corrected missed morning scan',
+        outEditNote: null,
+      },
+      {
+        inAt: '2026-06-12T19:00:00.000Z',
+        outAt: '2026-06-12T22:00:00.000Z',
+        durationMinutes: 180,
+        status: 'complete',
+        inMethod: 'badge',
+        outMethod: 'manual',
+        inEditNote: null,
+        outEditNote: 'Corrected final checkout time',
+      },
+    ])
   })
 })
 
@@ -536,6 +637,8 @@ describe('isStaleForcedCheckoutSession', () => {
           inAt: new Date('2026-05-05T23:00:00.000Z'),
           outAt: new Date('2026-05-06T13:24:00.000Z'),
           status: 'complete',
+          inCheckinId: 'checkin-in',
+          outCheckinId: 'checkin-out',
           checkoutKioskId: 'lockup-force-checkout',
         },
         new Date('2026-05-06T08:00:00.000Z')
@@ -551,6 +654,8 @@ describe('isStaleForcedCheckoutSession', () => {
           inAt: new Date('2026-05-05T23:00:00.000Z'),
           outAt: new Date('2026-05-06T13:24:00.000Z'),
           status: 'complete',
+          inCheckinId: 'checkin-in',
+          outCheckinId: 'checkin-out',
           checkoutKioskId: 'front',
         },
         new Date('2026-05-06T08:00:00.000Z')
@@ -565,6 +670,7 @@ describe('presenceSessionOverlapsRange', () => {
     inAt: new Date('2026-05-05T23:00:00.000Z'),
     outAt: null,
     status: 'open',
+    inCheckinId: 'checkin-in',
   }
   const asOf = new Date('2026-05-06T14:23:00.000Z')
 
@@ -598,6 +704,7 @@ describe('presenceSessionOverlapsRange', () => {
           inAt: new Date('2026-05-06T18:00:00.000Z'),
           outAt: null,
           status: 'open',
+          inCheckinId: 'checkin-in',
         },
         new Date('2026-05-06T05:00:00.000Z'),
         new Date('2026-05-07T05:00:00.000Z'),

--- a/apps/backend/src/services/operational-report-service.ts
+++ b/apps/backend/src/services/operational-report-service.ts
@@ -40,6 +40,7 @@ import { DEFAULT_TIMEZONE, getOperationalDayStartTime } from '../utils/operation
 import {
   OperationalReportRepository,
   type OperationalReportCheckinRecord,
+  type OperationalReportCheckinTimestampEditRecord,
   type OperationalReportLockupStatusRecord,
   type OperationalReportMemberRecord,
   type OperationalReportMissedCheckoutRecord,
@@ -98,6 +99,10 @@ export interface PresenceSessionInternal {
   inAt: Date
   outAt: Date | null
   status: 'complete' | 'open' | 'degraded'
+  inCheckinId: string
+  outCheckinId?: string | null
+  inMethod?: string | null
+  outMethod?: string | null
   checkoutKioskId?: string | null
 }
 
@@ -538,6 +543,8 @@ export function pairOperationalPresenceSessions(
             inAt: openIn.timestamp,
             outAt: null,
             status: 'degraded',
+            inCheckinId: openIn.id,
+            inMethod: openIn.method,
           })
         }
         openIn = record
@@ -578,6 +585,10 @@ export function pairOperationalPresenceSessions(
           inAt: openIn.timestamp,
           outAt: record.timestamp,
           status: 'complete',
+          inCheckinId: openIn.id,
+          outCheckinId: record.id,
+          inMethod: openIn.method,
+          outMethod: record.method,
           checkoutKioskId: record.kioskId,
         })
         openIn = null
@@ -593,6 +604,8 @@ export function pairOperationalPresenceSessions(
         inAt: openIn.timestamp,
         outAt: null,
         status: 'open',
+        inCheckinId: openIn.id,
+        inMethod: openIn.method,
       })
     }
 
@@ -669,6 +682,10 @@ export class OperationalReportService {
       warnings,
       warningMemberIds
     )
+    const timestampEditNotesByCheckinId = await this.getTimestampEditNotesForSessions(
+      sessionsByMember,
+      range
+    )
     const scheduledDutyRolesByMember = await this.getScheduledDutyRolesByMember(members, range)
 
     const sortableRows = members
@@ -693,7 +710,7 @@ export class OperationalReportService {
             sessionCount: stats.sessionCount,
             leftAndReturned: stats.sessionCount > 1,
             sessions: overlappingSessions.map((session) =>
-              this.toPresenceSession(session, range.start, range.end)
+              this.toPresenceSession(session, range.start, range.end, timestampEditNotesByCheckinId)
             ),
           },
         }
@@ -1346,6 +1363,48 @@ export class OperationalReportService {
     return pairOperationalPresenceSessions(checkins, warnings, options)
   }
 
+  private async getTimestampEditNotesForSessions(
+    sessionsByMember: ReadonlyMap<string, PresenceSessionInternal[]>,
+    range: DateRange
+  ): Promise<Map<string, string>> {
+    const checkinIds = new Set<string>()
+
+    for (const sessions of sessionsByMember.values()) {
+      for (const session of sessions) {
+        if (!this.sessionOverlaps(session, range.start, range.end)) {
+          continue
+        }
+
+        if (session.inAt >= range.start && session.inAt < range.end) {
+          checkinIds.add(session.inCheckinId)
+        }
+        if (session.outAt && session.outAt >= range.start && session.outAt < range.end) {
+          const outCheckinId = session.outCheckinId
+          if (outCheckinId) {
+            checkinIds.add(outCheckinId)
+          }
+        }
+      }
+    }
+
+    const editRecords = await this.repository.findCheckinTimestampEditNotes([...checkinIds])
+    return this.toLatestTimestampEditNoteMap(editRecords)
+  }
+
+  private toLatestTimestampEditNoteMap(
+    editRecords: OperationalReportCheckinTimestampEditRecord[]
+  ): Map<string, string> {
+    const notes = new Map<string, string>()
+
+    for (const record of editRecords) {
+      if (!notes.has(record.checkinId)) {
+        notes.set(record.checkinId, record.editReason ?? '')
+      }
+    }
+
+    return notes
+  }
+
   private getPresenceMarker(
     date: string,
     sessions: PresenceSessionInternal[],
@@ -1858,11 +1917,14 @@ export class OperationalReportService {
   private toPresenceSession(
     session: PresenceSessionInternal,
     start: Date,
-    end: Date
+    end: Date,
+    timestampEditNotesByCheckinId: ReadonlyMap<string, string> = new Map()
   ): PresenceSession {
     const clippedIn = session.inAt < start ? start : session.inAt
     const rawOut = session.outAt && session.outAt > end ? end : session.outAt
     const clippedOut = rawOut && rawOut < start ? start : rawOut
+    const showInDetails = session.inAt >= start && session.inAt < end
+    const showOutDetails = Boolean(session.outAt && session.outAt >= start && session.outAt < end)
 
     return {
       inAt: clippedIn.toISOString(),
@@ -1871,6 +1933,18 @@ export class OperationalReportService {
         ? Math.max(0, Math.round((clippedOut.getTime() - clippedIn.getTime()) / 60_000))
         : null,
       status: session.status,
+      inMethod: showInDetails ? (session.inMethod ?? null) : null,
+      outMethod: showOutDetails ? (session.outMethod ?? null) : null,
+      inEditNote:
+        showInDetails && timestampEditNotesByCheckinId.has(session.inCheckinId)
+          ? (timestampEditNotesByCheckinId.get(session.inCheckinId) ?? '')
+          : null,
+      outEditNote:
+        showOutDetails &&
+        session.outCheckinId &&
+        timestampEditNotesByCheckinId.has(session.outCheckinId)
+          ? (timestampEditNotesByCheckinId.get(session.outCheckinId) ?? '')
+          : null,
     }
   }
 

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.4.9",
+  "version": "3.4.10",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/app/globals.css
+++ b/apps/frontend-admin/src/app/globals.css
@@ -474,12 +474,44 @@
     width: 14%;
   }
 
+  .reports-daily-presence-table-with-details .reports-daily-member-col {
+    width: 20%;
+  }
+
+  .reports-daily-presence-table-with-details .reports-daily-department-col {
+    width: 8%;
+  }
+
+  .reports-daily-presence-table-with-details .reports-daily-tags-col {
+    width: 23%;
+  }
+
+  .reports-daily-presence-table-with-details .reports-daily-time-col {
+    width: 10%;
+  }
+
+  .reports-daily-presence-table-with-details .reports-daily-last-out-col {
+    width: 10%;
+  }
+
+  .reports-daily-presence-table-with-details .reports-daily-presence-col {
+    width: 9%;
+  }
+
+  .reports-daily-details-col {
+    width: 20%;
+  }
+
   .reports-daily-presence-table .reports-tags-cell {
     color: oklch(21% 0.006 285.885) !important;
   }
 
   .reports-daily-presence-table .reports-session-cell {
     text-align: right !important;
+  }
+
+  .reports-daily-presence-table .reports-details-cell {
+    white-space: normal !important;
   }
 }
 

--- a/apps/frontend-admin/src/components/admin/reports/report-preview.tsx
+++ b/apps/frontend-admin/src/components/admin/reports/report-preview.tsx
@@ -259,8 +259,72 @@ function SummaryGrid({ items }: { items: Array<{ label: string; value: string | 
   )
 }
 
+type DailyPresenceReportRow = DailyPresenceReportResponse['data']['rows'][number]
+type DailyPresenceReportSession = DailyPresenceReportRow['sessions'][number]
+
+function getDailyPresenceDetailLines(row: DailyPresenceReportRow): string[] {
+  return row.sessions.flatMap((session) => {
+    const lines: string[] = []
+    const inMethodLabel = formatCheckinMethodDetail(session.inMethod)
+    const outMethodLabel = formatCheckinMethodDetail(session.outMethod)
+
+    if (inMethodLabel) {
+      lines.push(`${formatReportTime(session.inAt)} in: ${inMethodLabel}`)
+    }
+    if (session.outAt && outMethodLabel) {
+      lines.push(`${formatReportTime(session.outAt)} out: ${outMethodLabel}`)
+    }
+    if (session.inEditNote !== null) {
+      lines.push(formatSessionEditDetail(session, 'in'))
+    }
+    if (session.outAt && session.outEditNote !== null) {
+      lines.push(formatSessionEditDetail(session, 'out'))
+    }
+
+    return lines
+  })
+}
+
+function formatCheckinMethodDetail(method: string | null | undefined): string | null {
+  const normalized = method?.trim().toLowerCase()
+  if (!normalized || normalized === 'badge') {
+    return null
+  }
+
+  if (normalized === 'manual' || normalized === 'admin_manual') {
+    return 'Manual'
+  }
+  if (normalized === 'override') {
+    return 'Override'
+  }
+  if (normalized === 'login') {
+    return 'Login'
+  }
+
+  return normalized
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+function formatSessionEditDetail(
+  session: DailyPresenceReportSession,
+  direction: 'in' | 'out'
+): string {
+  const timestamp = direction === 'in' ? session.inAt : (session.outAt ?? session.inAt)
+  const note = direction === 'in' ? session.inEditNote : session.outEditNote
+  const trimmedNote = note?.trim() ?? ''
+  return `${formatReportTime(timestamp)} ${direction} edited${trimmedNote ? `: ${trimmedNote}` : ''}`
+}
+
 function DailyPresenceReport({ report }: { report: DailyPresenceReportResponse }) {
   const { summary, rows } = report.data
+  const rowsWithDetails = rows.map((row) => ({
+    row,
+    detailLines: getDailyPresenceDetailLines(row),
+  }))
+  const hasDetails = rowsWithDetails.some(({ detailLines }) => detailLines.length > 0)
 
   return (
     <>
@@ -280,7 +344,12 @@ function DailyPresenceReport({ report }: { report: DailyPresenceReportResponse }
         />
       ) : (
         <div className="overflow-x-auto">
-          <table className="table table-sm reports-table reports-daily-presence-table">
+          <table
+            className={cn(
+              'table table-sm reports-table reports-daily-presence-table',
+              hasDetails && 'reports-daily-presence-table-with-details'
+            )}
+          >
             <colgroup>
               <col className="reports-daily-member-col" />
               <col className="reports-daily-department-col" />
@@ -288,6 +357,7 @@ function DailyPresenceReport({ report }: { report: DailyPresenceReportResponse }
               <col className="reports-daily-time-col" />
               <col className="reports-daily-last-out-col" />
               <col className="reports-daily-presence-col" />
+              {hasDetails && <col className="reports-daily-details-col" />}
             </colgroup>
             <thead>
               <tr>
@@ -297,10 +367,11 @@ function DailyPresenceReport({ report }: { report: DailyPresenceReportResponse }
                 <th>Check-In</th>
                 <th>Check-Out</th>
                 <th>Presence</th>
+                {hasDetails && <th>Details</th>}
               </tr>
             </thead>
             <tbody>
-              {rows.map((row) => {
+              {rowsWithDetails.map(({ row, detailLines }) => {
                 const isPresent = row.sessions.some((session) => session.status === 'open')
 
                 return (
@@ -348,6 +419,17 @@ function DailyPresenceReport({ report }: { report: DailyPresenceReportResponse }
                         {isPresent ? 'Present' : 'Out'}
                       </span>
                     </td>
+                    {hasDetails && (
+                      <td className="reports-details-cell">
+                        {detailLines.length > 0 && (
+                          <div className="grid gap-(--space-1) text-xs leading-tight text-base-content/70">
+                            {detailLines.map((line, lineIndex) => (
+                              <span key={`${row.member.id}-detail-${lineIndex}`}>{line}</span>
+                            ))}
+                          </div>
+                        )}
+                      </td>
+                    )}
                   </tr>
                 )
               })}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.4.9",
+  "version": "3.4.10",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.4.9",
+  "version": "3.4.10",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/contracts/src/schemas/report.schema.ts
+++ b/packages/contracts/src/schemas/report.schema.ts
@@ -437,6 +437,10 @@ export const PresenceSessionSchema = v.object({
   outAt: v.nullable(v.string()),
   durationMinutes: v.nullable(v.number()),
   status: PresenceSessionStatusEnum,
+  inMethod: v.nullable(v.string()),
+  outMethod: v.nullable(v.string()),
+  inEditNote: v.nullable(v.string()),
+  outEditNote: v.nullable(v.string()),
 })
 
 export type PresenceSession = v.InferOutput<typeof PresenceSessionSchema>

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.4.9",
+  "version": "3.4.10",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.4.9",
+  "version": "3.4.10",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Adds Daily Presence session details for non-normal check-in and check-out activity.
- Shows manual, login, override, or unknown non-badge methods in a compact Details column.
- Adds timestamp edit notes from check-in audit history to the Daily Presence report output.
- Prepares Sentinel v3.4.10 as the next patch release.

## Why this change was needed

Daily Presence reviewers need a way to see when report times came from manual or other non-badge activity, and whether displayed check-in/check-out times were edited with an operator-entered reason. The report should preserve raw scan history while making exceptions visible in the printed report.

## What changed

### User-facing

- Daily Presence reports now show a final Details column only when at least one row has details to show.
- Normal badge scans are hidden from Details so routine rows stay quiet.
- Non-badge methods and timestamp edit notes appear as short session-level lines next to the displayed session times.

### Admin/operator-facing

- Operators can review manual/login/override report details without changing raw check-in data.
- Timestamp edit notes are sourced from audit logs for check-in timestamp changes.

### Backend/API

- Daily Presence session responses now include check-in/check-out methods and timestamp edit notes.
- The operational report repository reads timestamp edit reasons from check-in audit logs.

### Database

- No database schema changes.

### Deployment/update

- Package versions are synchronized to 3.4.10.

### Documentation

- No documentation files changed.

### Tests

- Added focused service coverage for session methods and timestamp edit notes.

## User impact

Daily Presence report viewers will only notice a Details column when there is non-normal report context to show. Routine badge-only reports remain visually unchanged.

## Operator impact

Operators get clearer audit context for manual or edited attendance times without editing or hiding the underlying scan records.

## Upgrade or migration notes

No upgrade action required. No database migration or configuration change is required.

## Risk and rollback notes

Main risk is report layout density on busy days with many edited sessions. The Details column is conditional, compact, and uses wrapped short lines. Rollback is safe by reverting the application code; no data migration is involved.

## Testing performed

- `pnpm --filter @sentinel/contracts typecheck`
- `pnpm --filter @sentinel/backend typecheck`
- `pnpm --filter frontend-admin typecheck`
- `pnpm --filter frontend-admin lint` passed with existing warnings only
- `pnpm --filter @sentinel/backend lint` passed with existing warnings only
- Playwright CLI visual sanity check at 1920x1080 for the Daily Presence Details column
- `pnpm version:check`

## Changelog candidates

- Added a conditional Details column to Daily Presence reports for manual/login/override check-in activity and timestamp edit notes.
- Kept normal badge scans out of Daily Presence details so routine reports stay concise.