### PR TITLE
fix(auth): keep first daily login stable

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.4.16",
+  "version": "3.4.17",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/services/auth-service.test.ts
+++ b/apps/backend/src/services/auth-service.test.ts
@@ -290,4 +290,83 @@ describe('AuthService', () => {
 
     expect(sessionRepository.endById).toHaveBeenCalledWith('session-1', 'auto_checkin_failed')
   })
+
+  it('keeps login successful when presence broadcasting fails after auto checkin', async () => {
+    const prisma = createPrismaMock()
+    const service = new AuthService(prisma)
+    const sessionRepository = attachSessionRepository(service)
+    const checkinRepository = attachCheckinRepository(service)
+    const presenceService = attachPresenceService(service)
+    attachAuditRepository(service)
+
+    presenceService.broadcastStatsUpdate.mockRejectedValueOnce(new Error('stats unavailable'))
+
+    await expect(
+      service.login(
+        'serial-1',
+        {
+          remoteSystemId: 'remote-1',
+          remoteSystemName: 'Server',
+        },
+        '127.0.0.1',
+        'vitest'
+      )
+    ).resolves.toMatchObject({
+      sessionId: 'session-1',
+      member: {
+        id: 'member-1',
+      },
+    })
+
+    expect(checkinRepository.create).toHaveBeenCalled()
+    expect(sessionRepository.endById).not.toHaveBeenCalled()
+  })
+
+  it('keeps first post-reset login successful when presence broadcasting fails', async () => {
+    const prisma = createPrismaMock()
+    const service = new AuthService(prisma)
+    const sessionRepository = attachSessionRepository(service)
+    const checkinRepository = attachCheckinRepository(service)
+    const presenceService = attachPresenceService(service)
+    attachAuditRepository(service)
+
+    checkinRepository.findLatestByMember.mockResolvedValue({
+      id: 'daily-reset-checkout',
+      memberId: 'member-1',
+      direction: 'out',
+      timestamp: new Date('2026-04-02T03:00:00.000Z'),
+      kioskId: 'SYSTEM',
+      method: 'system',
+      synced: true,
+      createdAt: new Date('2026-04-02T03:00:00.000Z'),
+    })
+    presenceService.broadcastStatsUpdate.mockRejectedValueOnce(new Error('stats unavailable'))
+
+    await expect(
+      service.login(
+        'serial-1',
+        {
+          remoteSystemId: 'remote-1',
+          remoteSystemName: 'Server',
+        },
+        '127.0.0.1',
+        'vitest'
+      )
+    ).resolves.toMatchObject({
+      sessionId: 'session-1',
+      member: {
+        id: 'member-1',
+      },
+    })
+
+    expect(checkinRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        memberId: 'member-1',
+        direction: 'in',
+        kioskId: 'remote-1',
+        method: 'login',
+      })
+    )
+    expect(sessionRepository.endById).not.toHaveBeenCalled()
+  })
 })

--- a/apps/backend/src/services/auth-service.ts
+++ b/apps/backend/src/services/auth-service.ts
@@ -294,37 +294,64 @@ export class AuthService {
       synced: true,
     })
 
