### PR TITLE
fix(access-rules): restore bulk policy saves

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.4.14",
+  "version": "3.4.15",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/routes/access-rules.test.ts
+++ b/apps/backend/src/routes/access-rules.test.ts
@@ -1,0 +1,44 @@
+import { createExpressEndpoints } from '@ts-rest/express'
+import { accessRuleContract } from '@sentinel/contracts'
+import express from 'express'
+import request from 'supertest'
+import { describe, expect, it } from 'vitest'
+import { accessRulesRouter } from './access-rules.js'
+
+function createTestApp() {
+  const app = express()
+  app.use(express.json())
+  createExpressEndpoints(accessRuleContract, accessRulesRouter, app, {
+    requestValidationErrorHandler: (err, _req, res) => {
+      return res.status(400).json({
+        error: 'VALIDATION_ERROR',
+        message: 'Request validation failed',
+        issues: err.body?.issues || err.pathParams?.issues || err.query?.issues || [],
+      })
+    },
+  })
+  return app
+}
+
+describe('accessRulesRouter', () => {
+  it('routes bulk updates without validating bulk as an Access Rule key', async () => {
+    const response = await request(createTestApp())
+      .patch('/api/access-rules/bulk/update')
+      .send({
+        reason: 'Routine policy adjustment',
+        changes: [
+          {
+            key: 'dashboard.view',
+            configuredMinimumLevel: 2,
+            localDescription: null,
+          },
+        ],
+      })
+
+    expect(response.status).toBe(401)
+    expect(response.body).toMatchObject({
+      error: 'UNAUTHORIZED',
+      message: 'Authentication required',
+    })
+  })
+})

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.4.14",
+  "version": "3.4.15",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.4.14",
+  "version": "3.4.15",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.4.14",
+  "version": "3.4.15",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/contracts/src/contracts/access-rule.contract.ts
+++ b/packages/contracts/src/contracts/access-rule.contract.ts
@@ -40,7 +40,7 @@ export const accessRuleContract = c.router({
 
   bulkUpdateRules: {
     method: 'PATCH',
-    path: '/api/access-rules/bulk',
+    path: '/api/access-rules/bulk/update',
     body: BulkUpdateAccessRulesSchema,
     responses: {
       200: BulkAccessRuleUpdateResponseSchema,

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.4.14",
+  "version": "3.4.15",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.4.14",
+  "version": "3.4.15",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Fixes Access Rules bulk saves failing with `Request validation failed`.
- Moves the bulk update endpoint away from the single-rule `:key` route so `bulk` is no longer treated as an Access Rule key.
- Adds a backend route regression test for the bulk update path.
- Prepares patch release `v3.4.15`.

## Why this change was needed

Access Rules bulk saves were routed through `/api/access-rules/:key` before they reached the bulk handler. The backend validated the path segment `bulk` as a dotted Access Rule key and rejected the request before any policy changes could be saved.

## What changed

### User-facing

- Developers can save Access Rule policy changes from Settings again.

### Admin/operator-facing

- No manual operator action is required beyond installing the patch release.

### Backend/API

- Changes the bulk Access Rules endpoint from `/api/access-rules/bulk` to `/api/access-rules/bulk/update` to avoid the parameter route collision.
- Adds a regression test that confirms the bulk route reaches authentication instead of request validation.

### Database

- No database migration required.

### Deployment/update

- Workspace package versions are bumped to `3.4.15`.

### Tests

- Added backend route coverage for the Access Rules bulk update route.

## User impact

Developers using the Access Rules settings page can save reviewed policy changes without hitting the generic request validation error.

## Operator impact

Operators should update to `v3.4.15` to restore Access Rules bulk-save behavior. No database or configuration changes are needed.

## Upgrade or migration notes

No upgrade action required beyond deploying the patch release.

## Risk and rollback notes

Risk is low and isolated to the Access Rules bulk update endpoint. Rollback to `v3.4.14` is safe for data compatibility, but it restores the bulk-save route collision.

## Testing performed

- Reproduced the old route collision and confirmed the new route reaches authentication.
- `pnpm --filter @sentinel/contracts typecheck`
- `pnpm --filter @sentinel/backend typecheck`
- `pnpm --filter frontend-admin typecheck`
- `pnpm --filter @sentinel/backend lint`
- Targeted Access Rules route regression test via the available Vitest runner.

## Changelog candidates

- Fixed Access Rules bulk saves failing with request validation because the bulk route was being handled as a single-rule key.
