### PR TITLE
feat(reports): add Daily Presence operations context

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.4.11",
+  "version": "3.4.12",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/repositories/operational-report-repository.ts
+++ b/apps/backend/src/repositories/operational-report-repository.ts
@@ -170,6 +170,37 @@ export interface OperationalReportCheckinTimestampEditRecord {
   createdAt: Date | null
 }
 
+export interface OperationalReportDdsResponsibilityRecord {
+  memberId: string
+  acceptedAt: Date | null
+  member: {
+    id: string
+    rank: string
+    firstName: string
+    lastName: string
+    displayName: string | null
+  }
+}
+
+export interface OperationalReportResponsibilityAuditRecord {
+  memberId: string
+  tagName: string
+  action: string
+  fromMemberId: string | null
+  toMemberId: string | null
+  performedBy: string | null
+  performedByType: string
+  timestamp: Date
+  notes: string | null
+}
+
+export type OperationalReportLockupTransferRecord = Prisma.LockupTransferGetPayload<{
+  include: {
+    fromMember: { select: typeof reportDutyMemberSelect }
+    toMember: { select: typeof reportDutyMemberSelect }
+  }
+}>
+
 export type OperationalReportUnitEventRecord = Prisma.UnitEventGetPayload<{
   include: typeof unitEventInclude
 }>
@@ -442,6 +473,136 @@ export class OperationalReportRepository {
         }
       })
       .filter((record): record is OperationalReportCheckinTimestampEditRecord => record !== null)
