### PR TITLE
fix(reports): improve Daily Presence staff reporting

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.4.10",
+  "version": "3.4.11",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/services/operational-report-service.test.ts
+++ b/apps/backend/src/services/operational-report-service.test.ts
@@ -20,6 +20,7 @@ import type {
   OperationalReportMemberRecord,
   OperationalReportRepository,
 } from '../repositories/operational-report-repository.js'
+import { getDefaultOperationalTimingsSettings } from '../lib/operational-timings-runtime.js'
 
 function checkin(
   id: string,
@@ -52,7 +53,10 @@ function operationalReportMember(input: {
   rank: string
   firstName: string
   lastName: string
+  tagIds?: string[]
 }): OperationalReportMemberRecord {
+  const tagIds = input.tagIds ?? []
+
   return {
     id: input.id,
     serviceNumber: input.id,
@@ -91,7 +95,19 @@ function operationalReportMember(input: {
       code: 'active',
       name: 'Active',
     },
-    memberTags: [],
+    memberTags: tagIds.map((tagId) => ({
+      tagId,
+      tag: {
+        id: tagId,
+        name: tagId.toUpperCase(),
+        displayOrder: 0,
+        chipVariant: 'faded',
+        chipColor: 'default',
+        isPositional: false,
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      },
+    })),
     qualifications: [],
   } as unknown as OperationalReportMemberRecord
 }
@@ -418,6 +434,9 @@ describe('generateDailyPresence', () => {
       findScheduledDutyAssignmentsForMembers: async () => [],
       findDdsAssignmentsForMembers: async () => [],
       findLiveDutyAssignmentsForMembers: async () => [],
+      findTagShortcut: async () => null,
+      findUnitEvents: async () => [],
+      findAppSettingValue: async () => null,
     } as unknown as OperationalReportRepository
     const service = new OperationalReportService(undefined, repository)
 
@@ -468,6 +487,9 @@ describe('generateDailyPresence', () => {
       findScheduledDutyAssignmentsForMembers: async () => [],
       findDdsAssignmentsForMembers: async () => [],
       findLiveDutyAssignmentsForMembers: async () => [],
+      findTagShortcut: async () => null,
+      findUnitEvents: async () => [],
+      findAppSettingValue: async () => null,
     } as unknown as OperationalReportRepository
     const service = new OperationalReportService(undefined, repository)
 
@@ -480,6 +502,117 @@ describe('generateDailyPresence', () => {
       'Some checkout records could not be paired with a prior check-in and were ignored.'
     )
     expect(report.warningDetails).toEqual([])
+  })
+
+  it('summarizes Daily Presence for staff attendance using working hours and FTS/GEO tags', async () => {
+    const ftsTagId = '11111111-1111-4111-8111-111111111111'
+    const geoTagId = '22222222-2222-4222-8222-222222222222'
+    const members = [
+      operationalReportMember({
+        id: '33333333-3333-4333-8333-333333333333',
+        displayName: 'MS OnTime, A',
+        rank: 'MS',
+        firstName: 'Alex',
+        lastName: 'OnTime',
+        tagIds: [ftsTagId],
+      }),
+      operationalReportMember({
+        id: '44444444-4444-4444-8444-444444444444',
+        displayName: 'MS Late, B',
+        rank: 'MS',
+        firstName: 'Blair',
+        lastName: 'Late',
+        tagIds: [ftsTagId],
+      }),
+      operationalReportMember({
+        id: '55555555-5555-4555-8555-555555555555',
+        displayName: 'MS VeryLate, C',
+        rank: 'MS',
+        firstName: 'Casey',
+        lastName: 'VeryLate',
+        tagIds: [ftsTagId],
+      }),
+      operationalReportMember({
+        id: '66666666-6666-4666-8666-666666666666',
+        displayName: 'S1 Geo, D',
+        rank: 'S1',
+        firstName: 'Devon',
+        lastName: 'Geo',
+        tagIds: [geoTagId],
+      }),
+    ]
+    const settings = getDefaultOperationalTimingsSettings()
+    const repository = {
+      findActiveMembers: async () => members,
+      findCheckinsForMembers: async (memberIds: string[]) =>
+        [
+          checkin('fts-on-time-in', members[0].id, 'in', '2026-06-15T12:55:00.000Z'),
+          checkin('fts-late-in', members[1].id, 'in', '2026-06-15T13:12:00.000Z'),
+          checkin('fts-very-late-in', members[2].id, 'in', '2026-06-15T13:45:00.000Z'),
+          checkin('geo-in', members[3].id, 'in', '2026-06-15T15:00:00.000Z'),
+        ].filter((record) => record.memberId !== null && memberIds.includes(record.memberId)),
+      findCheckinTimestampEditNotes: async () => [],
+      findScheduledDutyAssignmentsForMembers: async () => [],
+      findDdsAssignmentsForMembers: async () => [],
+      findLiveDutyAssignmentsForMembers: async () => [],
+      findTagShortcut: async (shortcut: 'fts' | 'geo') =>
+        shortcut === 'fts'
+          ? { id: ftsTagId, name: 'FTS', chipVariant: 'faded', chipColor: 'success' }
+          : { id: geoTagId, name: 'GEO', chipVariant: 'faded', chipColor: 'info' },
+      findUnitEvents: async () => [
+        {
+          id: 'training-event',
+          title: 'Training Night',
+          eventDate: new Date('2026-06-15T00:00:00.000Z'),
+          endDate: null,
+          startTime: new Date('1970-01-01T23:00:00.000Z'),
+          endTime: new Date('1970-01-02T02:00:00.000Z'),
+          eventType: {
+            id: 'training-type',
+            name: 'Training',
+            category: 'training',
+            defaultDurationMinutes: 180,
+          },
+        },
+        {
+          id: 'admin-event',
+          title: 'Admin Night',
+          eventDate: new Date('2026-06-15T00:00:00.000Z'),
+          endDate: null,
+          startTime: new Date('1970-01-01T22:30:00.000Z'),
+          endTime: new Date('1970-01-02T00:30:00.000Z'),
+          eventType: {
+            id: 'admin-type',
+            name: 'Admin',
+            category: 'administrative',
+            defaultDurationMinutes: 120,
+          },
+        },
+      ],
+      findAppSettingValue: async () => settings,
+      findReportSettingValue: async () => null,
+    } as unknown as OperationalReportRepository
+    const service = new OperationalReportService(undefined, repository)
+
+    const report = await service.generateDailyPresence(
+      { date: '2026-06-15', scopeType: 'everyone' },
+      { id: 'actor-1', rank: 'MS', firstName: 'Report', lastName: 'Runner' }
+    )
+
+    expect(report.data.summary).toMatchObject({
+      totalScopedMembers: 4,
+      ftsTotalMembers: 3,
+      ftsOnTimeCount: 1,
+      ftsLateCount: 1,
+      geoCheckedInCount: 1,
+    })
+    expect(report.data.dayContext.workingHours).toMatchObject({
+      startTime: '08:00',
+      endTime: '15:00',
+      label: '08:00-15:00',
+    })
+    expect(report.data.dayContext.isTrainingNight).toBe(true)
+    expect(report.data.dayContext.isAdminNight).toBe(true)
   })
 
   it('includes session methods and timestamp edit notes', async () => {
@@ -541,6 +674,9 @@ describe('generateDailyPresence', () => {
       findScheduledDutyAssignmentsForMembers: async () => [],
       findDdsAssignmentsForMembers: async () => [],
       findLiveDutyAssignmentsForMembers: async () => [],
+      findTagShortcut: async () => null,
+      findUnitEvents: async () => [],
+      findAppSettingValue: async () => null,
     } as unknown as OperationalReportRepository
     const service = new OperationalReportService(undefined, repository)
 
@@ -577,6 +713,124 @@ describe('generateDailyPresence', () => {
         outEditNote: 'Corrected final checkout time',
       },
     ])
+  })
+})
+
+describe('generateWeeklyPresence', () => {
+  it('shows Monday to Friday only and excludes weekend sessions from totals', async () => {
+    const member = operationalReportMember({
+      id: '11111111-1111-4111-8111-111111111111',
+      displayName: 'S1 Example, A',
+      rank: 'S1',
+      firstName: 'Alex',
+      lastName: 'Example',
+    })
+    const repository = {
+      findActiveMembers: async () => [member],
+      findCheckinsForMembers: async () => [
+        checkin(
+          'monday-in',
+          '11111111-1111-4111-8111-111111111111',
+          'in',
+          '2026-06-08T15:00:00.000Z'
+        ),
+        checkin(
+          'monday-out',
+          '11111111-1111-4111-8111-111111111111',
+          'out',
+          '2026-06-08T17:00:00.000Z'
+        ),
+        checkin(
+          'saturday-in',
+          '11111111-1111-4111-8111-111111111111',
+          'in',
+          '2026-06-13T15:00:00.000Z'
+        ),
+        checkin(
+          'saturday-out',
+          '11111111-1111-4111-8111-111111111111',
+          'out',
+          '2026-06-13T17:00:00.000Z'
+        ),
+      ],
+      findScheduledDutyAssignmentsForMembers: async () => [],
+      findDdsAssignmentsForMembers: async () => [],
+      findLiveDutyAssignmentsForMembers: async () => [],
+      findUnitEvents: async () => [],
+      findAppSettingValue: async () => null,
+      findReportSettingValue: async () => null,
+    } as unknown as OperationalReportRepository
+    const service = new OperationalReportService(undefined, repository)
+
+    const report = await service.generateWeeklyPresence(
+      { weekStartDate: '2026-06-08', scopeType: 'everyone' },
+      { id: 'actor-1', rank: 'MS', firstName: 'Report', lastName: 'Runner' }
+    )
+
+    expect(report.data.days.map((day) => day.date)).toEqual([
+      '2026-06-08',
+      '2026-06-09',
+      '2026-06-10',
+      '2026-06-11',
+      '2026-06-12',
+    ])
+    expect(report.data.rows[0]?.totalDaysPresent).toBe(1)
+    expect(report.data.rows[0]?.totalSessions).toBe(1)
+  })
+})
+
+describe('generateMonthlyPresence', () => {
+  it('shows weekdays only and excludes weekend sessions from totals', async () => {
+    const member = operationalReportMember({
+      id: '11111111-1111-4111-8111-111111111111',
+      displayName: 'S1 Example, A',
+      rank: 'S1',
+      firstName: 'Alex',
+      lastName: 'Example',
+    })
+    const repository = {
+      findActiveMembers: async () => [member],
+      findCheckinsForMembers: async () => [
+        checkin(
+          'weekday-in',
+          '11111111-1111-4111-8111-111111111111',
+          'in',
+          '2026-06-08T15:00:00.000Z'
+        ),
+        checkin(
+          'weekday-out',
+          '11111111-1111-4111-8111-111111111111',
+          'out',
+          '2026-06-08T17:00:00.000Z'
+        ),
+        checkin(
+          'weekend-in',
+          '11111111-1111-4111-8111-111111111111',
+          'in',
+          '2026-06-13T15:00:00.000Z'
+        ),
+        checkin(
+          'weekend-out',
+          '11111111-1111-4111-8111-111111111111',
+          'out',
+          '2026-06-13T17:00:00.000Z'
+        ),
+      ],
+      findUnitEvents: async () => [],
+      findAppSettingValue: async () => null,
+      findReportSettingValue: async () => null,
+    } as unknown as OperationalReportRepository
+    const service = new OperationalReportService(undefined, repository)
+
+    const report = await service.generateMonthlyPresence(
+      { month: '2026-06', scopeType: 'everyone' },
+      { id: 'actor-1', rank: 'MS', firstName: 'Report', lastName: 'Runner' }
+    )
+
+    expect(report.data.days.map((day) => day.date)).not.toContain('2026-06-13')
+    expect(report.data.days.every((day) => !['6', '7'].includes(day.label))).toBe(true)
+    expect(report.data.rows[0]?.totalDaysPresent).toBe(1)
+    expect(report.data.rows[0]?.totalSessions).toBe(1)
   })
 })
 

--- a/apps/backend/src/services/operational-report-service.ts
+++ b/apps/backend/src/services/operational-report-service.ts
@@ -12,6 +12,7 @@ import type {
   OperationalNightAudienceTarget,
   OperationalNightOccurrence,
   OperationalNightType,
+  OperationalTimingsWorkingHours,
   OperationalExceptionsReportConfig,
   OperationalExceptionsReportResponse,
   PresenceMarker,
@@ -119,6 +120,30 @@ interface PresenceStats {
   lastOut: string | null
   sessionCount: number
   note: string | null
+}
+
+interface DailyPresenceWorkingHoursDetails {
+  startTime: string
+  endTime: string
+  startAt: string
+  endAt: string
+  label: string
+  start: Date
+  end: Date
+}
+
+interface DailyPresenceDayContextInternal {
+  workingHours: DailyPresenceWorkingHoursDetails | null
+  isTrainingNight: boolean
+  isAdminNight: boolean
+  keyNights: KeyNightWindow[]
+}
+
+interface DailyPresenceAttendanceSummary {
+  ftsTotalMembers: number
+  ftsOnTimeCount: number
+  ftsLateCount: number
+  geoCheckedInCount: number
 }
 
 type ScheduledDutyRolesByMember = Map<string, Set<OperationalReportScheduledDutyRoleCode>>
@@ -668,14 +693,10 @@ export class OperationalReportService {
     const warnings = new Set<string>()
     const warningMemberIds = new Map<string, Set<string>>()
     const scope = await this.resolveScope(config, warnings)
+    const allActiveMembers = await this.repository.findActiveMembers()
     const members = scope.noResults
       ? []
-      : await this.repository.findActiveMembers({
-          divisionId: scope.divisionId,
-          divisionIds: scope.divisionIds,
-          tagId: scope.tagId,
-          tagIds: scope.tagIds,
-        })
+      : this.filterMembersForResolvedScope(allActiveMembers, scope)
     const sessionsByMember = await this.getSessionsByMember(
       members,
       range,
@@ -687,6 +708,19 @@ export class OperationalReportService {
       range
     )
     const scheduledDutyRolesByMember = await this.getScheduledDutyRolesByMember(members, range)
+    const dayContext = await this.getDailyPresenceDayContext(range, warnings)
+    const attendanceSessionsByMember =
+      allActiveMembers.length === members.length &&
+      allActiveMembers.every((member) => sessionsByMember.has(member.id))
+        ? sessionsByMember
+        : await this.getSessionsByMember(allActiveMembers, range, new Set<string>())
+    const attendanceSummary = await this.getDailyPresenceAttendanceSummary(
+      allActiveMembers,
+      attendanceSessionsByMember,
+      range,
+      dayContext.workingHours,
+      warnings
+    )
 
     const sortableRows = members
       .map((member) => {
@@ -739,6 +773,21 @@ export class OperationalReportService {
               total + row.sessions.filter((session) => session.status !== 'complete').length,
             0
           ),
+          ...attendanceSummary,
+        },
+        dayContext: {
+          workingHours: dayContext.workingHours
+            ? {
+                startTime: dayContext.workingHours.startTime,
+                endTime: dayContext.workingHours.endTime,
+                startAt: dayContext.workingHours.startAt,
+                endAt: dayContext.workingHours.endAt,
+                label: dayContext.workingHours.label,
+              }
+            : null,
+          isTrainingNight: dayContext.isTrainingNight,
+          isAdminNight: dayContext.isAdminNight,
+          keyNights: dayContext.keyNights.map(this.toApiKeyNight),
         },
         rows,
       },
@@ -762,8 +811,10 @@ export class OperationalReportService {
         })
     const sessionsByMember = await this.getSessionsByMember(members, range, warnings)
     const scheduledDutyRolesByMember = await this.getScheduledDutyRolesByMember(members, range)
-    const keyNights = await this.getKeyNights(range, ['training', 'administrative'], warnings)
-    const days = this.getDatesInRange(range).map((date) => ({
+    const keyNights = (
+      await this.getKeyNights(range, ['training', 'administrative'], warnings)
+    ).filter((night) => this.isWeekdayDate(night.date))
+    const days = this.getWeekdayDatesInRange(range).map((date) => ({
       date,
       label: this.formatShortDate(date),
       isTrainingNight: keyNights.some(
@@ -792,9 +843,10 @@ export class OperationalReportService {
           adminNightPresent: this.getCategoryPresence('administrative', keyNights, keyNightMarkers),
           keyNights: keyNightMarkers,
           totalDaysPresent: dayMarkers.filter((marker) => marker.present).length,
-          totalSessions: memberSessions.filter((session) =>
-            this.sessionOverlaps(session, range.start, range.end)
-          ).length,
+          totalSessions: this.countSessionsOverlappingDates(
+            memberSessions,
+            days.map((day) => day.date)
+          ),
         },
       }
     })
@@ -839,8 +891,10 @@ export class OperationalReportService {
           tagIds: scope.tagIds,
         })
     const sessionsByMember = await this.getSessionsByMember(members, range, warnings)
-    const keyNights = await this.getKeyNights(range, ['training', 'administrative'], warnings)
-    const days = this.getDatesInRange(range).map((date) => ({
+    const keyNights = (
+      await this.getKeyNights(range, ['training', 'administrative'], warnings)
+    ).filter((night) => this.isWeekdayDate(night.date))
+    const days = this.getWeekdayDatesInRange(range).map((date) => ({
       date,
       label: DateTime.fromISO(date, { zone: DEFAULT_TIMEZONE }).toFormat('d'),
       isTrainingNight: keyNights.some(
@@ -867,9 +921,10 @@ export class OperationalReportService {
           days: dayMarkers,
           keyNights: keyNightMarkers,
           totalDaysPresent: dayMarkers.filter((marker) => marker.present).length,
-          totalSessions: memberSessions.filter((session) =>
-            this.sessionOverlaps(session, range.start, range.end)
-          ).length,
+          totalSessions: this.countSessionsOverlappingDates(
+            memberSessions,
+            days.map((day) => day.date)
+          ),
           trainingNightsPresent: this.countCategoryPresence('training', keyNights, keyNightMarkers),
           adminNightsPresent: this.countCategoryPresence(
             'administrative',
@@ -1329,6 +1384,24 @@ export class OperationalReportService {
     return [...new Set([...(ids ?? []), fallbackId].filter((id): id is string => Boolean(id)))]
   }
 
+  private filterMembersForResolvedScope(
+    members: OperationalReportMemberRecord[],
+    scope: EffectiveScope
+  ): OperationalReportMemberRecord[] {
+    const divisionIds = new Set(this.uniqueIds(scope.divisionIds, scope.divisionId))
+    const tagIds = this.uniqueIds(scope.tagIds, scope.tagId)
+
+    if (divisionIds.size === 0 && tagIds.length === 0) {
+      return members
+    }
+
+    return members.filter((member) => {
+      const matchesDivision = Boolean(member.divisionId && divisionIds.has(member.divisionId))
+      const matchesTag = tagIds.some((tagId) => this.memberHasTag(member, tagId))
+      return matchesDivision || matchesTag
+    })
+  }
+
   private async getSessionsByMember(
     members: OperationalReportMemberRecord[],
     range: DateRange,
@@ -1341,6 +1414,156 @@ export class OperationalReportService {
       .toJSDate()
     const checkins = await this.repository.findCheckinsForMembers(memberIds, queryStart, range.end)
     return this.pairSessions(checkins, range, warnings, warningMemberIds)
+  }
+
+  private async getDailyPresenceDayContext(
+    range: DateRange,
+    warnings: Set<string>
+  ): Promise<DailyPresenceDayContextInternal> {
+    const [workingHours, keyNights] = await Promise.all([
+      this.getDailyPresenceWorkingHours(range, warnings),
+      this.getKeyNights(range, ['training', 'administrative'], warnings, {
+        warnWhenMissing: false,
+      }),
+    ])
+
+    return {
+      workingHours,
+      isTrainingNight: keyNights.some((night) => night.category === 'training'),
+      isAdminNight: keyNights.some((night) => night.category === 'administrative'),
+      keyNights,
+    }
+  }
+
+  private async getDailyPresenceWorkingHours(
+    range: DateRange,
+    warnings: Set<string>
+  ): Promise<DailyPresenceWorkingHoursDetails | null> {
+    const value = await this.repository.findAppSettingValue(OPERATIONAL_TIMINGS_SETTING_KEY_V3)
+    if (!value) {
+      return null
+    }
+
+    const parsed = v.safeParse(OperationalTimingsSettingsSchema, value)
+    if (!parsed.success) {
+      warnings.add(
+        'Operational Timings settings are present but invalid; Daily Presence working hours were omitted.'
+      )
+      return null
+    }
+
+    return this.getWorkingHoursForDate(range.startDate, parsed.output.workingHours)
+  }
+
+  private getWorkingHoursForDate(
+    date: string,
+    workingHours: OperationalTimingsWorkingHours
+  ): DailyPresenceWorkingHoursDetails | null {
+    const weekday = DateTime.fromISO(date, { zone: DEFAULT_TIMEZONE }).weekday
+    if (!workingHours.regularWeekdays.includes(weekday)) {
+      return null
+    }
+
+    const summerHours = this.isWithinMonthDayRange(
+      date,
+      workingHours.summerStartDate,
+      workingHours.summerEndDate
+    )
+    const startTime = summerHours
+      ? workingHours.summerWeekdayStart
+      : workingHours.regularWeekdayStart
+    const endTime = summerHours ? workingHours.summerWeekdayEnd : workingHours.regularWeekdayEnd
+    const start = this.dateTimeFromLocalDateAndTime(date, startTime)
+    const end = this.ensureEndAfterStart(start, this.dateTimeFromLocalDateAndTime(date, endTime))
+
+    return {
+      startTime,
+      endTime,
+      startAt: start.toISOString(),
+      endAt: end.toISOString(),
+      label: `${startTime}-${endTime}`,
+      start,
+      end,
+    }
+  }
+
+  private isWithinMonthDayRange(date: string, startMonthDay: string, endMonthDay: string): boolean {
+    const monthDay = DateTime.fromISO(date, { zone: DEFAULT_TIMEZONE }).toFormat('MM-dd')
+    return monthDay >= startMonthDay && monthDay <= endMonthDay
+  }
+
+  private async getDailyPresenceAttendanceSummary(
+    members: OperationalReportMemberRecord[],
+    sessionsByMember: ReadonlyMap<string, PresenceSessionInternal[]>,
+    range: DateRange,
+    workingHours: DailyPresenceWorkingHoursDetails | null,
+    warnings: Set<string>
+  ): Promise<DailyPresenceAttendanceSummary> {
+    const [ftsTag, geoTag] = await Promise.all([
+      this.repository.findTagShortcut('fts'),
+      this.repository.findTagShortcut('geo'),
+    ])
+    if (!ftsTag) {
+      warnings.add('FTS tag was not found. FTS attendance stats were omitted.')
+    }
+    if (!geoTag) {
+      warnings.add('GEO tag was not found. GEO attendance stats were omitted.')
+    }
+
+    const ftsMembers = ftsTag
+      ? members.filter((member) => this.memberHasTag(member, ftsTag.id))
+      : []
+    const geoMembers = geoTag
+      ? members.filter((member) => this.memberHasTag(member, geoTag.id))
+      : []
+
+    const ftsTimeliness = workingHours
+      ? this.getFtsTimelinessCounts(ftsMembers, sessionsByMember, range, workingHours)
+      : { onTime: 0, late: 0 }
+
+    return {
+      ftsTotalMembers: ftsMembers.length,
+      ftsOnTimeCount: ftsTimeliness.onTime,
+      ftsLateCount: ftsTimeliness.late,
+      geoCheckedInCount: geoMembers.filter(
+        (member) =>
+          this.getPresenceStats(sessionsByMember.get(member.id) ?? [], range.start, range.end)
+            .present
+      ).length,
+    }
+  }
+
+  private getFtsTimelinessCounts(
+    members: OperationalReportMemberRecord[],
+    sessionsByMember: ReadonlyMap<string, PresenceSessionInternal[]>,
+    range: DateRange,
+    workingHours: DailyPresenceWorkingHoursDetails
+  ): { onTime: number; late: number } {
+    const lateCutoff = DateTime.fromJSDate(workingHours.start, { zone: DEFAULT_TIMEZONE })
+      .plus({ minutes: 30 })
+      .toJSDate()
+    let onTime = 0
+    let late = 0
+
+    for (const member of members) {
+      const stats = this.getPresenceStats(
+        sessionsByMember.get(member.id) ?? [],
+        range.start,
+        range.end
+      )
+      if (!stats.firstIn) {
+        continue
+      }
+
+      const firstIn = new Date(stats.firstIn)
+      if (firstIn <= workingHours.start) {
+        onTime += 1
+      } else if (firstIn <= lateCutoff) {
+        late += 1
+      }
+    }
+
+    return { onTime, late }
   }
 
   private pairSessions(
@@ -1475,7 +1698,8 @@ export class OperationalReportService {
   private async getKeyNights(
     range: DateRange,
     categories: KeyNightCategory[],
-    warnings: Set<string>
+    warnings: Set<string>,
+    options: { warnWhenMissing?: boolean } = {}
   ): Promise<KeyNightWindow[]> {
     const events = await this.repository.findUnitEvents(range.start, range.end, categories)
     const eventNights = events.map((event) => this.toKeyNightFromEvent(event))
@@ -1505,11 +1729,13 @@ export class OperationalReportService {
       `${left.date}:${left.category}`.localeCompare(`${right.date}:${right.category}`)
     )
 
-    for (const category of categories) {
-      if (!result.some((night) => night.category === category)) {
-        warnings.add(
-          `No ${category === 'training' ? 'Training' : 'Admin'} Nights were found from Unit Events, Operational Timings rules, or report schedule settings.`
-        )
+    if (options.warnWhenMissing ?? true) {
+      for (const category of categories) {
+        if (!result.some((night) => night.category === category)) {
+          warnings.add(
+            `No ${category === 'training' ? 'Training' : 'Admin'} Nights were found from Unit Events, Operational Timings rules, or report schedule settings.`
+          )
+        }
       }
     }
 
@@ -2331,6 +2557,26 @@ export class OperationalReportService {
     }
 
     return dates
+  }
+
+  private getWeekdayDatesInRange(range: DateRange): string[] {
+    return this.getDatesInRange(range).filter((date) => this.isWeekdayDate(date))
+  }
+
+  private isWeekdayDate(date: string): boolean {
+    const weekday = DateTime.fromISO(date, { zone: DEFAULT_TIMEZONE }).weekday
+    return weekday >= 1 && weekday <= 5
+  }
+
+  private countSessionsOverlappingDates(
+    sessions: PresenceSessionInternal[],
+    dates: string[]
+  ): number {
+    const ranges = dates.map((date) => this.getDayRange(date))
+
+    return sessions.filter((session) =>
+      ranges.some((range) => this.sessionOverlaps(session, range.start, range.end))
+    ).length
   }
 
   private dateTimeFromLocalDateAndTime(date: string, time: string): Date {

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.4.10",
+  "version": "3.4.11",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/components/admin/reports/AdminReportsPage.tsx
+++ b/apps/frontend-admin/src/components/admin/reports/AdminReportsPage.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useMemo, useState, type ReactNode } from 'react'
 import {
   ArrowDown,
   ArrowUp,
@@ -17,6 +17,7 @@ import {
   AppCard,
   AppCardContent,
   AppCardDescription,
+  AppCardFooter,
   AppCardHeader,
   AppCardTitle,
 } from '@/components/ui/AppCard'
@@ -221,6 +222,7 @@ export function AdminReportsPage() {
     getBaseReportFilters('daily_presence')
   )
   const [lastReport, setLastReport] = useState<AdminReportResponse | null>(null)
+  const [isReportSetupCollapsed, setIsReportSetupCollapsed] = useState(false)
   const divisionsQuery = useDivisions()
   const tagsQuery = useTags()
   const visitTypesQuery = useVisitTypesForReports()
@@ -303,7 +305,7 @@ export function AdminReportsPage() {
 
   return (
     <div className="space-y-(--space-4)">
-      <header className="flex flex-wrap items-start justify-between gap-(--space-4)">
+      <header>
         <div>
           <h1 id="admin-page-title" className="font-display text-3xl font-bold tracking-normal">
             Reports
@@ -311,9 +313,6 @@ export function AdminReportsPage() {
           <p className="mt-(--space-1) text-sm text-base-content/65">
             Generate printable attendance, presence, and visitor reports.
           </p>
-        </div>
-        <div className="rounded-box border border-base-300 bg-base-100 px-(--space-3) py-(--space-2) text-sm text-base-content/65 shadow-[var(--shadow-1)]">
-          <span className="font-semibold text-base-content">V1 export:</span> browser print
         </div>
       </header>
 
@@ -329,38 +328,58 @@ export function AdminReportsPage() {
                 Choose a report, set only the relevant filters, then preview it below.
               </AppCardDescription>
             </div>
-            <AppBadge status="info" size="sm">
-              Admin / Developer
-            </AppBadge>
+            <div className="flex items-center gap-(--space-2)">
+              <AppBadge status="info" size="sm">
+                Admin / Developer
+              </AppBadge>
+              <button
+                type="button"
+                className="btn btn-ghost btn-sm"
+                aria-expanded={!isReportSetupCollapsed}
+                onClick={() => setIsReportSetupCollapsed((collapsed) => !collapsed)}
+              >
+                <ChevronDown
+                  className={cn(
+                    'h-4 w-4 transition-transform duration-(--duration-fast)',
+                    !isReportSetupCollapsed && 'rotate-180'
+                  )}
+                  aria-hidden="true"
+                />
+                {isReportSetupCollapsed ? 'Expand setup' : 'Collapse setup'}
+              </button>
+            </div>
           </div>
         </AppCardHeader>
-        <AppCardContent className="space-y-(--space-4)">
-          <div className="grid gap-(--space-4) xl:grid-cols-[minmax(18rem,0.7fr)_minmax(0,1.3fr)]">
-            <ReportTypeSelector value={filters.reportType} onChange={handleReportTypeChange} />
-
+        {!isReportSetupCollapsed && (
+          <AppCardContent className="space-y-(--space-4)">
             <ReportsFilterPanel
               filters={filters}
               updateFilters={updateFilters}
+              reportTypeSelector={
+                <ReportTypeSelector value={filters.reportType} onChange={handleReportTypeChange} />
+              }
               divisions={divisionsQuery.data?.divisions ?? []}
               tags={tags}
               visitTypes={visitTypesQuery.data ?? []}
               hostMembers={reportHostMembers}
               shortcutWarnings={shortcutWarnings}
             />
-          </div>
 
-          {validationMessages.length > 0 && (
-            <div className="rounded-box border border-warning/40 bg-warning-fadded p-(--space-3) text-sm text-warning-fadded-content">
-              <p className="font-semibold">Required before running</p>
-              <ul className="mt-(--space-1) list-disc pl-(--space-4)">
-                {validationMessages.map((message) => (
-                  <li key={message}>{message}</li>
-                ))}
-              </ul>
-            </div>
-          )}
-
+            {validationMessages.length > 0 && (
+              <div className="rounded-box border border-warning/40 bg-warning-fadded p-(--space-3) text-sm text-warning-fadded-content">
+                <p className="font-semibold">Required before running</p>
+                <ul className="mt-(--space-1) list-disc pl-(--space-4)">
+                  {validationMessages.map((message) => (
+                    <li key={message}>{message}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </AppCardContent>
+        )}
+        <AppCardFooter className="block">
           <ReportActionBar
+            isSetupCollapsed={isReportSetupCollapsed}
             isRunDisabled={isRunDisabled}
             isRunning={reportRunner.isPending}
             hasReport={lastReport !== null}
@@ -370,7 +389,7 @@ export function AdminReportsPage() {
             onPrint={handlePrint}
             onReset={handleReset}
           />
-        </AppCardContent>
+        </AppCardFooter>
       </AppCard>
 
       <ReportPreview
@@ -417,6 +436,7 @@ function ReportTypeSelector({
 function ReportsFilterPanel({
   filters,
   updateFilters,
+  reportTypeSelector,
   divisions,
   tags,
   visitTypes,
@@ -425,6 +445,7 @@ function ReportsFilterPanel({
 }: {
   filters: ReportFilters
   updateFilters: (next: Partial<ReportFilters>) => void
+  reportTypeSelector: ReactNode
   divisions: Array<{ id: string; code: string; name: string }>
   tags: Array<{ id: string; name: string }>
   visitTypes: Array<{ id: string; code: string; name: string }>
@@ -496,7 +517,8 @@ function ReportsFilterPanel({
   }
 
   return (
-    <div className="grid gap-(--space-3) md:grid-cols-2 xl:grid-cols-3">
+    <div className="grid gap-(--space-3) md:grid-cols-2 xl:grid-cols-[minmax(20rem,1.5fr)_minmax(12rem,1fr)_minmax(12rem,1fr)_minmax(12rem,1fr)]">
+      {reportTypeSelector}
       {visible.has('date') && (
         <DateInput label="Day" value={filters.date} onChange={(date) => updateFilters({ date })} />
       )}
@@ -665,7 +687,7 @@ function ReportsFilterPanel({
         </label>
       )}
       {showDailyPresenceSort && (
-        <div className="md:col-span-2 xl:col-span-3">
+        <div className="md:col-span-2 xl:col-span-4">
           <MemberReportSortBuilder
             reportType={filters.reportType}
             rules={filters.dailyPresenceSort}
@@ -1101,7 +1123,7 @@ function MemberReportSortBuilder({
     return (
       <div
         key={rule.id}
-        className="grid items-center gap-(--space-2) rounded-box border border-base-300 bg-base-100 p-(--space-2) md:grid-cols-[2rem_8rem_minmax(0,1fr)_8rem_auto]"
+        className="grid items-center gap-(--space-2) rounded-box border border-base-300 bg-base-100 p-(--space-2) md:grid-cols-[2rem_8rem_minmax(10rem,1fr)_10rem_auto]"
       >
         <span className="text-center text-xs font-semibold text-base-content/55">{index + 1}</span>
         <select
@@ -1187,7 +1209,9 @@ function MemberReportSortBuilder({
           const directionLabels =
             rule.type === 'field'
               ? getDailyPresenceFieldDirectionLabels(rule.field)
-              : { asc: 'First', desc: 'Last' }
+              : rule.type === 'tag_priority'
+                ? { asc: 'Ascending', desc: 'Descending' }
+                : { asc: 'First', desc: 'Last' }
 
           return (
             <select
@@ -1311,7 +1335,7 @@ function MemberReportSortBuilder({
         </p>
       </div>
 
-      <div className="mt-(--space-3) grid gap-(--space-3)">
+      <div className="mt-(--space-3) grid gap-(--space-3) 2xl:grid-cols-2">
         {renderSortSection({
           group: 'primary',
           title: 'Primary sort order',
@@ -1359,6 +1383,7 @@ function DateInput({
 }
 
 function ReportActionBar({
+  isSetupCollapsed,
   isRunDisabled,
   isRunning,
   hasReport,
@@ -1366,6 +1391,7 @@ function ReportActionBar({
   onPrint,
   onReset,
 }: {
+  isSetupCollapsed: boolean
   isRunDisabled: boolean
   isRunning: boolean
   hasReport: boolean
@@ -1374,15 +1400,24 @@ function ReportActionBar({
   onReset: () => void
 }) {
   return (
-    <div className="flex flex-wrap items-center justify-between gap-(--space-3) border-t border-base-300 pt-(--space-4)">
-      <p className="max-w-2xl text-sm text-base-content/62">
-        Uses your browser print dialog. Choose “Save to PDF” to create a PDF file.
-      </p>
+    <div
+      className={cn(
+        'flex flex-wrap items-center gap-(--space-3) border-t border-base-300 pt-(--space-4)',
+        isSetupCollapsed ? 'justify-end' : 'justify-between'
+      )}
+    >
+      {!isSetupCollapsed && (
+        <p className="max-w-2xl text-sm text-base-content/62">
+          Uses your browser print dialog. Choose “Save to PDF” to create a PDF file.
+        </p>
+      )}
       <div className="flex flex-wrap items-center gap-(--space-2)">
-        <button type="button" className="btn btn-ghost btn-sm" onClick={onReset}>
-          <RotateCcw className="h-4 w-4" aria-hidden="true" />
-          Reset filters
-        </button>
+        {!isSetupCollapsed && (
+          <button type="button" className="btn btn-ghost btn-sm" onClick={onReset}>
+            <RotateCcw className="h-4 w-4" aria-hidden="true" />
+            Reset filters
+          </button>
+        )}
         <button
           type="button"
           className="btn btn-outline btn-sm"

--- a/apps/frontend-admin/src/components/admin/reports/report-definitions.ts
+++ b/apps/frontend-admin/src/components/admin/reports/report-definitions.ts
@@ -132,7 +132,26 @@ export function getBaseReportFilters(reportType: AdminReportType): ReportFilters
     hostMemberId: '',
     organization: '',
     scopeTypes: ['everyone'],
-    dailyPresenceSort: [
+    dailyPresenceSort: getDefaultMemberReportSort(reportType),
+  }
+}
+
+function getDefaultMemberReportSort(reportType: AdminReportType): DailyPresenceSortRule[] {
+  if (reportType === 'daily_presence') {
+    return [
+      {
+        id: 'daily-sort-primary-tag-priority',
+        sortGroup: 'primary',
+        type: 'tag_priority',
+        direction: 'asc',
+      },
+      {
+        id: 'daily-sort-secondary-rank',
+        sortGroup: 'secondary',
+        type: 'field',
+        field: 'rank',
+        direction: 'desc',
+      },
       {
         id: 'daily-sort-secondary-last-name',
         sortGroup: 'secondary',
@@ -140,8 +159,18 @@ export function getBaseReportFilters(reportType: AdminReportType): ReportFilters
         field: 'last_name',
         direction: 'asc',
       },
-    ],
+    ]
   }
+
+  return [
+    {
+      id: `${reportType}-sort-secondary-last-name`,
+      sortGroup: 'secondary',
+      type: 'field',
+      field: 'last_name',
+      direction: 'asc',
+    },
+  ]
 }
 
 export const REPORT_DEFINITIONS = [
@@ -158,7 +187,7 @@ export const REPORT_DEFINITIONS = [
   {
     reportType: 'weekly_presence',
     label: 'Weekly Presence',
-    description: 'Presence across a Monday-Sunday week with key night attendance markers.',
+    description: 'Presence across a Monday-Friday week with key night attendance markers.',
     defaultFilters: () => getBaseReportFilters('weekly_presence'),
     requiredFilters: ['weekStartDate'],
     visibleFilters: ['weekStartDate', 'scopeType', 'divisionId', 'tagId', 'dailyPresenceSort'],

--- a/apps/frontend-admin/src/components/admin/reports/report-preview.tsx
+++ b/apps/frontend-admin/src/components/admin/reports/report-preview.tsx
@@ -259,20 +259,77 @@ function SummaryGrid({ items }: { items: Array<{ label: string; value: string | 
   )
 }
 
+function DailyPresenceDayContext({ report }: { report: DailyPresenceReportResponse }) {
+  const { dayContext } = report.data
+  const workingHours = dayContext.workingHours
+  const nightLabels = [
+    dayContext.isTrainingNight ? 'Training Night' : null,
+    dayContext.isAdminNight ? 'Admin Night' : null,
+  ].filter((label): label is string => label !== null)
+
+  return (
+    <div className="mb-(--space-3) flex flex-wrap items-center gap-(--space-2) text-xs text-base-content/65">
+      <span className="rounded-box bg-base-200 px-(--space-2) py-(--space-1)">
+        Working hours:{' '}
+        <span className="font-semibold text-base-content">
+          {workingHours ? formatTimeRangeLabel(workingHours.label) : 'Unavailable'}
+        </span>
+      </span>
+      {nightLabels.length > 0 ? (
+        nightLabels.map((label) => (
+          <span
+            key={label}
+            className="rounded-box border border-info/30 bg-info-fadded px-(--space-2) py-(--space-1) font-semibold text-info-fadded-content"
+          >
+            {label}
+          </span>
+        ))
+      ) : (
+        <span className="rounded-box bg-base-200 px-(--space-2) py-(--space-1)">
+          No Training/Admin Night
+        </span>
+      )}
+    </div>
+  )
+}
+
+function formatTimeRangeLabel(label: string): string {
+  return label.replace(
+    /(\d{2}):(\d{2})-(\d{2}):(\d{2})/,
+    (_match, startHour: string, startMinute: string, endHour: string, endMinute: string) =>
+      `${startHour}${startMinute}-${endHour}${endMinute}`
+  )
+}
+
 type DailyPresenceReportRow = DailyPresenceReportResponse['data']['rows'][number]
 type DailyPresenceReportSession = DailyPresenceReportRow['sessions'][number]
+type DailyPresenceDetailDirection = 'in' | 'out'
 
-function getDailyPresenceDetailLines(row: DailyPresenceReportRow): string[] {
+interface DailyPresenceDetailLine {
+  direction: DailyPresenceDetailDirection
+  time: string
+  text: string
+}
+
+function getDailyPresenceDetailLines(row: DailyPresenceReportRow): DailyPresenceDetailLine[] {
   return row.sessions.flatMap((session) => {
-    const lines: string[] = []
+    const lines: DailyPresenceDetailLine[] = []
     const inMethodLabel = formatCheckinMethodDetail(session.inMethod)
     const outMethodLabel = formatCheckinMethodDetail(session.outMethod)
 
     if (inMethodLabel) {
-      lines.push(`${formatReportTime(session.inAt)} in: ${inMethodLabel}`)
+      lines.push({
+        direction: 'in',
+        time: formatReportTime(session.inAt),
+        text: inMethodLabel,
+      })
     }
     if (session.outAt && outMethodLabel) {
-      lines.push(`${formatReportTime(session.outAt)} out: ${outMethodLabel}`)
+      lines.push({
+        direction: 'out',
+        time: formatReportTime(session.outAt),
+        text: outMethodLabel,
+      })
     }
     if (session.inEditNote !== null) {
       lines.push(formatSessionEditDetail(session, 'in'))
@@ -310,12 +367,16 @@ function formatCheckinMethodDetail(method: string | null | undefined): string | 
 
 function formatSessionEditDetail(
   session: DailyPresenceReportSession,
-  direction: 'in' | 'out'
-): string {
+  direction: DailyPresenceDetailDirection
+): DailyPresenceDetailLine {
   const timestamp = direction === 'in' ? session.inAt : (session.outAt ?? session.inAt)
   const note = direction === 'in' ? session.inEditNote : session.outEditNote
   const trimmedNote = note?.trim() ?? ''
-  return `${formatReportTime(timestamp)} ${direction} edited${trimmedNote ? `: ${trimmedNote}` : ''}`
+  return {
+    direction,
+    time: formatReportTime(timestamp),
+    text: `Edited${trimmedNote ? `: ${trimmedNote}` : ''}`,
+  }
 }
 
 function DailyPresenceReport({ report }: { report: DailyPresenceReportResponse }) {
@@ -328,12 +389,18 @@ function DailyPresenceReport({ report }: { report: DailyPresenceReportResponse }
 
   return (
     <>
+      <DailyPresenceDayContext report={report} />
       <SummaryGrid
         items={[
-          { label: 'Present', value: summary.presentMembers },
           { label: 'Scoped members', value: summary.totalScopedMembers },
-          { label: 'Sessions', value: summary.totalSessions },
-          { label: 'Left and returned', value: summary.leftAndReturnedCount },
+          { label: 'FTS total', value: summary.ftsTotalMembers },
+          {
+            label: 'FTS on time / late',
+            value: report.data.dayContext.workingHours
+              ? `${summary.ftsOnTimeCount} / ${summary.ftsLateCount}`
+              : '— / —',
+          },
+          { label: 'GEO checked in', value: summary.geoCheckedInCount },
         ]}
       />
 
@@ -352,21 +419,21 @@ function DailyPresenceReport({ report }: { report: DailyPresenceReportResponse }
           >
             <colgroup>
               <col className="reports-daily-member-col" />
+              <col className="reports-daily-presence-col" />
               <col className="reports-daily-department-col" />
               <col className="reports-daily-tags-col" />
               <col className="reports-daily-time-col" />
               <col className="reports-daily-last-out-col" />
-              <col className="reports-daily-presence-col" />
               {hasDetails && <col className="reports-daily-details-col" />}
             </colgroup>
             <thead>
               <tr>
                 <th>Member</th>
+                <th>Presence</th>
                 <th>Department</th>
                 <th>Tags</th>
                 <th>Check-In</th>
                 <th>Check-Out</th>
-                <th>Presence</th>
                 {hasDetails && <th>Details</th>}
               </tr>
             </thead>
@@ -378,6 +445,25 @@ function DailyPresenceReport({ report }: { report: DailyPresenceReportResponse }
                   <tr key={row.member.id}>
                     <td className="reports-member-cell">
                       <MemberName member={row.member} />
+                    </td>
+                    <td>
+                      <span className="reports-screen-only">
+                        <span
+                          role="status"
+                          data-slot="daily-presence-status-badge"
+                          className={cn(
+                            'badge badge-sm border',
+                            isPresent
+                              ? 'border-success/35 bg-success-fadded text-success-fadded-content'
+                              : 'border-base-300 bg-neutral-fadded text-neutral-fadded-content'
+                          )}
+                        >
+                          {isPresent ? 'Present' : 'Out'}
+                        </span>
+                      </span>
+                      <span className="hidden reports-print-inline font-mono">
+                        {isPresent ? 'Present' : 'Out'}
+                      </span>
                     </td>
                     <td className="reports-department-cell">
                       {row.member.division?.code ?? row.member.division?.name ?? 'Unassigned'}
@@ -409,22 +495,19 @@ function DailyPresenceReport({ report }: { report: DailyPresenceReportResponse }
                         ))}
                       </div>
                     </td>
-                    <td>
-                      <span className="reports-screen-only">
-                        <AppBadge status={isPresent ? 'success' : 'neutral'} size="sm">
-                          {isPresent ? 'Present' : 'Out'}
-                        </AppBadge>
-                      </span>
-                      <span className="hidden reports-print-inline font-mono">
-                        {isPresent ? 'Present' : 'Out'}
-                      </span>
-                    </td>
                     {hasDetails && (
                       <td className="reports-details-cell">
                         {detailLines.length > 0 && (
                           <div className="grid gap-(--space-1) text-xs leading-tight text-base-content/70">
                             {detailLines.map((line, lineIndex) => (
-                              <span key={`${row.member.id}-detail-${lineIndex}`}>{line}</span>
+                              <span
+                                key={`${row.member.id}-detail-${lineIndex}`}
+                                className="flex flex-wrap items-center gap-x-(--space-1) gap-y-0.5"
+                              >
+                                <span className="font-mono text-base-content/55">{line.time}</span>
+                                <DailyPresenceDetailDirectionBadge direction={line.direction} />
+                                <span>{line.text}</span>
+                              </span>
                             ))}
                           </div>
                         )}
@@ -437,6 +520,30 @@ function DailyPresenceReport({ report }: { report: DailyPresenceReportResponse }
           </table>
         </div>
       )}
+    </>
+  )
+}
+
+function DailyPresenceDetailDirectionBadge({
+  direction,
+}: {
+  direction: DailyPresenceDetailDirection
+}) {
+  const label = direction === 'in' ? 'Check-in' : 'Check-out'
+
+  return (
+    <>
+      <span
+        className={cn(
+          'reports-screen-only badge badge-xs border px-(--space-1) text-[0.625rem] font-semibold uppercase tracking-wide',
+          direction === 'in'
+            ? 'border-info/35 bg-info-fadded text-info-fadded-content'
+            : 'border-base-300 bg-neutral-fadded text-neutral-fadded-content'
+        )}
+      >
+        {label}
+      </span>
+      <span className="hidden reports-print-inline font-semibold">{label}</span>
     </>
   )
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.4.10",
+  "version": "3.4.11",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.4.10",
+  "version": "3.4.11",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/contracts/src/schemas/report.schema.ts
+++ b/packages/contracts/src/schemas/report.schema.ts
@@ -483,6 +483,25 @@ export const KeyNightPresenceMarkerSchema = v.object({
 
 export type KeyNightPresenceMarker = v.InferOutput<typeof KeyNightPresenceMarkerSchema>
 
+export const DailyPresenceWorkingHoursSchema = v.object({
+  startTime: v.string(),
+  endTime: v.string(),
+  startAt: v.string(),
+  endAt: v.string(),
+  label: v.string(),
+})
+
+export type DailyPresenceWorkingHours = v.InferOutput<typeof DailyPresenceWorkingHoursSchema>
+
+export const DailyPresenceDayContextSchema = v.object({
+  workingHours: v.nullable(DailyPresenceWorkingHoursSchema),
+  isTrainingNight: v.boolean(),
+  isAdminNight: v.boolean(),
+  keyNights: v.array(KeyNightSchema),
+})
+
+export type DailyPresenceDayContext = v.InferOutput<typeof DailyPresenceDayContextSchema>
+
 export const DailyPresenceRowSchema = v.object({
   member: ReportMemberSummarySchema,
   firstIn: v.nullable(v.string()),
@@ -501,7 +520,12 @@ export const DailyPresenceReportDataSchema = v.object({
     totalSessions: v.number(),
     leftAndReturnedCount: v.number(),
     openSessionCount: v.number(),
+    ftsTotalMembers: v.number(),
+    ftsOnTimeCount: v.number(),
+    ftsLateCount: v.number(),
+    geoCheckedInCount: v.number(),
   }),
+  dayContext: DailyPresenceDayContextSchema,
   rows: v.array(DailyPresenceRowSchema),
 })
 

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.4.10",
+  "version": "3.4.11",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.4.10",
+  "version": "3.4.11",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Updates Daily Presence report setup so key run/print actions remain available when setup is collapsed.
- Adds staff-focused Daily Presence summary stats for scoped members, active FTS totals, FTS on-time/late counts, and GEO check-ins.
- Adds working-hours and Training/Admin Night context to the Daily Presence report header area.
- Keeps Daily Presence table details focused on attendance issues, with softer presence badges and clearer Check-in/Check-out markers.
- Bumps Sentinel workspace packages to v3.4.11 for the next patch release.

## Why this change was needed

The Daily Presence report is used by the Staff Officer as an attendance record and issue review tool, not as a live dashboard. The previous summary emphasized current presence counts, while the requested workflow needs daily attendance timing, FTS/GEO tracking, and check-in/out issue visibility.

## What changed

### User-facing

- Daily Presence now shows:
  - Scoped members
  - FTS total
  - FTS on time / late
  - GEO checked in
- FTS late only counts members whose first check-in is after the workday start and within 30 minutes after it.
- Daily Presence now shows the day working-hours range when operational timings are available.
- Daily Presence now indicates whether the selected day is a Training Night or Admin Night.
- Presence moved beside Member in the Daily Presence table.
- Present badges use the softer fadded style.
- Details now uses compact Check-in / Check-out badges instead of plain in/out text.
- Report setup can collapse while Print / Save PDF and Run report remain visible.

### Backend/API

- Extends the Daily Presence report response schema with day context and staff attendance summary fields.
- Resolves FTS and GEO through configured tag shortcuts instead of hard-coded tag IDs.
- Uses operational timing working hours when available to classify FTS check-ins.
- Weekly and Monthly Presence reports show Monday-Friday only.

### Database

- No database migration required.

### Deployment/update

- Workspace versions bumped to 3.4.11.

### Tests

- Adds Daily Presence service coverage for FTS/GEO summary counts, working hours, and Training/Admin Night context.
- Adds weekday-only Weekly/Monthly Presence report coverage.

## User impact

Staff Officers get a Daily Presence report that better reflects attendance review needs: who was in scope, how FTS reported relative to start time, which GEO members checked in, and whether the day had Training/Admin Night context.

## Operator impact

No manual operator action is required. Existing Operational Timings settings are used when available.

## Upgrade or migration notes

No upgrade action required beyond applying the patch release. No database migration is required.

## Risk and rollback notes

Main risk is report interpretation changing for Daily Presence summary stats. The row-level attendance records remain available below the summary. Rollback is safe by reverting the application version; no data migration is involved.

## Testing performed

- pnpm version:check
- pnpm --filter @sentinel/contracts typecheck
- pnpm --filter @sentinel/backend typecheck
- pnpm --filter frontend-admin typecheck
- pnpm --filter @sentinel/backend lint
- pnpm --filter frontend-admin lint

Notes:
- Backend and frontend lint pass with existing warnings only.
- Direct backend Vitest execution is unavailable in this workspace because the package command cannot find vitest.
- Visual check was skipped at user request.

## Changelog candidates

- Improved Daily Presence report summary stats for Staff Officer attendance review.
- Added Daily Presence working-hours and Training/Admin Night context.
- Kept report print/run actions visible when setup is collapsed.
- Limited Weekly and Monthly Presence reports to Monday-Friday.