### PR TITLE
fix(dds): show daily responsibility prompt after login

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/backend",
-  "version": "3.4.17",
+  "version": "3.4.18",
   "private": true,
   "description": "Backend API for Sentinel RFID Attendance System",
   "main": "./src/index.ts",

--- a/apps/backend/src/routes/dds.ts
+++ b/apps/backend/src/routes/dds.ts
@@ -185,6 +185,56 @@ export const ddsRouter = s.router(ddsContract, {
     }
   },
 
+  getLoginResponsibilityState: async ({ req }: { req: Request }) => {
+    try {
+      if (!req.member) {
+        return {
+          status: 401 as const,
+          body: {
+            error: 'UNAUTHORIZED',
+            message: 'Authentication required',
+          },
+        }
+      }
+
+      const state = await ddsService.getLoginResponsibilityState(req.member.id)
+
+      return {
+        status: 200 as const,
+        body: state,
+      }
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('not found')) {
+        return {
+          status: 404 as const,
+          body: {
+            error: 'NOT_FOUND',
+            message: error.message,
+          },
+        }
+      }
+
+      if (error instanceof Error && error.message.includes('Invalid')) {
+        return {
+          status: 400 as const,
+          body: {
+            error: 'VALIDATION_ERROR',
+            message: error.message,
+          },
+        }
+      }
+
+      return {
+        status: 500 as const,
+        body: {
+          error: 'INTERNAL_ERROR',
+          message:
+            error instanceof Error ? error.message : 'Failed to fetch login responsibility state',
+        },
+      }
+    }
+  },
+
   getKioskResponsibilityState: async ({ params }: { params: IdParam }) => {
     try {
       const state = await ddsService.getKioskResponsibilityState(params.id)

--- a/apps/frontend-admin/package.json
+++ b/apps/frontend-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-admin",
-  "version": "3.4.17",
+  "version": "3.4.18",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/frontend-admin/src/app/layout.tsx
+++ b/apps/frontend-admin/src/app/layout.tsx
@@ -10,6 +10,7 @@ import { queryClient } from '@/lib/query-client'
 import { AppNavbar } from '@/components/layout/app-navbar'
 import { AppSidebar } from '@/components/layout/app-sidebar'
 import { AuthHydrator } from '@/components/auth/auth-hydrator'
+import { DailyResponsibilityGate } from '@/components/dashboard/daily-responsibility-gate'
 import { AutomatedHotspotRecoveryNotice } from '@/components/network/automated-hotspot-recovery-notice'
 import './globals.css'
 
@@ -48,6 +49,7 @@ export default function RootLayout({
               <div className="drawer-content flex flex-col">
                 <AppNavbar drawerId={DRAWER_ID} isDrawerOpen={isDrawerOpen} />
                 <main className="flex-1 overflow-y-auto p-4 lg:p-6">{children}</main>
+                <DailyResponsibilityGate />
               </div>
 
               {/* Sidebar */}

--- a/apps/frontend-admin/src/components/dashboard/daily-responsibility-gate.tsx
+++ b/apps/frontend-admin/src/components/dashboard/daily-responsibility-gate.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { KioskResponsibilityPrompt } from '@/components/kiosk/kiosk-responsibility-prompt'
+import { useAcceptDds, useLoginResponsibilityState } from '@/hooks/use-dds'
+import type { ResponsibilityActionChoice } from '@/components/kiosk/kiosk-responsibility-prompt.logic'
+import { useOpenBuilding } from '@/hooks/use-lockup'
+import { invalidateDashboardQueries } from '@/lib/dashboard-query-invalidation'
+import { queryClient } from '@/lib/query-client'
+import { useAuthStore } from '@/store/auth-store'
+
+export function DailyResponsibilityGate() {
+  const member = useAuthStore((state) => state.member)
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated)
+  const [dismissedMemberId, setDismissedMemberId] = useState<string | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const loginStateQuery = useLoginResponsibilityState(isAuthenticated && Boolean(member?.id))
+  const acceptDdsMutation = useAcceptDds()
+  const openBuildingMutation = useOpenBuilding()
+
+  const responsibilityState = loginStateQuery.data ?? null
+  const shouldShowPrompt = Boolean(
+    member &&
+    responsibilityState?.shouldPrompt &&
+    dismissedMemberId !== member.id &&
+    !loginStateQuery.isLoading
+  )
+  const isPending =
+    acceptDdsMutation.isPending || openBuildingMutation.isPending || loginStateQuery.isFetching
+
+  const refreshResponsibilityState = async () => {
+    await Promise.allSettled([
+      loginStateQuery.refetch(),
+      queryClient.invalidateQueries({ queryKey: ['dds-status'] }),
+      queryClient.invalidateQueries({ queryKey: ['lockup-status'] }),
+      invalidateDashboardQueries(queryClient),
+    ])
+  }
+
+  const handleSubmit = async (action: ResponsibilityActionChoice) => {
+    if (!member) {
+      return
+    }
+
+    setErrorMessage(null)
+
+    try {
+      if (action === 'accept_dds') {
+        await acceptDdsMutation.mutateAsync(member.id)
+        toast.success('DDS responsibility accepted')
+      } else {
+        await openBuildingMutation.mutateAsync({
+          memberId: member.id,
+          data: { note: 'Opened from Sentinel login responsibility prompt' },
+        })
+        setDismissedMemberId(member.id)
+        toast.warning('Building opened. DDS still needs to be accepted.')
+      }
+
+      await refreshResponsibilityState()
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : 'Failed to update daily responsibility.'
+      )
+    }
+  }
+
+  const handleDecline = () => {
+    if (member) {
+      setDismissedMemberId(member.id)
+    }
+
+    setErrorMessage(null)
+  }
+
+  if (!shouldShowPrompt || !responsibilityState) {
+    return null
+  }
+
+  return (
+    <KioskResponsibilityPrompt
+      mode="login"
+      state={responsibilityState}
+      isPending={isPending}
+      errorMessage={errorMessage}
+      onDecline={handleDecline}
+      onSubmit={handleSubmit}
+    />
+  )
+}

--- a/apps/frontend-admin/src/components/kiosk/kiosk-responsibility-prompt.logic.test.ts
+++ b/apps/frontend-admin/src/components/kiosk/kiosk-responsibility-prompt.logic.test.ts
@@ -58,19 +58,29 @@ function createState(
 }
 
 describe('getKioskResponsibilityPromptPresentation', () => {
-  it('defaults the expected DDS flow to accepting DDS and opening the building', () => {
+  it('shows accepting DDS as the only expected DDS action when the member can accept', () => {
     const state = createState()
 
     const presentation = getKioskResponsibilityPromptPresentation(state)
 
     expect(presentation.defaultAction).toBe('accept_dds')
-    expect(presentation.actionOptions.map((option) => option.value)).toEqual([
-      'accept_dds',
-      'open_building',
-    ])
+    expect(presentation.headline).toBe("You're today's DDS. Accept responsibility now.")
+    expect(presentation.actionOptions.map((option) => option.value)).toEqual(['accept_dds'])
     expect(getResponsibilityPrimaryLabel(state, presentation.defaultAction ?? 'accept_dds')).toBe(
       'Accept DDS and Open Building'
     )
+  })
+
+  it('falls back to open building for the expected DDS only when DDS acceptance is unavailable', () => {
+    const state = createState({
+      canAcceptDds: false,
+      canOpenBuilding: true,
+    })
+
+    const presentation = getKioskResponsibilityPromptPresentation(state)
+
+    expect(presentation.defaultAction).toBe('open_building')
+    expect(presentation.actionOptions.map((option) => option.value)).toEqual(['open_building'])
   })
 
   it('defaults the replacement candidate flow to opening the building first', () => {

--- a/apps/frontend-admin/src/components/kiosk/kiosk-responsibility-prompt.logic.ts
+++ b/apps/frontend-admin/src/components/kiosk/kiosk-responsibility-prompt.logic.ts
@@ -108,22 +108,20 @@ export function getKioskResponsibilityPromptPresentation(
 
       if (state.canAcceptDds) {
         actionOptions.push(buildAcceptDdsOption(state))
-      }
-
-      if (state.needsBuildingOpen && state.canOpenBuilding) {
+      } else if (state.needsBuildingOpen && state.canOpenBuilding) {
         actionOptions.push(buildCommonOpenOnlyOption(state))
       }
 
       return {
-        headline: "You're today's expected DDS.",
+        headline: "You're today's DDS. Accept responsibility now.",
         helperText: state.needsBuildingOpen
-          ? 'Accept DDS in one step to activate duty and open the building.'
-          : 'Accept DDS now so later arrivals can continue without another stop.',
+          ? 'Accept DDS and open the building in one step before continuing.'
+          : 'Accept DDS now before continuing with daily operations.',
         bannerTone: 'info',
-        bannerTitle: 'This badge matches the expected DDS for today.',
+        bannerTitle: 'This badge matches the scheduled DDS for today.',
         bannerDescription: state.needsBuildingOpen
-          ? 'The safe default is to accept DDS now so opening and lockup transfer happen together.'
-          : 'The building is already open. Accept DDS now to clear the remaining daily responsibility.',
+          ? 'Use the primary action unless someone else is formally taking over DDS.'
+          : 'The building is already open. Accept DDS now to clear the daily responsibility.',
         defaultAction: actionOptions[0]?.value ?? null,
         actionOptions,
         blockedMessage: actionOptions.length === 0 ? buildBlockedMessage(state) : null,

--- a/apps/frontend-admin/src/components/kiosk/kiosk-responsibility-prompt.tsx
+++ b/apps/frontend-admin/src/components/kiosk/kiosk-responsibility-prompt.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { AlertTriangle, Clock3, DoorOpen, ShieldCheck, UserCheck, Users } from 'lucide-react'
 import {
   AppCard,
@@ -24,6 +24,7 @@ interface KioskResponsibilityPromptProps {
   state: KioskResponsibilityStateResponse
   isPending: boolean
   errorMessage?: string | null
+  mode?: 'kiosk' | 'login'
   onDecline: () => void
   onSubmit: (action: ResponsibilityActionChoice) => void
 }
@@ -73,17 +74,23 @@ export function KioskResponsibilityPrompt({
   state,
   isPending,
   errorMessage,
+  mode = 'kiosk',
   onDecline,
   onSubmit,
 }: KioskResponsibilityPromptProps) {
   const presentation = useMemo(() => getKioskResponsibilityPromptPresentation(state), [state])
-  const [selectedAction, setSelectedAction] = useState<ResponsibilityActionChoice | null>(
-    presentation.defaultAction
-  )
-
-  useEffect(() => {
-    setSelectedAction(presentation.defaultAction)
-  }, [presentation.defaultAction, state.member.id, state.promptVariant])
+  const selectionKey = `${state.member.id}:${state.promptVariant}:${presentation.defaultAction ?? 'none'}`
+  const [selectedActionState, setSelectedActionState] = useState<{
+    key: string
+    action: ResponsibilityActionChoice | null
+  }>(() => ({
+    key: selectionKey,
+    action: presentation.defaultAction,
+  }))
+  const selectedAction =
+    selectedActionState.key === selectionKey
+      ? selectedActionState.action
+      : presentation.defaultAction
 
   const selectedOption =
     presentation.actionOptions.find((option) => option.value === selectedAction) ?? null
@@ -96,10 +103,14 @@ export function KioskResponsibilityPrompt({
       'Arrival was recorded. Another member still needs to resolve responsibility.')
   const cardStatus = state.promptVariant === 'expected_dds' ? 'info' : 'warning'
   const openContext = state.currentOpenContext
+  const actorLabel = mode === 'login' ? 'Signed-in Member' : 'Scanned Member'
+  const recordedText =
+    mode === 'login' ? 'This login has checked you in.' : 'This arrival is already recorded.'
+  const declineLabel = mode === 'login' ? 'Skip for now' : 'Not Me'
 
   return (
     <div
-      className="absolute inset-0 z-(--z-modal) bg-base-300/80 backdrop-blur-[2px]"
+      className="fixed inset-0 z-[calc(var(--z-tooltip)+1)] bg-base-300/80 backdrop-blur-[2px]"
       data-testid={TID.dashboard.kiosk.responsibilityPrompt}
     >
       <div className="flex h-full items-center justify-center p-(--space-4)">
@@ -194,7 +205,9 @@ export function KioskResponsibilityPrompt({
                           name="kiosk-responsibility-action"
                           className="radio radio-primary radio-lg mt-1"
                           checked={selectedAction === option.value}
-                          onChange={() => setSelectedAction(option.value)}
+                          onChange={() =>
+                            setSelectedActionState({ key: selectionKey, action: option.value })
+                          }
                         />
                         <div className="min-w-0">
                           <p className="text-lg font-semibold">{option.title}</p>
@@ -238,7 +251,7 @@ export function KioskResponsibilityPrompt({
                   disabled={isPending}
                   data-testid={TID.dashboard.kiosk.responsibilityDecline}
                 >
-                  Not Me
+                  {declineLabel}
                 </button>
                 {selectedOption && primaryLabel && (
                   <button
@@ -262,9 +275,9 @@ export function KioskResponsibilityPrompt({
                     <div className="stat-figure text-primary">
                       <UserCheck className="h-5 w-5" />
                     </div>
-                    <div className="stat-title">Scanned Member</div>
+                    <div className="stat-title">{actorLabel}</div>
                     <div className="stat-value text-xl">{formatMemberName(state.member)}</div>
-                    <div className="stat-desc">This arrival is already recorded.</div>
+                    <div className="stat-desc">{recordedText}</div>
                   </div>
 
                   <div className="stat border-t border-base-300 px-0 py-3">

--- a/apps/frontend-admin/src/hooks/use-dds.ts
+++ b/apps/frontend-admin/src/hooks/use-dds.ts
@@ -76,6 +76,24 @@ export function useKioskResponsibilityState(memberId: string, enabled: boolean =
   })
 }
 
+export function useLoginResponsibilityState(enabled: boolean = true) {
+  return useQuery({
+    queryKey: ['dds', 'login-state'],
+    queryFn: async () => {
+      const response = await apiClient.dds.getLoginResponsibilityState()
+      if (response.status !== 200) {
+        throw new Error(
+          extractErrorMessage(response.body, 'Failed to fetch login responsibility state')
+        )
+      }
+      return response.body
+    },
+    enabled,
+    staleTime: 0,
+    refetchOnMount: 'always',
+  })
+}
+
 export function useAcceptDds() {
   const queryClient = useQueryClient()
 
@@ -93,6 +111,7 @@ export function useAcceptDds() {
       void Promise.allSettled([
         queryClient.invalidateQueries({ queryKey: ['dds-status'] }),
         queryClient.invalidateQueries({ queryKey: ['dds', 'kiosk-state'] }),
+        queryClient.invalidateQueries({ queryKey: ['dds', 'login-state'] }),
         invalidateDashboardQueries(queryClient),
       ])
     },
@@ -117,6 +136,7 @@ export function useSetTodayDds() {
         queryClient.invalidateQueries({ queryKey: ['dds-status'] }),
         queryClient.invalidateQueries({ queryKey: ['dds', 'current'] }),
         queryClient.invalidateQueries({ queryKey: ['dds', 'kiosk-state'] }),
+        queryClient.invalidateQueries({ queryKey: ['dds', 'login-state'] }),
         invalidateDashboardQueries(queryClient),
       ])
     },
@@ -141,6 +161,7 @@ export function useTransferDds() {
         queryClient.invalidateQueries({ queryKey: ['dds-status'] }),
         queryClient.invalidateQueries({ queryKey: ['dds', 'current'] }),
         queryClient.invalidateQueries({ queryKey: ['dds', 'kiosk-state'] }),
+        queryClient.invalidateQueries({ queryKey: ['dds', 'login-state'] }),
         invalidateDashboardQueries(queryClient),
       ])
     },

--- a/apps/frontend-admin/src/hooks/use-lockup.ts
+++ b/apps/frontend-admin/src/hooks/use-lockup.ts
@@ -332,6 +332,8 @@ export function useOpenBuilding() {
       queryClient.invalidateQueries({ queryKey: ['presence'] })
       queryClient.invalidateQueries({ queryKey: ['checkins'] })
       queryClient.invalidateQueries({ queryKey: ['eligible-openers'] })
+      queryClient.invalidateQueries({ queryKey: ['dds', 'login-state'] })
+      queryClient.invalidateQueries({ queryKey: ['dds', 'kiosk-state'] })
       void invalidateDashboardQueries(queryClient)
     },
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentinel-monorepo",
-  "version": "3.4.17",
+  "version": "3.4.18",
   "private": true,
   "description": "RFID Attendance Tracking System for HMCS Chippawa",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/contracts",
-  "version": "3.4.17",
+  "version": "3.4.18",
   "private": true,
   "type": "module",
   "description": "API contracts for Sentinel (ts-rest + Valibot)",

--- a/packages/contracts/src/contracts/dds.contract.ts
+++ b/packages/contracts/src/contracts/dds.contract.ts
@@ -70,6 +70,24 @@ export const ddsContract = c.router({
   },
 
   /**
+   * Get login responsibility state for the authenticated member
+   */
+  getLoginResponsibilityState: {
+    method: 'GET',
+    path: '/api/dds/login-state',
+    responses: {
+      200: KioskResponsibilityStateResponseSchema,
+      400: ErrorResponseSchema,
+      401: ErrorResponseSchema,
+      404: ErrorResponseSchema,
+      500: ErrorResponseSchema,
+    },
+    summary: 'Get login DDS responsibility state',
+    description:
+      'Get responsibility context for the authenticated member after Sentinel login, including DDS and open-building state',
+  },
+
+  /**
    * Get kiosk responsibility state for a checked-in member
    */
   getKioskResponsibilityState: {

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/database",
-  "version": "3.4.17",
+  "version": "3.4.18",
   "private": true,
   "type": "module",
   "description": "Database schema and client for Sentinel",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentinel/types",
-  "version": "3.4.17",
+  "version": "3.4.18",
   "private": true,
   "type": "module",
   "description": "Shared TypeScript types for Sentinel",


### PR DESCRIPTION
## Summary

- Shows the daily DDS responsibility prompt after normal Sentinel login, not only after kiosk scan-in.
- Adds a typed login responsibility-state endpoint for the authenticated member.
- Makes the expected DDS path clearer by presenting “Accept DDS and Open Building” as the primary action.
- Prepares the v3.4.18 patch release.

## Why this change was needed

The kiosk is not currently being used, so DDS members logging in from the server or other laptops were not seeing the same first-arrival responsibility choice. This made it easy for the expected DDS to miss accepting responsibility when opening the building for the day.

## What changed

### User-facing

- The normal authenticated Sentinel shell now checks whether the signed-in member should resolve daily DDS/open-building responsibility.
- Expected DDS users now see direct copy telling them to accept responsibility now.
- The expected DDS no longer sees “Open building without accepting DDS” as an equal option when they are allowed to accept DDS.

### Admin/operator-facing

- No operator configuration is required.
- The prompt appears on server/laptop Sentinel sessions after login, while `/login` and `/kiosk` remain bare routes.

### Backend/API

- Added `GET /api/dds/login-state` for authenticated member responsibility state.
- Reused the existing DDS responsibility-state service logic so kiosk and normal login flows stay aligned.

### Database

- No database migration required.

### Deployment/update

- Bumped root and workspace package versions to `3.4.18`.

### Tests

- Updated prompt presentation tests for the expected DDS flow.

## User impact

DDS members signing into Sentinel from the server or a laptop will be prompted to accept DDS responsibility and open the building when they are the scheduled DDS for the day.

## Operator impact

Operators should see fewer missed DDS acceptances during first daily login. No settings or training-data changes are required.

## Upgrade or migration notes

No upgrade action required beyond deploying v3.4.18. No database migration is required.

## Risk and rollback notes

Main risk is that the prompt could interrupt normal navigation for members who are eligible to resolve DDS responsibility. The prompt can be skipped for the current session with “Skip for now.” Rollback is safe by redeploying the previous release; no data migration is involved.

## Testing performed

- `pnpm version:check`
- `pnpm --filter frontend-admin typecheck`
- `pnpm --filter @sentinel/backend typecheck`
- `pnpm --filter frontend-admin exec vitest run src/components/kiosk/kiosk-responsibility-prompt.logic.test.ts`
- `pnpm --filter frontend-admin exec eslint src/components/kiosk/kiosk-responsibility-prompt.tsx src/components/dashboard/daily-responsibility-gate.tsx src/hooks/use-dds.ts src/hooks/use-lockup.ts src/app/layout.tsx`
- Visual sanity check at 1920x1080 with mocked expected-DDS login state; screenshot saved at `.playwright-cli/runs/login-responsibility/2026-06-30/expected-dds-login-gate.png`.

## Changelog candidates

- Fixed daily DDS responsibility prompting so server and laptop logins now show the same first-arrival DDS choice that previously depended on the kiosk flow.
- Clarified the expected DDS prompt so accepting DDS and opening the building is the obvious primary action.
- Added an authenticated DDS login-state API endpoint to keep normal login and kiosk responsibility checks aligned.