+  }
+
+  async findFirstCheckinForMembers(
+    memberIds: string[],
+    start: Date,
+    end: Date
+  ): Promise<OperationalReportCheckinRecord | null> {
+    if (memberIds.length === 0) {
+      return null
+    }
+
+    return this.prisma.checkin.findFirst({
+      where: {
+        memberId: {
+          in: memberIds,
+        },
+        direction: 'in',
+        timestamp: {
+          gte: start,
+          lt: end,
+        },
+      },
+      select: {
+        id: true,
+        memberId: true,
+        direction: true,
+        timestamp: true,
+        kioskId: true,
+        method: true,
+      },
+      orderBy: { timestamp: 'asc' },
+    })
+  }
+
+  async findDdsResponsibilityForDate(
+    startDate: Date,
+    endDate: Date
+  ): Promise<OperationalReportDdsResponsibilityRecord[]> {
+    return this.prisma.ddsAssignment.findMany({
+      where: {
+        assignedDate: {
+          gte: startDate,
+          lt: endDate,
+        },
+        acceptedAt: {
+          not: null,
+        },
+      },
+      select: {
+        memberId: true,
+        acceptedAt: true,
+        member: {
+          select: reportDutyMemberSelect,
+        },
+      },
+      orderBy: { acceptedAt: 'asc' },
+    })
+  }
+
+  async findResponsibilityAuditRecords(
+    start: Date,
+    end: Date
+  ): Promise<OperationalReportResponsibilityAuditRecord[]> {
+    return this.prisma.responsibilityAuditLog.findMany({
+      where: {
+        timestamp: {
+          gte: start,
+          lt: end,
+        },
+        OR: [
+          { tagName: 'DDS', action: { in: ['transferred', 'self_accepted', 'accepted'] } },
+          { tagName: 'Lockup', action: 'building_opened' },
+        ],
+      },
+      select: {
+        memberId: true,
+        tagName: true,
+        action: true,
+        fromMemberId: true,
+        toMemberId: true,
+        performedBy: true,
+        performedByType: true,
+        timestamp: true,
+        notes: true,
+      },
+      orderBy: { timestamp: 'asc' },
+    })
+  }
+
+  async findLockupTransfersForRange(
+    start: Date,
+    end: Date
+  ): Promise<OperationalReportLockupTransferRecord[]> {
+    return this.prisma.lockupTransfer.findMany({
+      where: {
+        transferredAt: {
+          gte: start,
+          lt: end,
+        },
+      },
+      include: {
+        fromMember: { select: reportDutyMemberSelect },
+        toMember: { select: reportDutyMemberSelect },
+      },
+      orderBy: { transferredAt: 'asc' },
+    })
+  }
+
+  async findDutyPeopleByIds(memberIds: string[]): Promise<
+    Array<{
+      id: string
+      rank: string
+      firstName: string
+      lastName: string
+      displayName: string | null
+    }>
+  > {
+    const uniqueIds = [...new Set(memberIds.filter((memberId) => memberId.trim().length > 0))]
+    if (uniqueIds.length === 0) {
+      return []
+    }
+
+    return this.prisma.member.findMany({
+      where: {
+        id: {
+          in: uniqueIds,
+        },
+      },
+      select: reportDutyMemberSelect,
+    })
   }
 
   async findScheduledDutyAssignmentsForMembers(

--- a/apps/backend/src/routes/lockup.ts
+++ b/apps/backend/src/routes/lockup.ts
@@ -1,10 +1,11 @@
 import { initServer } from '@ts-rest/express'
-import { lockupContract } from '@sentinel/contracts'
+import { lockupContract, type LockupStatusResponse } from '@sentinel/contracts'
 import { formatAuditMemberName, logRequestAudit } from '../lib/audit-log.js'
 import { LockupService } from '../services/lockup-service.js'
 import { MemberRepository } from '../repositories/member-repository.js'
 import { AuditRepository } from '../repositories/audit-repository.js'
 import { BadgeRepository } from '../repositories/badge-repository.js'
+import type { LockupStatusEntity } from '../repositories/lockup-repository.js'
 import { getPrismaClient } from '../lib/database.js'
 import { AccountLevel } from '../middleware/roles.js'
 
@@ -14,6 +15,22 @@ const lockupService = new LockupService(getPrismaClient())
 const memberRepository = new MemberRepository(getPrismaClient())
 const auditRepo = new AuditRepository(getPrismaClient())
 const badgeRepository = new BadgeRepository(getPrismaClient())
+
+async function toLockupStatusResponse(status: LockupStatusEntity): Promise<LockupStatusResponse> {
+  const opening = await lockupService.getFirstOpeningForOperationalDate(status.date)
+
+  return {
+    date: status.date.toISOString().split('T')[0] ?? '',
+    buildingStatus: status.buildingStatus,
+    currentHolder: status.currentHolder,
+    acquiredAt: status.acquiredAt?.toISOString() ?? null,
+    openedBy: opening?.openedBy ?? null,
+    openedAt: opening?.openedAt.toISOString() ?? null,
+    securedAt: status.securedAt?.toISOString() ?? null,
+    securedBy: status.securedByMember ?? null,
+    isActive: status.isActive,
+  }
+}
 
 /**
  * Lockup route implementation using ts-rest
@@ -32,15 +49,7 @@ export const lockupRouter = s.router(lockupContract, {
 
       return {
         status: 200 as const,
-        body: {
-          date: status.date.toISOString().split('T')[0] ?? '',
-          buildingStatus: status.buildingStatus,
-          currentHolder: status.currentHolder,
-          acquiredAt: status.acquiredAt?.toISOString() ?? null,
-          securedAt: status.securedAt?.toISOString() ?? null,
-          securedBy: status.securedByMember ?? null,
-          isActive: status.isActive,
-        },
+        body: await toLockupStatusResponse(status),
       }
     } catch (error) {
       return {
@@ -72,15 +81,7 @@ export const lockupRouter = s.router(lockupContract, {
 
       return {
         status: 200 as const,
-        body: {
-          date: status.date.toISOString().split('T')[0] ?? '',
-          buildingStatus: status.buildingStatus,
-          currentHolder: status.currentHolder,
-          acquiredAt: status.acquiredAt?.toISOString() ?? null,
-          securedAt: status.securedAt?.toISOString() ?? null,
-          securedBy: status.securedByMember ?? null,
-          isActive: status.isActive,
-        },
+        body: await toLockupStatusResponse(status),
       }
     } catch (error) {
       return {
@@ -371,15 +372,7 @@ export const lockupRouter = s.router(lockupContract, {
         body: {
           success: true,
           message: 'Building opened successfully',
-          status: {
-            date: status.date.toISOString().split('T')[0] ?? '',
-            buildingStatus: status.buildingStatus,
-            currentHolder: status.currentHolder,
-            acquiredAt: status.acquiredAt?.toISOString() ?? null,
-            securedAt: status.securedAt?.toISOString() ?? null,
-            securedBy: status.securedByMember ?? null,
-            isActive: status.isActive,
-          },
+          status: await toLockupStatusResponse(status),
         },
       }
     } catch (error) {

--- a/apps/backend/src/services/lockup-service.test.ts
+++ b/apps/backend/src/services/lockup-service.test.ts
@@ -31,6 +31,7 @@ function createService() {
     },
     responsibilityAuditLog: {
       create: vi.fn(),
+      findFirst: vi.fn(),
     },
     $transaction: vi.fn(async (operations: Array<Promise<unknown>>) => Promise.all(operations)),
   }
@@ -132,6 +133,82 @@ describe('LockupService.getPresentMembersForLockup', () => {
     const result = await service.getPresentMembersForLockup({ excludeMemberId: 'member-1' })
 
     expect(result.members.map((member) => member.id)).toEqual(['member-2'])
+  })
+})
+
+describe('LockupService.getFirstOpeningForOperationalDate', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns the first building opener from the operational-day audit log', async () => {
+    const { service, prisma } = createService()
+    const openedAt = new Date('2026-03-26T13:16:00.000Z')
+
+    prisma.responsibilityAuditLog.findFirst.mockResolvedValue({
+      memberId: 'member-1',
+      timestamp: openedAt,
+    })
+    prisma.member.findUnique.mockResolvedValue({
+      id: 'member-1',
+      firstName: 'Jordan',
+      lastName: 'Ryu',
+      rank: 'S1',
+      serviceNumber: '12345',
+    })
+
+    const result = await service.getFirstOpeningForOperationalDate(
+      new Date('2026-03-26T00:00:00.000Z')
+    )
+
+    expect(prisma.responsibilityAuditLog.findFirst).toHaveBeenCalledWith({
+      where: {
+        tagName: 'Lockup',
+        action: 'building_opened',
+        timestamp: {
+          gte: expect.any(Date),
+          lt: expect.any(Date),
+        },
+      },
+      orderBy: { timestamp: 'asc' },
+      select: {
+        memberId: true,
+        timestamp: true,
+      },
+    })
+    expect(prisma.member.findUnique).toHaveBeenCalledWith({
+      where: { id: 'member-1' },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        rank: true,
+        serviceNumber: true,
+      },
+    })
+    expect(result).toEqual({
+      openedBy: {
+        id: 'member-1',
+        firstName: 'Jordan',
+        lastName: 'Ryu',
+        rank: 'S1',
+        serviceNumber: '12345',
+      },
+      openedAt,
+    })
+  })
+
+  it('returns null when no building open audit record exists for the day', async () => {
+    const { service, prisma } = createService()
+
+    prisma.responsibilityAuditLog.findFirst.mockResolvedValue(null)
+
+    const result = await service.getFirstOpeningForOperationalDate(
+      new Date('2026-03-26T00:00:00.000Z')
+    )
+
+    expect(result).toBeNull()
+    expect(prisma.member.findUnique).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/backend/src/services/lockup-service.ts
+++ b/apps/backend/src/services/lockup-service.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient } from '@sentinel/database'
 import type { MemberType } from '@sentinel/types'
+import { DateTime } from 'luxon'
 import { getPrismaClient } from '../lib/database.js'
 import { CheckinRepository } from '../repositories/checkin-repository.js'
 import { TemporaryPersonnelRepository } from '../repositories/temporary-personnel-repository.js'
@@ -15,7 +16,11 @@ import { PresenceService } from './presence-service.js'
 import { LiveDutyAssignmentService } from './live-duty-assignment-service.js'
 import { ScheduleService } from './schedule-service.js'
 import { NotFoundError, ValidationError } from '../middleware/error-handler.js'
-import { getOperationalDate } from '../utils/operational-date.js'
+import {
+  DEFAULT_TIMEZONE,
+  getOperationalDate,
+  getOperationalDayStartTime,
+} from '../utils/operational-date.js'
 import {
   broadcastLockupExecution,
   broadcastLockupTransfer,
@@ -91,6 +96,11 @@ export interface CheckoutOptions {
 
 export type TransferReason = 'manual' | 'dds_handoff' | 'duty_watch_takeover' | 'checkout_transfer'
 
+export interface LockupOpeningSummary {
+  openedBy: LockupHolder | null
+  openedAt: Date
+}
+
 interface LockupTransferHistoryItem {
   id: string
   type: 'transfer'
@@ -165,6 +175,62 @@ export class LockupService {
   async getStatusByDate(date: string): Promise<LockupStatusEntity | null> {
     const parsedDate = new Date(date + 'T00:00:00')
     return this.lockupRepo.findStatusByDate(parsedDate)
+  }
+
+  async getFirstOpeningForOperationalDate(
+    operationalDate: Date
+  ): Promise<LockupOpeningSummary | null> {
+    const dayStart = getOperationalDayStartTime()
+    const windowStart = DateTime.fromObject(
+      {
+        year: operationalDate.getUTCFullYear(),
+        month: operationalDate.getUTCMonth() + 1,
+        day: operationalDate.getUTCDate(),
+      },
+      { zone: DEFAULT_TIMEZONE }
+    ).set({
+      hour: dayStart.hour,
+      minute: dayStart.minute,
+      second: 0,
+      millisecond: 0,
+    })
+    const windowEnd = windowStart.plus({ days: 1 })
+
+    const openingLog = await this.prisma.responsibilityAuditLog.findFirst({
+      where: {
+        tagName: 'Lockup',
+        action: 'building_opened',
+        timestamp: {
+          gte: windowStart.toJSDate(),
+          lt: windowEnd.toJSDate(),
+        },
+      },
+      orderBy: { timestamp: 'asc' },
+      select: {
+        memberId: true,
+        timestamp: true,
+      },
+    })
+
+    if (!openingLog) {
+      return null
+    }
+
+    const openedBy = await this.prisma.member.findUnique({
+      where: { id: openingLog.memberId },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        rank: true,
+        serviceNumber: true,
+      },
+    })
+
+    return {
+      openedBy,
+      openedAt: openingLog.timestamp,
+    }
   }
 
   /**

--- a/apps/backend/src/services/operational-report-service.test.ts
+++ b/apps/backend/src/services/operational-report-service.test.ts
@@ -434,6 +434,10 @@ describe('generateDailyPresence', () => {
       findScheduledDutyAssignmentsForMembers: async () => [],
       findDdsAssignmentsForMembers: async () => [],
       findLiveDutyAssignmentsForMembers: async () => [],
+      findResponsibilityAuditRecords: async () => [],
+      findDdsResponsibilityForDate: async () => [],
+      findLockupTransfersForRange: async () => [],
+      findDutyPeopleByIds: async () => [],
       findTagShortcut: async () => null,
       findUnitEvents: async () => [],
       findAppSettingValue: async () => null,
@@ -487,6 +491,10 @@ describe('generateDailyPresence', () => {
       findScheduledDutyAssignmentsForMembers: async () => [],
       findDdsAssignmentsForMembers: async () => [],
       findLiveDutyAssignmentsForMembers: async () => [],
+      findResponsibilityAuditRecords: async () => [],
+      findDdsResponsibilityForDate: async () => [],
+      findLockupTransfersForRange: async () => [],
+      findDutyPeopleByIds: async () => [],
       findTagShortcut: async () => null,
       findUnitEvents: async () => [],
       findAppSettingValue: async () => null,
@@ -555,6 +563,10 @@ describe('generateDailyPresence', () => {
       findScheduledDutyAssignmentsForMembers: async () => [],
       findDdsAssignmentsForMembers: async () => [],
       findLiveDutyAssignmentsForMembers: async () => [],
+      findResponsibilityAuditRecords: async () => [],
+      findDdsResponsibilityForDate: async () => [],
+      findLockupTransfersForRange: async () => [],
+      findDutyPeopleByIds: async () => [],
       findTagShortcut: async (shortcut: 'fts' | 'geo') =>
         shortcut === 'fts'
           ? { id: ftsTagId, name: 'FTS', chipVariant: 'faded', chipColor: 'success' }
@@ -613,6 +625,173 @@ describe('generateDailyPresence', () => {
     })
     expect(report.data.dayContext.isTrainingNight).toBe(true)
     expect(report.data.dayContext.isAdminNight).toBe(true)
+  })
+
+  it('includes Daily Presence building, DDS, and lockup operations context', async () => {
+    const opener = operationalReportMember({
+      id: '11111111-1111-4111-8111-111111111111',
+      displayName: 'S1 Opener, A',
+      rank: 'S1',
+      firstName: 'Alex',
+      lastName: 'Opener',
+    })
+    const outgoingDds = operationalReportMember({
+      id: '22222222-2222-4222-8222-222222222222',
+      displayName: 'MS Outgoing, B',
+      rank: 'MS',
+      firstName: 'Blair',
+      lastName: 'Outgoing',
+    })
+    const incomingDds = operationalReportMember({
+      id: '33333333-3333-4333-8333-333333333333',
+      displayName: 'PO2 Incoming, C',
+      rank: 'PO2',
+      firstName: 'Casey',
+      lastName: 'Incoming',
+    })
+    const members = [opener, outgoingDds, incomingDds]
+    const repository = {
+      findActiveMembers: async () => members,
+      findCheckinsForMembers: async () => [
+        checkin('opener-in', opener.id, 'in', '2026-06-15T13:00:00.000Z'),
+      ],
+      findCheckinTimestampEditNotes: async () => [],
+      findScheduledDutyAssignmentsForMembers: async () => [],
+      findDdsAssignmentsForMembers: async () => [],
+      findLiveDutyAssignmentsForMembers: async () => [],
+      findResponsibilityAuditRecords: async () => [
+        {
+          memberId: opener.id,
+          tagName: 'Lockup',
+          action: 'building_opened',
+          fromMemberId: null,
+          toMemberId: null,
+          performedBy: opener.id,
+          performedByType: 'member',
+          timestamp: new Date('2026-06-15T13:02:00.000Z'),
+          notes: null,
+        },
+        {
+          memberId: incomingDds.id,
+          tagName: 'DDS',
+          action: 'transferred',
+          fromMemberId: outgoingDds.id,
+          toMemberId: incomingDds.id,
+          performedBy: outgoingDds.id,
+          performedByType: 'member',
+          timestamp: new Date('2026-06-15T20:00:00.000Z'),
+          notes: 'DDS turnover completed',
+        },
+      ],
+      findDdsResponsibilityForDate: async () => [
+        {
+          memberId: outgoingDds.id,
+          acceptedAt: new Date('2026-06-15T13:10:00.000Z'),
+          member: outgoingDds,
+        },
+      ],
+      findLockupTransfersForRange: async () => [
+        {
+          id: 'lockup-transfer-1',
+          lockupStatusId: 'lockup-status-1',
+          fromMemberId: outgoingDds.id,
+          toMemberId: incomingDds.id,
+          transferredAt: new Date('2026-06-15T20:05:00.000Z'),
+          reason: 'dds_handoff',
+          notes: 'Lockup moved with DDS',
+          createdAt: new Date('2026-06-15T20:05:00.000Z'),
+          fromMember: outgoingDds,
+          toMember: incomingDds,
+        },
+      ],
+      findDutyPeopleByIds: async () => [],
+      findTagShortcut: async () => null,
+      findUnitEvents: async () => [],
+      findAppSettingValue: async () => null,
+    } as unknown as OperationalReportRepository
+    const service = new OperationalReportService(undefined, repository)
+
+    const report = await service.generateDailyPresence(
+      { date: '2026-06-15', scopeType: 'everyone' },
+      { id: 'actor-1', rank: 'MS', firstName: 'Report', lastName: 'Runner' }
+    )
+
+    expect(report.data.dayContext.operations).toMatchObject({
+      buildingOpening: {
+        openedAt: '2026-06-15T13:02:00.000Z',
+        openedBy: { id: opener.id, displayName: 'S1 Opener, A', rank: 'S1' },
+        source: 'building_opened',
+      },
+      ddsAcceptance: {
+        acceptedAt: '2026-06-15T13:10:00.000Z',
+        acceptedBy: { id: outgoingDds.id, displayName: 'MS Outgoing, B', rank: 'MS' },
+      },
+      ddsTransfers: [
+        {
+          transferredAt: '2026-06-15T20:00:00.000Z',
+          from: { id: outgoingDds.id, displayName: 'MS Outgoing, B', rank: 'MS' },
+          to: { id: incomingDds.id, displayName: 'PO2 Incoming, C', rank: 'PO2' },
+          reason: 'dds_turnover',
+          notes: 'DDS turnover completed',
+        },
+      ],
+      lockupTransfers: [
+        {
+          transferredAt: '2026-06-15T20:05:00.000Z',
+          from: { id: outgoingDds.id, displayName: 'MS Outgoing, B', rank: 'MS' },
+          to: { id: incomingDds.id, displayName: 'PO2 Incoming, C', rank: 'PO2' },
+          reason: 'dds_handoff',
+          notes: 'Lockup moved with DDS',
+        },
+      ],
+    })
+  })
+
+  it('uses the first check-in as the Daily Presence opening fallback', async () => {
+    const firstMember = operationalReportMember({
+      id: '11111111-1111-4111-8111-111111111111',
+      displayName: 'S1 First, A',
+      rank: 'S1',
+      firstName: 'Alex',
+      lastName: 'First',
+    })
+    const secondMember = operationalReportMember({
+      id: '22222222-2222-4222-8222-222222222222',
+      displayName: 'S1 Second, B',
+      rank: 'S1',
+      firstName: 'Blair',
+      lastName: 'Second',
+    })
+    const repository = {
+      findActiveMembers: async () => [firstMember, secondMember],
+      findCheckinsForMembers: async () => [
+        checkin('second-in', secondMember.id, 'in', '2026-06-15T14:00:00.000Z'),
+        checkin('first-in', firstMember.id, 'in', '2026-06-15T13:00:00.000Z'),
+      ],
+      findCheckinTimestampEditNotes: async () => [],
+      findScheduledDutyAssignmentsForMembers: async () => [],
+      findDdsAssignmentsForMembers: async () => [],
+      findLiveDutyAssignmentsForMembers: async () => [],
+      findResponsibilityAuditRecords: async () => [],
+      findDdsResponsibilityForDate: async () => [],
+      findLockupTransfersForRange: async () => [],
+      findDutyPeopleByIds: async () => [],
+      findTagShortcut: async () => null,
+      findUnitEvents: async () => [],
+      findAppSettingValue: async () => null,
+    } as unknown as OperationalReportRepository
+    const service = new OperationalReportService(undefined, repository)
+
+    const report = await service.generateDailyPresence(
+      { date: '2026-06-15', scopeType: 'everyone' },
+      { id: 'actor-1', rank: 'MS', firstName: 'Report', lastName: 'Runner' }
+    )
+
+    expect(report.data.dayContext.operations.buildingOpening).toEqual({
+      openedAt: '2026-06-15T13:00:00.000Z',
+      openedBy: { id: firstMember.id, displayName: 'S1 First, A', rank: 'S1' },
+      source: 'first_checkin',
+    })
   })
 
   it('includes session methods and timestamp edit notes', async () => {
@@ -674,6 +853,10 @@ describe('generateDailyPresence', () => {
       findScheduledDutyAssignmentsForMembers: async () => [],
       findDdsAssignmentsForMembers: async () => [],
       findLiveDutyAssignmentsForMembers: async () => [],
+      findResponsibilityAuditRecords: async () => [],
+      findDdsResponsibilityForDate: async () => [],
+      findLockupTransfersForRange: async () => [],
+      findDutyPeopleByIds: async () => [],
       findTagShortcut: async () => null,
       findUnitEvents: async () => [],
       findAppSettingValue: async () => null,
@@ -756,6 +939,10 @@ describe('generateWeeklyPresence', () => {
       findScheduledDutyAssignmentsForMembers: async () => [],
       findDdsAssignmentsForMembers: async () => [],
       findLiveDutyAssignmentsForMembers: async () => [],
+      findResponsibilityAuditRecords: async () => [],
+      findDdsResponsibilityForDate: async () => [],
+      findLockupTransfersForRange: async () => [],
+      findDutyPeopleByIds: async () => [],
       findUnitEvents: async () => [],
       findAppSettingValue: async () => null,
       findReportSettingValue: async () => null,

--- a/apps/backend/src/services/operational-report-service.ts
+++ b/apps/backend/src/services/operational-report-service.ts
@@ -1,6 +1,8 @@
 import * as v from 'valibot'
 import { DateTime } from 'luxon'
 import type {
+  DailyPresenceOperationsContext,
+  DailyPresenceResponsibilityTransfer,
   DailyPresenceRow,
   DailyPresenceReportConfig,
   DailyPresenceReportResponse,
@@ -42,9 +44,12 @@ import {
   OperationalReportRepository,
   type OperationalReportCheckinRecord,
   type OperationalReportCheckinTimestampEditRecord,
+  type OperationalReportDdsResponsibilityRecord,
+  type OperationalReportLockupTransferRecord,
   type OperationalReportLockupStatusRecord,
   type OperationalReportMemberRecord,
   type OperationalReportMissedCheckoutRecord,
+  type OperationalReportResponsibilityAuditRecord,
   type OperationalReportScheduledDutyRoleCode,
   type OperationalReportScheduledDutyRecord,
   type OperationalReportUnitEventRecord,
@@ -137,6 +142,7 @@ interface DailyPresenceDayContextInternal {
   isTrainingNight: boolean
   isAdminNight: boolean
   keyNights: KeyNightWindow[]
+  operations: DailyPresenceOperationsContext
 }
 
 interface DailyPresenceAttendanceSummary {
@@ -714,6 +720,11 @@ export class OperationalReportService {
       allActiveMembers.every((member) => sessionsByMember.has(member.id))
         ? sessionsByMember
         : await this.getSessionsByMember(allActiveMembers, range, new Set<string>())
+    const operationsContext = await this.getDailyPresenceOperationsContext(
+      range,
+      allActiveMembers,
+      attendanceSessionsByMember
+    )
     const attendanceSummary = await this.getDailyPresenceAttendanceSummary(
       allActiveMembers,
       attendanceSessionsByMember,
@@ -788,6 +799,7 @@ export class OperationalReportService {
           isTrainingNight: dayContext.isTrainingNight,
           isAdminNight: dayContext.isAdminNight,
           keyNights: dayContext.keyNights.map(this.toApiKeyNight),
+          operations: operationsContext,
         },
         rows,
       },
@@ -1432,7 +1444,219 @@ export class OperationalReportService {
       isTrainingNight: keyNights.some((night) => night.category === 'training'),
       isAdminNight: keyNights.some((night) => night.category === 'administrative'),
       keyNights,
+      operations: this.emptyDailyPresenceOperationsContext(),
     }
+  }
+
+  private async getDailyPresenceOperationsContext(
+    range: DateRange,
+    members: OperationalReportMemberRecord[],
+    sessionsByMember: ReadonlyMap<string, PresenceSessionInternal[]>
+  ): Promise<DailyPresenceOperationsContext> {
+    const [responsibilityAuditRecords, ddsAssignments, lockupTransfers] = await Promise.all([
+      this.repository.findResponsibilityAuditRecords(range.start, range.end),
+      this.repository.findDdsResponsibilityForDate(
+        new Date(`${range.startDate}T00:00:00.000Z`),
+        new Date(`${range.endDate}T00:00:00.000Z`)
+      ),
+      this.repository.findLockupTransfersForRange(range.start, range.end),
+    ])
+    const firstSession = this.getFirstPresenceSession(members, sessionsByMember, range)
+    const peopleById = await this.getDailyPresenceOperationsPeopleById(
+      members,
+      responsibilityAuditRecords,
+      ddsAssignments,
+      lockupTransfers
+    )
+
+    return {
+      buildingOpening: this.getDailyPresenceBuildingOpening(
+        responsibilityAuditRecords,
+        firstSession,
+        peopleById
+      ),
+      ddsAcceptance: this.getDailyPresenceDdsAcceptance(
+        responsibilityAuditRecords,
+        ddsAssignments,
+        peopleById
+      ),
+      ddsTransfers: this.getDailyPresenceDdsTransfers(responsibilityAuditRecords, peopleById),
+      lockupTransfers: lockupTransfers.map((transfer) => ({
+        transferredAt: transfer.transferredAt.toISOString(),
+        from: this.toDutyPerson(transfer.fromMember),
+        to: this.toDutyPerson(transfer.toMember),
+        reason: transfer.reason,
+        notes: transfer.notes,
+      })),
+    }
+  }
+
+  private emptyDailyPresenceOperationsContext(): DailyPresenceOperationsContext {
+    return {
+      buildingOpening: null,
+      ddsAcceptance: null,
+      ddsTransfers: [],
+      lockupTransfers: [],
+    }
+  }
+
+  private getFirstPresenceSession(
+    members: OperationalReportMemberRecord[],
+    sessionsByMember: ReadonlyMap<string, PresenceSessionInternal[]>,
+    range: DateRange
+  ): { member: OperationalReportMemberRecord; inAt: Date } | null {
+    let firstSession: { member: OperationalReportMemberRecord; inAt: Date } | null = null
+
+    for (const member of members) {
+      for (const session of sessionsByMember.get(member.id) ?? []) {
+        if (session.inAt < range.start || session.inAt >= range.end) {
+          continue
+        }
+
+        if (!firstSession || session.inAt < firstSession.inAt) {
+          firstSession = { member, inAt: session.inAt }
+        }
+      }
+    }
+
+    return firstSession
+  }
+
+  private async getDailyPresenceOperationsPeopleById(
+    members: OperationalReportMemberRecord[],
+    responsibilityAuditRecords: OperationalReportResponsibilityAuditRecord[],
+    ddsAssignments: OperationalReportDdsResponsibilityRecord[],
+    lockupTransfers: OperationalReportLockupTransferRecord[]
+  ): Promise<Map<string, ReportDutyPerson>> {
+    const people = new Map<string, ReportDutyPerson>()
+    const addPerson = (person: {
+      id: string
+      rank: string
+      firstName: string
+      lastName: string
+      displayName: string | null
+    }) => {
+      people.set(person.id, this.toDutyPerson(person))
+    }
+
+    for (const member of members) {
+      addPerson(member)
+    }
+    for (const assignment of ddsAssignments) {
+      addPerson(assignment.member)
+    }
+    for (const transfer of lockupTransfers) {
+      addPerson(transfer.fromMember)
+      addPerson(transfer.toMember)
+    }
+
+    const unresolvedIds = new Set<string>()
+    for (const record of responsibilityAuditRecords) {
+      for (const memberId of [
+        record.memberId,
+        record.fromMemberId,
+        record.toMemberId,
+        record.performedBy,
+      ]) {
+        if (memberId && !people.has(memberId)) {
+          unresolvedIds.add(memberId)
+        }
+      }
+    }
+
+    const unresolvedPeople = await this.repository.findDutyPeopleByIds([...unresolvedIds])
+    for (const person of unresolvedPeople) {
+      addPerson(person)
+    }
+
+    return people
+  }
+
+  private getDailyPresenceBuildingOpening(
+    responsibilityAuditRecords: OperationalReportResponsibilityAuditRecord[],
+    firstSession: { member: OperationalReportMemberRecord; inAt: Date } | null,
+    peopleById: ReadonlyMap<string, ReportDutyPerson>
+  ): DailyPresenceOperationsContext['buildingOpening'] {
+    const openingRecord = responsibilityAuditRecords.find(
+      (record) => record.tagName === 'Lockup' && record.action === 'building_opened'
+    )
+    if (openingRecord) {
+      const openedBy = peopleById.get(openingRecord.memberId)
+      if (openedBy) {
+        return {
+          openedAt: openingRecord.timestamp.toISOString(),
+          openedBy,
+          source: 'building_opened',
+        }
+      }
+    }
+
+    if (!firstSession) {
+      return null
+    }
+
+    return {
+      openedAt: firstSession.inAt.toISOString(),
+      openedBy: this.toDutyPerson(firstSession.member),
+      source: 'first_checkin',
+    }
+  }
+
+  private getDailyPresenceDdsAcceptance(
+    responsibilityAuditRecords: OperationalReportResponsibilityAuditRecord[],
+    ddsAssignments: OperationalReportDdsResponsibilityRecord[],
+    peopleById: ReadonlyMap<string, ReportDutyPerson>
+  ): DailyPresenceOperationsContext['ddsAcceptance'] {
+    const acceptedAssignment = ddsAssignments.find((assignment) => assignment.acceptedAt !== null)
+    if (acceptedAssignment?.acceptedAt) {
+      return {
+        acceptedAt: acceptedAssignment.acceptedAt.toISOString(),
+        acceptedBy: this.toDutyPerson(acceptedAssignment.member),
+      }
+    }
+
+    const acceptedAuditRecord = responsibilityAuditRecords.find(
+      (record) =>
+        record.tagName === 'DDS' &&
+        (record.action === 'self_accepted' || record.action === 'accepted')
+    )
+    if (!acceptedAuditRecord) {
+      return null
+    }
+
+    const acceptedBy = peopleById.get(acceptedAuditRecord.memberId)
+    if (!acceptedBy) {
+      return null
+    }
+
+    return {
+      acceptedAt: acceptedAuditRecord.timestamp.toISOString(),
+      acceptedBy,
+    }
+  }
+
+  private getDailyPresenceDdsTransfers(
+    responsibilityAuditRecords: OperationalReportResponsibilityAuditRecord[],
+    peopleById: ReadonlyMap<string, ReportDutyPerson>
+  ): DailyPresenceResponsibilityTransfer[] {
+    return responsibilityAuditRecords
+      .filter((record) => record.tagName === 'DDS' && record.action === 'transferred')
+      .map((record): DailyPresenceResponsibilityTransfer | null => {
+        const toMemberId = record.toMemberId ?? record.memberId
+        const to = peopleById.get(toMemberId)
+        if (!to) {
+          return null
+        }
+
+        return {
+          transferredAt: record.timestamp.toISOString(),
+          from: record.fromMemberId ? (peopleById.get(record.fromMemberId) ?? null) : null,
+          to,
+          reason: 'dds_turnover',
+          notes: record.notes,
+        }
+      })
+      .filter((transfer): transfer is DailyPresenceResponsibilityTransfer => transfer !== null)
   }
 
   private async getDailyPresenceWorkingHours(

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.4.11",
+  "version": "3.4.12",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/app/globals.css
+++ b/apps/frontend-admin/src/app/globals.css
@@ -297,6 +297,10 @@
     display: none !important;
   }
 
+  .reports-print-hidden {
+    display: none !important;
+  }
+
   .reports-print-inline {
     display: inline !important;
   }
@@ -370,6 +374,11 @@
     gap: 0.03in !important;
   }
 
+  .reports-operations-context {
+    gap: 0.015in !important;
+    padding: 0.04in 0.07in !important;
+  }
+
   .reports-summary-grid,
   .reports-print-document section,
   .reports-print-document tr {
@@ -434,7 +443,6 @@
   }
 
   .reports-table .reports-member-cell,
-  .reports-table .reports-department-cell,
   .reports-table .reports-tags-cell {
     overflow-wrap: normal !important;
     word-break: normal !important;
@@ -450,60 +458,36 @@
     font-size: 6.8pt !important;
   }
 
-  .reports-daily-member-col {
-    width: 24%;
+  .reports-daily-presence-table {
+    table-layout: auto !important;
   }
 
-  .reports-daily-department-col {
-    width: 10%;
+  .reports-daily-presence-table .reports-daily-member-col,
+  .reports-daily-presence-table .reports-daily-tags-col,
+  .reports-daily-presence-table .reports-daily-time-col,
+  .reports-daily-presence-table .reports-daily-last-out-col {
+    width: 1% !important;
   }
 
-  .reports-daily-tags-col {
-    width: 28%;
+  .reports-daily-presence-table .reports-daily-details-col {
+    width: auto !important;
   }
 
-  .reports-daily-time-col {
-    width: 12%;
-  }
-
-  .reports-daily-last-out-col {
-    width: 12%;
-  }
-
-  .reports-daily-presence-col {
-    width: 14%;
-  }
-
-  .reports-daily-presence-table-with-details .reports-daily-member-col {
-    width: 20%;
-  }
-
-  .reports-daily-presence-table-with-details .reports-daily-department-col {
-    width: 8%;
-  }
-
-  .reports-daily-presence-table-with-details .reports-daily-tags-col {
-    width: 23%;
-  }
-
-  .reports-daily-presence-table-with-details .reports-daily-time-col {
-    width: 10%;
-  }
-
-  .reports-daily-presence-table-with-details .reports-daily-last-out-col {
-    width: 10%;
-  }
-
-  .reports-daily-presence-table-with-details .reports-daily-presence-col {
-    width: 9%;
-  }
-
-  .reports-daily-details-col {
-    width: 20%;
+  .reports-daily-presence-table th,
+  .reports-daily-presence-table td {
+    padding-right: 0.075in !important;
+    padding-left: 0.075in !important;
   }
 
   .reports-daily-presence-table .reports-tags-cell {
     color: oklch(21% 0.006 285.885) !important;
+  }
+
+  .reports-daily-presence-table th,
+  .reports-daily-presence-table .reports-member-cell,
+  .reports-daily-presence-table .reports-tags-cell,
+  .reports-daily-presence-table .reports-time-cell {
+    white-space: nowrap !important;
   }
 
   .reports-daily-presence-table .reports-session-cell {
@@ -512,6 +496,16 @@
 
   .reports-daily-presence-table .reports-details-cell {
     white-space: normal !important;
+  }
+
+  .reports-daily-presence-table .reports-detail-time {
+    font-size: 7.5pt !important;
+  }
+
+  .reports-daily-presence-table .reports-detail-direction-label,
+  .reports-daily-presence-table .reports-detail-text {
+    font-size: 6.8pt !important;
+    line-height: 1.08 !important;
   }
 }
 

--- a/apps/frontend-admin/src/components/admin/reports/report-formatters.test.ts
+++ b/apps/frontend-admin/src/components/admin/reports/report-formatters.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { formatReportDateTime, formatReportTime } from './report-formatters'
+
+describe('report formatters', () => {
+  it('formats report times in military HHmm style', () => {
+    const timestamp = new Date(2026, 5, 15, 8, 1).toISOString()
+
+    expect(formatReportTime(timestamp)).toBe('0801')
+  })
+
+  it('formats report date-times with military HHmm time', () => {
+    const timestamp = new Date(2026, 5, 15, 16, 30).toISOString()
+
+    expect(formatReportDateTime(timestamp)).toBe('Jun 15, 1630')
+  })
+
+  it('preserves invalid timestamp values for diagnosis', () => {
+    expect(formatReportTime('not-a-date')).toBe('not-a-date')
+    expect(formatReportDateTime('not-a-date')).toBe('not-a-date')
+  })
+})

--- a/apps/frontend-admin/src/components/admin/reports/report-formatters.ts
+++ b/apps/frontend-admin/src/components/admin/reports/report-formatters.ts
@@ -1,3 +1,17 @@
+const REPORT_LOCALE = 'en-CA'
+
+function formatMilitaryTime(date: Date): string {
+  const parts = new Intl.DateTimeFormat(REPORT_LOCALE, {
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+  }).formatToParts(date)
+  const hour = parts.find((part) => part.type === 'hour')?.value ?? '00'
+  const minute = parts.find((part) => part.type === 'minute')?.value ?? '00'
+
+  return `${hour}${minute}`
+}
+
 export function formatReportDateTime(value: string | null | undefined): string {
   if (!value) {
     return '—'
@@ -8,12 +22,12 @@ export function formatReportDateTime(value: string | null | undefined): string {
     return value
   }
 
-  return date.toLocaleString(undefined, {
+  const dateLabel = date.toLocaleDateString(REPORT_LOCALE, {
     month: 'short',
     day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
   })
+
+  return `${dateLabel}, ${formatMilitaryTime(date)}`
 }
 
 export function formatReportTime(value: string | null | undefined): string {
@@ -26,10 +40,7 @@ export function formatReportTime(value: string | null | undefined): string {
     return value
   }
 
-  return date.toLocaleTimeString(undefined, {
-    hour: '2-digit',
-    minute: '2-digit',
-  })
+  return formatMilitaryTime(date)
 }
 
 export function formatDuration(minutes: number | null | undefined): string {

--- a/apps/frontend-admin/src/components/admin/reports/report-preview.tsx
+++ b/apps/frontend-admin/src/components/admin/reports/report-preview.tsx
@@ -166,7 +166,7 @@ function ReportDocumentFrame({
           <dl className="grid gap-(--space-1) text-right text-xs text-base-content/65">
             <div>
               <dt className="font-semibold uppercase tracking-wide">Generated</dt>
-              <dd className="font-mono">{formatReportDateTime(report.generatedAt)}</dd>
+              <dd className="tabular-nums">{formatReportDateTime(report.generatedAt)}</dd>
             </div>
             <div>
               <dt className="font-semibold uppercase tracking-wide">By</dt>
@@ -262,35 +262,94 @@ function SummaryGrid({ items }: { items: Array<{ label: string; value: string | 
 function DailyPresenceDayContext({ report }: { report: DailyPresenceReportResponse }) {
   const { dayContext } = report.data
   const workingHours = dayContext.workingHours
+  const operationLines = getDailyPresenceOperationLines(dayContext.operations)
   const nightLabels = [
     dayContext.isTrainingNight ? 'Training Night' : null,
     dayContext.isAdminNight ? 'Admin Night' : null,
   ].filter((label): label is string => label !== null)
 
   return (
-    <div className="mb-(--space-3) flex flex-wrap items-center gap-(--space-2) text-xs text-base-content/65">
-      <span className="rounded-box bg-base-200 px-(--space-2) py-(--space-1)">
-        Working hours:{' '}
-        <span className="font-semibold text-base-content">
-          {workingHours ? formatTimeRangeLabel(workingHours.label) : 'Unavailable'}
-        </span>
-      </span>
-      {nightLabels.length > 0 ? (
-        nightLabels.map((label) => (
-          <span
-            key={label}
-            className="rounded-box border border-info/30 bg-info-fadded px-(--space-2) py-(--space-1) font-semibold text-info-fadded-content"
-          >
-            {label}
-          </span>
-        ))
-      ) : (
+    <div className="mb-(--space-3) grid gap-(--space-2) text-xs text-base-content/65">
+      <div className="flex flex-wrap items-center gap-(--space-2)">
         <span className="rounded-box bg-base-200 px-(--space-2) py-(--space-1)">
-          No Training/Admin Night
+          Working hours:{' '}
+          <span className="font-semibold text-base-content">
+            {workingHours ? formatTimeRangeLabel(workingHours.label) : 'Unavailable'}
+          </span>
         </span>
+        {nightLabels.length > 0 ? (
+          nightLabels.map((label) => (
+            <span
+              key={label}
+              className="rounded-box border border-info/30 bg-info-fadded px-(--space-2) py-(--space-1) font-semibold text-info-fadded-content"
+            >
+              {label}
+            </span>
+          ))
+        ) : (
+          <span className="rounded-box bg-base-200 px-(--space-2) py-(--space-1)">
+            No Training/Admin Night
+          </span>
+        )}
+      </div>
+      {operationLines.length > 0 && (
+        <dl className="reports-operations-context grid gap-(--space-1) rounded-box bg-base-200 px-(--space-2) py-(--space-2)">
+          {operationLines.map((line) => (
+            <div key={`${line.label}-${line.value}`} className="flex flex-wrap gap-x-(--space-1)">
+              <dt className="font-semibold text-base-content/60">{line.label}:</dt>
+              <dd className="text-base-content/80">{line.value}</dd>
+            </div>
+          ))}
+        </dl>
       )}
     </div>
   )
+}
+
+function getDailyPresenceOperationLines(
+  operations: DailyPresenceReportResponse['data']['dayContext']['operations']
+): Array<{ label: string; value: string }> {
+  const lines: Array<{ label: string; value: string }> = []
+
+  if (operations.buildingOpening) {
+    lines.push({
+      label:
+        operations.buildingOpening.source === 'building_opened'
+          ? 'Building opened'
+          : 'First check-in',
+      value: `${formatReportTime(operations.buildingOpening.openedAt)} by ${operations.buildingOpening.openedBy.displayName}`,
+    })
+  }
+
+  if (operations.ddsAcceptance) {
+    lines.push({
+      label: 'DDS accepted',
+      value: `${formatReportTime(operations.ddsAcceptance.acceptedAt)} by ${operations.ddsAcceptance.acceptedBy.displayName}`,
+    })
+  }
+
+  for (const transfer of operations.ddsTransfers) {
+    lines.push({
+      label: 'DDS turnover',
+      value: `${formatReportTime(transfer.transferredAt)} ${formatTransferPeople(transfer)}`,
+    })
+  }
+
+  for (const transfer of operations.lockupTransfers) {
+    lines.push({
+      label: 'Lockup transfer',
+      value: `${formatReportTime(transfer.transferredAt)} ${formatTransferPeople(transfer)}`,
+    })
+  }
+
+  return lines
+}
+
+function formatTransferPeople(
+  transfer: DailyPresenceReportResponse['data']['dayContext']['operations']['ddsTransfers'][number]
+): string {
+  const from = transfer.from?.displayName ?? 'Unassigned'
+  return `${from} to ${transfer.to.displayName}`
 }
 
 function formatTimeRangeLabel(label: string): string {
@@ -395,12 +454,12 @@ function DailyPresenceReport({ report }: { report: DailyPresenceReportResponse }
           { label: 'Scoped members', value: summary.totalScopedMembers },
           { label: 'FTS total', value: summary.ftsTotalMembers },
           {
-            label: 'FTS on time / late',
+            label: 'FTS attendance',
             value: report.data.dayContext.workingHours
               ? `${summary.ftsOnTimeCount} / ${summary.ftsLateCount}`
               : '— / —',
           },
-          { label: 'GEO checked in', value: summary.geoCheckedInCount },
+          { label: 'GEO attendance', value: summary.geoCheckedInCount },
         ]}
       />
 
@@ -419,8 +478,7 @@ function DailyPresenceReport({ report }: { report: DailyPresenceReportResponse }
           >
             <colgroup>
               <col className="reports-daily-member-col" />
-              <col className="reports-daily-presence-col" />
-              <col className="reports-daily-department-col" />
+              <col className="reports-daily-presence-col reports-print-hidden" />
               <col className="reports-daily-tags-col" />
               <col className="reports-daily-time-col" />
               <col className="reports-daily-last-out-col" />
@@ -429,8 +487,7 @@ function DailyPresenceReport({ report }: { report: DailyPresenceReportResponse }
             <thead>
               <tr>
                 <th>Member</th>
-                <th>Presence</th>
-                <th>Department</th>
+                <th className="reports-print-hidden">Presence</th>
                 <th>Tags</th>
                 <th>Check-In</th>
                 <th>Check-Out</th>
@@ -444,9 +501,12 @@ function DailyPresenceReport({ report }: { report: DailyPresenceReportResponse }
                 return (
                   <tr key={row.member.id}>
                     <td className="reports-member-cell">
-                      <MemberName member={row.member} />
+                      <MemberName
+                        member={row.member}
+                        secondaryLabel={getMemberDepartmentLabel(row.member)}
+                      />
                     </td>
-                    <td>
+                    <td className="reports-print-hidden">
                       <span className="reports-screen-only">
                         <span
                           role="status"
@@ -461,17 +521,14 @@ function DailyPresenceReport({ report }: { report: DailyPresenceReportResponse }
                           {isPresent ? 'Present' : 'Out'}
                         </span>
                       </span>
-                      <span className="hidden reports-print-inline font-mono">
+                      <span className="hidden reports-print-inline tabular-nums">
                         {isPresent ? 'Present' : 'Out'}
                       </span>
-                    </td>
-                    <td className="reports-department-cell">
-                      {row.member.division?.code ?? row.member.division?.name ?? 'Unassigned'}
                     </td>
                     <td className="reports-tags-cell">
                       <TagList tags={row.member.tags} />
                     </td>
-                    <td className="reports-time-cell font-mono">
+                    <td className="reports-time-cell tabular-nums">
                       <div className="grid gap-(--space-1)">
                         {row.sessions.map((session, sessionIndex) => (
                           <span key={`${row.member.id}-in-${session.inAt}-${sessionIndex}`}>
@@ -480,7 +537,7 @@ function DailyPresenceReport({ report }: { report: DailyPresenceReportResponse }
                         ))}
                       </div>
                     </td>
-                    <td className="reports-time-cell font-mono">
+                    <td className="reports-time-cell tabular-nums">
                       <div className="grid gap-(--space-1)">
                         {row.sessions.map((session, sessionIndex) => (
                           <span key={`${row.member.id}-out-${session.inAt}-${sessionIndex}`}>
@@ -498,15 +555,19 @@ function DailyPresenceReport({ report }: { report: DailyPresenceReportResponse }
                     {hasDetails && (
                       <td className="reports-details-cell">
                         {detailLines.length > 0 && (
-                          <div className="grid gap-(--space-1) text-xs leading-tight text-base-content/70">
+                          <div className="grid gap-(--space-1) leading-tight text-base-content/70">
                             {detailLines.map((line, lineIndex) => (
                               <span
                                 key={`${row.member.id}-detail-${lineIndex}`}
                                 className="flex flex-wrap items-center gap-x-(--space-1) gap-y-0.5"
                               >
-                                <span className="font-mono text-base-content/55">{line.time}</span>
+                                <span className="reports-detail-time tabular-nums text-xs text-base-content/55">
+                                  {line.time}
+                                </span>
                                 <DailyPresenceDetailDirectionBadge direction={line.direction} />
-                                <span>{line.text}</span>
+                                <span className="reports-detail-text text-[0.6875rem] leading-snug">
+                                  {line.text}
+                                </span>
                               </span>
                             ))}
                           </div>
@@ -543,7 +604,9 @@ function DailyPresenceDetailDirectionBadge({
       >
         {label}
       </span>
-      <span className="hidden reports-print-inline font-semibold">{label}</span>
+      <span className="reports-detail-direction-label hidden reports-print-inline font-semibold">
+        {label}
+      </span>
     </>
   )
 }
@@ -677,7 +740,7 @@ function TrainingNightMonthlyReport({ report }: { report: TrainingNightMonthlyRe
                       </td>
                     )
                   })}
-                  <td className="text-right font-mono">
+                  <td className="text-right tabular-nums">
                     {row.attended}/{row.possible} · {formatPercent(row.percentage)}
                   </td>
                 </tr>
@@ -742,8 +805,8 @@ function VisitorActivityReport({ report }: { report: VisitorActivityReportRespon
                     </div>
                   </td>
                   <td>{row.organization ?? '—'}</td>
-                  <td className="font-mono">{formatReportDateTime(row.checkInTime)}</td>
-                  <td className="font-mono">
+                  <td className="tabular-nums">{formatReportDateTime(row.checkInTime)}</td>
+                  <td className="tabular-nums">
                     {row.checkOutTime ? formatReportDateTime(row.checkOutTime) : 'Still present'}
                   </td>
                   <td>{row.event?.name ?? '—'}</td>
@@ -801,10 +864,14 @@ function OperationalExceptionsReport({ report }: { report: OperationalExceptions
                   <tbody>
                     {forcedCheckouts.map((row) => (
                       <tr key={row.id}>
-                        <td className="font-mono">{row.operationalDate}</td>
+                        <td className="tabular-nums">{row.operationalDate}</td>
                         <td className="font-semibold">{row.member.displayName}</td>
-                        <td className="font-mono">{formatReportDateTime(row.originalCheckinAt)}</td>
-                        <td className="font-mono">{formatReportDateTime(row.forcedCheckoutAt)}</td>
+                        <td className="tabular-nums">
+                          {formatReportDateTime(row.originalCheckinAt)}
+                        </td>
+                        <td className="tabular-nums">
+                          {formatReportDateTime(row.forcedCheckoutAt)}
+                        </td>
                         <td>{row.resolverLabel}</td>
                         <td>{row.notes ?? '—'}</td>
                       </tr>
@@ -838,12 +905,12 @@ function OperationalExceptionsReport({ report }: { report: OperationalExceptions
                   <tbody>
                     {lockupExceptions.map((row) => (
                       <tr key={row.id}>
-                        <td className="font-mono">{row.operationalDate}</td>
+                        <td className="tabular-nums">{row.operationalDate}</td>
                         <td>{row.buildingStatus}</td>
                         <td>{row.expectedDds?.displayName ?? '—'}</td>
                         <td>{row.expectedSwk?.displayName ?? '—'}</td>
                         <td>{row.expectedLockupHolder?.displayName ?? '—'}</td>
-                        <td className="font-mono">{row.systemForcedCheckoutCount}</td>
+                        <td className="tabular-nums">{row.systemForcedCheckoutCount}</td>
                         <td>{row.notes.join('; ')}</td>
                       </tr>
                     ))}
@@ -909,7 +976,7 @@ function PresenceMatrixTable({
                   <PresenceSymbol present={day.present} note={day.note} />
                 </td>
               ))}
-              <td className="text-right font-mono">{row.total}</td>
+              <td className="text-right tabular-nums">{row.total}</td>
               {row.trailing.map((value, index) => (
                 <td key={`${row.member.id}-${trailingHeaders[index]}`} className="text-right">
                   {value}
@@ -979,11 +1046,21 @@ function PresenceSymbol({
   )
 }
 
-function MemberName({ member }: { member: ReportMemberSummary }) {
+function getMemberDepartmentLabel(member: ReportMemberSummary): string {
+  return member.division?.code ?? member.division?.name ?? 'Unassigned'
+}
+
+function MemberName({
+  member,
+  secondaryLabel = member.memberType ?? 'Member',
+}: {
+  member: ReportMemberSummary
+  secondaryLabel?: string
+}) {
   return (
     <div>
       <p className="font-semibold leading-tight">{member.displayName}</p>
-      <p className="text-xs text-base-content/55">{member.memberType ?? 'Member'}</p>
+      <p className="text-xs text-base-content/55">{secondaryLabel}</p>
     </div>
   )
 }

--- a/apps/frontend-admin/src/components/dashboard/status-stats.tsx
+++ b/apps/frontend-admin/src/components/dashboard/status-stats.tsx
@@ -305,13 +305,16 @@ function BuildingStat({
   const StatusIcon = display.Icon
 
   const getDesc = () => {
+    if (lockupStatus?.openedAt && lockupStatus.openedBy) {
+      return `Opened by ${formatMemberName(lockupStatus.openedBy)} at ${formatTime(lockupStatus.openedAt)}`
+    }
+    if (lockupStatus?.openedAt) {
+      return `Opened at ${formatTime(lockupStatus.openedAt)}`
+    }
     if (lockupStatus?.buildingStatus === 'secured' && lockupStatus.securedBy) {
       return `Secured by ${formatMemberName(lockupStatus.securedBy)}${lockupStatus.securedAt ? ` at ${formatTime(lockupStatus.securedAt)}` : ''}`
     }
-    if (lockupStatus?.currentHolder && lockupStatus.buildingStatus !== 'secured') {
-      return `Held by ${formatMemberName(lockupStatus.currentHolder)}${lockupStatus.acquiredAt ? ` since ${formatTime(lockupStatus.acquiredAt)}` : ''}`
-    }
-    return 'No lockup in progress'
+    return 'No opening recorded today'
   }
 
   if (display.label === 'Secured') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.4.11",
+  "version": "3.4.12",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.4.11",
+  "version": "3.4.12",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/contracts/src/schemas/lockup.schema.ts
+++ b/packages/contracts/src/schemas/lockup.schema.ts
@@ -28,6 +28,8 @@ export const LockupStatusResponseSchema = v.object({
   buildingStatus: BuildingStatusSchema,
   currentHolder: v.nullable(LockupHolderSchema),
   acquiredAt: v.nullable(v.string()), // ISO datetime
+  openedBy: v.nullable(LockupHolderSchema),
+  openedAt: v.nullable(v.string()), // ISO datetime
   securedAt: v.nullable(v.string()), // ISO datetime
   securedBy: v.nullable(LockupHolderSchema),
   isActive: v.boolean(),

--- a/packages/contracts/src/schemas/report.schema.ts
+++ b/packages/contracts/src/schemas/report.schema.ts
@@ -493,11 +493,58 @@ export const DailyPresenceWorkingHoursSchema = v.object({
 
 export type DailyPresenceWorkingHours = v.InferOutput<typeof DailyPresenceWorkingHoursSchema>
 
+const DailyPresenceOperationsPersonSchema = v.object({
+  id: v.string(),
+  displayName: v.string(),
+  rank: v.string(),
+})
+
+export type DailyPresenceOperationsPerson = v.InferOutput<
+  typeof DailyPresenceOperationsPersonSchema
+>
+
+export const DailyPresenceBuildingOpeningSchema = v.object({
+  openedAt: v.string(),
+  openedBy: DailyPresenceOperationsPersonSchema,
+  source: v.picklist(['building_opened', 'first_checkin']),
+})
+
+export type DailyPresenceBuildingOpening = v.InferOutput<typeof DailyPresenceBuildingOpeningSchema>
+
+export const DailyPresenceResponsibilityTransferSchema = v.object({
+  transferredAt: v.string(),
+  from: v.nullable(DailyPresenceOperationsPersonSchema),
+  to: DailyPresenceOperationsPersonSchema,
+  reason: v.nullable(v.string()),
+  notes: v.nullable(v.string()),
+})
+
+export type DailyPresenceResponsibilityTransfer = v.InferOutput<
+  typeof DailyPresenceResponsibilityTransferSchema
+>
+
+export const DailyPresenceOperationsContextSchema = v.object({
+  buildingOpening: v.nullable(DailyPresenceBuildingOpeningSchema),
+  ddsAcceptance: v.nullable(
+    v.object({
+      acceptedAt: v.string(),
+      acceptedBy: DailyPresenceOperationsPersonSchema,
+    })
+  ),
+  ddsTransfers: v.array(DailyPresenceResponsibilityTransferSchema),
+  lockupTransfers: v.array(DailyPresenceResponsibilityTransferSchema),
+})
+
+export type DailyPresenceOperationsContext = v.InferOutput<
+  typeof DailyPresenceOperationsContextSchema
+>
+
 export const DailyPresenceDayContextSchema = v.object({
   workingHours: v.nullable(DailyPresenceWorkingHoursSchema),
   isTrainingNight: v.boolean(),
   isAdminNight: v.boolean(),
   keyNights: v.array(KeyNightSchema),
+  operations: DailyPresenceOperationsContextSchema,
 })
 
 export type DailyPresenceDayContext = v.InferOutput<typeof DailyPresenceDayContextSchema>

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.4.11",
+  "version": "3.4.12",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.4.11",
+  "version": "3.4.12",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Adds Daily Presence report context for building opening, DDS acceptance, DDS turnover, and lockup transfers.
- Updates Daily Presence report layout for staff review: department appears under the member name, Presence is hidden for print/PDF, Details is more compact, and report times use military format.
- Updates Dashboard Building Status to show who first opened the building today and when it was opened.
- Prepares Sentinel v3.4.12 by syncing root and workspace package versions.

## Why this change was needed

Staff Officers need the Daily Presence report to explain the operational state of the day, not just who scanned in. Building opening, DDS responsibility, and lockup/DDS handoffs are important attendance context and should be visible when reviewing the day’s report.

## What changed

### User-facing

- Daily Presence now includes a compact operations context section near Working Hours.
- The report shows the real building-open event when available, or falls back to the first check-in for the day.
- DDS acceptance and DDS turnover details are included when recorded.
- Lockup transfers are included when recorded.
- Daily Presence print/PDF output hides the Presence column, uses department under Member instead of contract type, uses military-style times, and gives the Details column more room.
- Dashboard Building Status shows who first opened the building today and at what time.

### Backend/API

- Extends Daily Presence report day context with existing operational records from check-ins, DDS assignments, responsibility audit logs, and lockup transfers.
- Extends lockup status responses with first-opening metadata for the Dashboard.

### Database

- No database migration required. This reads existing records.

### Deployment/update

- Version synced to `3.4.12` across the monorepo.

### Tests

- Adds formatter coverage for military report time output.
- Adds service coverage for Daily Presence operations context and first-check-in fallback.
- Adds lockup service coverage for first opening metadata.

## User impact

Staff reviewing Daily Presence will see more useful operational context at the top of the report, with less wasted space in print/PDF output.

## Operator impact

No new configuration is required. Existing responsibility audit, DDS, lockup, and check-in records are used.

## Upgrade or migration notes

No upgrade action required beyond deploying the patch release. No database migration is required.

## Risk and rollback notes

Main risk is report context rendering incomplete if older data lacks audit records. The report falls back to first check-in for building opening when no building-open record exists. Rollback is safe because no schema migration or data rewrite is included.

## Testing performed

- `pnpm --filter frontend-admin exec vitest run src/components/admin/reports/report-formatters.test.ts`
- `pnpm --filter frontend-admin typecheck`
- `pnpm --filter backend typecheck`
- `pnpm --filter frontend-admin lint --quiet`
- `pnpm version:check`
- `git diff --check`

Backend Vitest service tests were updated but could not be run locally because the backend package does not expose a `vitest` binary in this workspace.

## Changelog candidates

- Added building opening, DDS acceptance, DDS turnover, and lockup transfer context to Daily Presence reports.
- Improved Daily Presence print/PDF layout and switched report times to military format.
- Updated Dashboard Building Status to show who opened the building today and when.