-    broadcastCheckin({
-      id: checkin.id,
-      memberId,
-      memberName: member.displayName ?? `${member.firstName} ${member.lastName}`,
-      rank: member.rank,
-      division: member.division?.name ?? 'Unknown',
-      direction: 'in',
-      timestamp: checkin.timestamp.toISOString(),
-      kioskId: remoteSystemId,
-    })
-
-    await this.presenceService.broadcastStatsUpdate()
-
-    await this.auditRepo.log({
-      adminUserId: null,
-      action: 'checkin_login',
-      entityType: 'checkin',
-      entityId: checkin.id,
-      details: {
-        actorMemberId: member.id,
-        actorName: formatAuditMemberName(member),
-        actorServiceNumber: member.serviceNumber,
-        actorType: 'member',
-        memberName: formatAuditMemberName(member),
-        memberRank: member.rank,
+    try {
+      broadcastCheckin({
+        id: checkin.id,
+        memberId,
+        memberName: member.displayName ?? `${member.firstName} ${member.lastName}`,
+        rank: member.rank,
+        division: member.division?.name ?? 'Unknown',
         direction: 'in',
+        timestamp: checkin.timestamp.toISOString(),
         kioskId: remoteSystemId,
-        method: 'login',
-      },
-      ipAddress: 'unknown',
-    })
+      })
+    } catch (error) {
+      authLogger.error('Login check-in broadcast failed after check-in creation', {
+        memberId,
+        checkinId: checkin.id,
+        remoteSystemId,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      })
+    }
+
+    try {
+      await this.presenceService.broadcastStatsUpdate()
+    } catch (error) {
+      authLogger.error('Login presence stats broadcast failed after check-in creation', {
+        memberId,
+        checkinId: checkin.id,
+        remoteSystemId,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      })
+    }
+
+    try {
+      await this.auditRepo.log({
+        adminUserId: null,
+        action: 'checkin_login',
+        entityType: 'checkin',
+        entityId: checkin.id,
+        details: {
+          actorMemberId: member.id,
+          actorName: formatAuditMemberName(member),
+          actorServiceNumber: member.serviceNumber,
+          actorType: 'member',
+          memberName: formatAuditMemberName(member),
+          memberRank: member.rank,
+          direction: 'in',
+          kioskId: remoteSystemId,
+          method: 'login',
+        },
+        ipAddress: 'unknown',
+      })
+    } catch (error) {
+      authLogger.error('Login check-in audit log failed after check-in creation', {
+        memberId,
+        checkinId: checkin.id,
+        remoteSystemId,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      })
+    }
 
     return {
       created: true,

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.4.16",
+  "version": "3.4.17",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/components/auth/auth-hydrator.logic.test.ts
+++ b/apps/frontend-admin/src/components/auth/auth-hydrator.logic.test.ts
@@ -28,8 +28,32 @@ describe('auth hydrator logic', () => {
       shouldIgnoreStaleUnauthorizedSessionCheck({
         wasAuthenticatedAtRequestStart: true,
         isAuthenticatedNow: true,
+        sessionIdAtRequestStart: 'session-1',
+        sessionIdNow: 'session-1',
       })
     ).toBe(false)
+  })
+
+  it('ignores stale unauthorized responses when a different session became current', () => {
+    expect(
+      shouldIgnoreStaleUnauthorizedSessionCheck({
+        wasAuthenticatedAtRequestStart: true,
+        isAuthenticatedNow: true,
+        sessionIdAtRequestStart: 'session-1',
+        sessionIdNow: 'session-2',
+      })
+    ).toBe(true)
+  })
+
+  it('ignores a daily-reset-ended session check after a fresh login becomes current', () => {
+    expect(
+      shouldIgnoreStaleUnauthorizedSessionCheck({
+        wasAuthenticatedAtRequestStart: true,
+        isAuthenticatedNow: true,
+        sessionIdAtRequestStart: 'session-ended-by-daily-reset',
+        sessionIdNow: 'session-created-by-first-login',
+      })
+    ).toBe(true)
   })
 
   it('does not start session heartbeats while a fresh login is still on the login page', () => {

--- a/apps/frontend-admin/src/components/auth/auth-hydrator.logic.ts
+++ b/apps/frontend-admin/src/components/auth/auth-hydrator.logic.ts
@@ -1,9 +1,27 @@
 export function shouldIgnoreStaleUnauthorizedSessionCheck(input: {
   wasAuthenticatedAtRequestStart: boolean
   isAuthenticatedNow: boolean
+  sessionIdAtRequestStart?: string | null
+  sessionIdNow?: string | null
 }): boolean {
-  const { wasAuthenticatedAtRequestStart, isAuthenticatedNow } = input
-  return !wasAuthenticatedAtRequestStart && isAuthenticatedNow
+  const {
+    wasAuthenticatedAtRequestStart,
+    isAuthenticatedNow,
+    sessionIdAtRequestStart = null,
+    sessionIdNow = null,
+  } = input
+
+  if (!isAuthenticatedNow) {
+    return false
+  }
+
+  if (!wasAuthenticatedAtRequestStart) {
+    return true
+  }
+
+  return Boolean(
+    sessionIdAtRequestStart && sessionIdNow && sessionIdAtRequestStart !== sessionIdNow
+  )
 }
 
 export function shouldRunSessionHeartbeat(input: {

--- a/apps/frontend-admin/src/components/auth/auth-hydrator.tsx
+++ b/apps/frontend-admin/src/components/auth/auth-hydrator.tsx
@@ -25,7 +25,9 @@ export function AuthHydrator() {
   const shouldHeartbeat = shouldRunSessionHeartbeat({ isAuthenticated, pathname })
 
   const validateSession = useEffectEvent(async () => {
-    const wasAuthenticatedAtRequestStart = useAuthStore.getState().isAuthenticated
+    const authStateAtRequestStart = useAuthStore.getState()
+    const wasAuthenticatedAtRequestStart = authStateAtRequestStart.isAuthenticated
+    const sessionIdAtRequestStart = authStateAtRequestStart.session?.sessionId ?? null
 
     try {
       const response = await apiClient.auth.getSession()
@@ -44,10 +46,13 @@ export function AuthHydrator() {
       }
 
       if (response.status === 401) {
+        const authStateNow = useAuthStore.getState()
         if (
           shouldIgnoreStaleUnauthorizedSessionCheck({
             wasAuthenticatedAtRequestStart,
-            isAuthenticatedNow: useAuthStore.getState().isAuthenticated,
+            isAuthenticatedNow: authStateNow.isAuthenticated,
+            sessionIdAtRequestStart,
+            sessionIdNow: authStateNow.session?.sessionId ?? null,
           })
         ) {
           return

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.4.16",
+  "version": "3.4.17",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.4.16",
+  "version": "3.4.17",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.4.16",
+  "version": "3.4.17",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.4.16",
+  "version": "3.4.17",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Keeps member login successful after the login check-in record has already been created, even if presence broadcasting or check-in audit side effects fail.
- Prevents stale session-validation responses from clearing a newer session created during first login after daily reset.
- Prepares the v3.4.17 patch release across the Sentinel workspace packages.

## Why this change was needed

Users reported that the first Sentinel login of the day could fail multiple times before succeeding. Daily reset ends active sessions and creates overnight checkout records, which makes the first morning login especially sensitive to stale browser auth state and post-check-in side effects.

## What changed

### User-facing

- First login after daily reset should no longer fail because a non-critical presence broadcast failed after the login check-in was already recorded.

### Admin/operator-facing

- Backend logs now retain structured errors when login check-in broadcast, presence stats broadcast, or check-in audit logging fail after check-in creation.

### Backend/API

- Login auto-check-in now treats post-check-in broadcast/audit work as non-blocking.
- Added regression coverage for normal and first-post-reset login when presence broadcasting fails.

### Frontend

- Auth hydration now ignores stale unauthorized responses when a different, newer session has become current.
- Added regression coverage for the daily-reset-ended-session race.

### Database

- No database schema changes.

### Deployment/update

- Workspace package versions are bumped to 3.4.17.

### Tests

- Added backend and frontend regression tests for first-login stability.

## User impact

Members should be able to sign in successfully on the first attempt after the overnight daily reset, even if a non-critical presence update fails in the background.

## Operator impact

Operators may still see backend log entries for non-critical login side-effect failures, but those failures should no longer block a valid login once the check-in is recorded.

## Upgrade or migration notes

No upgrade action required beyond deploying v3.4.17. No database migration or configuration change is required.

## Risk and rollback notes

Main risk is that a check-in audit side-effect failure may no longer block login after the check-in is created. The failure is still logged for operator investigation. Rollback to v3.4.16 is safe from a database compatibility perspective.

## Testing performed

- `pnpm version:check`
- `./apps/frontend-admin/node_modules/.bin/vitest run apps/backend/src/services/auth-service.test.ts apps/backend/src/routes/auth.test.ts apps/backend/src/routes/remote-systems.test.ts --root .`
- `pnpm --filter frontend-admin exec vitest run src/components/auth/auth-hydrator.logic.test.ts src/store/auth-store.test.ts src/components/auth/remote-system-login.logic.test.ts`
- `pnpm --filter @sentinel/backend typecheck`
- `pnpm --filter frontend-admin typecheck`
- `pnpm --filter @sentinel/backend lint`
- `pnpm --filter frontend-admin lint`

## Changelog candidates

- Fixed a first-login-after-daily-reset failure where Sentinel could reject a valid login after recording the check-in if a non-critical presence broadcast failed.
- Fixed a stale session-validation race that could clear a newly created login session after daily reset.
